### PR TITLE
Clarify parts of the rg template and organize services

### DIFF
--- a/template-resourcegroup.yaml
+++ b/template-resourcegroup.yaml
@@ -9,6 +9,9 @@ SupportCenterName: <NAME>
 # Resources contains one or more resources in this
 # ResourceGroup. A resource provides one or more services
 Resources:
+  # Resource Name should be a short descriptor of the resource.
+  # e.g. the Center for High Throughput Computing's GlideinWMS Frontend is "CHTC-glidein2"
+  # Resource Names need to be unique across all resources in the OSG.
   <RESOURCE NAME>:
     # Active is true if the resource is fully set up, and
     # false otherwise

--- a/template-resourcegroup.yaml
+++ b/template-resourcegroup.yaml
@@ -49,7 +49,7 @@ Resources:
     #   - <HOSTNAME2>
 
     # Services is one or more services provided by this resource;
-    # valid services are listed in topology/services.yaml
+    # valid services are listed in topology/services.yaml with the format <SERVICE NAME>: <ID>
     Services:
       <SERVICE NAME>:
         # Description is a brief description of the service
@@ -90,4 +90,5 @@ Resources:
     #   TapeCapacity: 0
 
   # Other resources if you have any...
-
+  #   <SERVICE NAME>:
+  #   ...

--- a/template-resourcegroup.yaml
+++ b/template-resourcegroup.yaml
@@ -66,6 +66,8 @@ Resources:
         #   # endpoint: <HOSTNAME>
 
       # Other services if you have any
+      # <SERVICE NAME>:
+      # ...
 
     ### VOOwnership (optional) is the percentage of the resource owned by one or more VOs.
     ### If part of the resource is not owned by the VO, do not list it.
@@ -90,5 +92,5 @@ Resources:
     #   TapeCapacity: 0
 
   # Other resources if you have any...
-  #   <SERVICE NAME>:
-  #   ...
+  # <RESOURCE NAME>:
+  # ...

--- a/template-resourcegroup.yaml
+++ b/template-resourcegroup.yaml
@@ -3,6 +3,7 @@ Disable: false
 # GridType is either "OSG Production Resource" or "OSG Integration Test Bed Resource"
 GridType: OSG Production Resource
 # SupportCenterName is one of the support centers in topology/support-centers.yaml
+# with the format "<NAME>: <ID>"
 SupportCenterName: <NAME>
 
 # Resources contains one or more resources in this
@@ -49,7 +50,7 @@ Resources:
     #   - <HOSTNAME2>
 
     # Services is one or more services provided by this resource;
-    # valid services are listed in topology/services.yaml with the format <SERVICE NAME>: <ID>
+    # valid services are listed in topology/services.yaml with the format "<SERVICE NAME>: <ID>"
     Services:
       <SERVICE NAME>:
         # Description is a brief description of the service

--- a/topology/services.yaml
+++ b/topology/services.yaml
@@ -1,25 +1,9 @@
 CE: 1
-SRMv1: 2
-SRMv2: 3
 GridFtp: 5
 LFC: 6
 FTS: 7
-GUMS Server: 101
-VOMS Server: 102
-Gratia Collector: 103
-RSV Collector: 104
-OSG BDII: 105
-Twiki Server: 106
-ReSS Collector: 108
 Submit Node: 109
-VOMRS Server: 110
-WLCG Interoperability BDII: 111
-MyOSG: 112
-VOMS_Monitoring: 113
-CADIST_Monitoring: 114
-CRL_Monitoring: 115
 OSG_Display: 116
-GOCTicket: 117
 OIM: 118
 Software Cache: 119
 OSG Homepage: 120
@@ -34,18 +18,37 @@ CVMFS Stratum-1: 132
 Oasis Server: 133
 (removed): 134
 Software Repo Mirror: 135
-Ticket Exchange: 136
 Squid: 138
 Condor Collector: 139
 oasis-login: 140
-GratiaWeb: 141
 XRootD component: 142
-OSG blogs: 143
 Cassandra DB: 144
 perfsonar data store: 145
+Connect: 149
 XRootD origin server: 147
 XRootD HA component: 148
-Connect: 149
 Virtual Machine Host: 150
 Certificate Provider: 151
 Message Bus: 154
+# deprecated
+SRMv2: 3
+GUMS Server: 101
+VOMS Server: 102
+Gratia Collector: 103
+RSV Collector: 104
+# unsupported
+SRMv1: 2
+OSG BDII: 105
+Twiki Server: 106
+ReSS Collector: 108
+VOMRS Server: 110
+WLCG Interoperability BDII: 111
+MyOSG: 112
+VOMS_Monitoring: 113
+CADIST_Monitoring: 114
+CRL_Monitoring: 115
+GOCTicket: 117
+Ticket Exchange: 136
+GratiaWeb: 141
+OSG blogs: 143
+


### PR DESCRIPTION
We refer to services.yaml from the template so we should clean it up a
bit for users

I'm not sure what some of these services are, i.e. FTS and LFC