### PR TITLE
Fixing Unicode names of facilities

### DIFF
--- a/app.py
+++ b/app.py
@@ -55,6 +55,10 @@ _dn_set = None
 
 @app.route('/map/iframe')
 def map():
+    @app.template_filter()
+    def encode(text):
+        """Convert a partial unicode string to full unicode"""
+        return text.encode('utf-8', 'surrogateescape').decode('utf-8')
     rgsummary = _get_topology().get_resource_summary()
 
     return render_template('iframe.tmpl', resourcegroups=rgsummary["ResourceSummary"]["ResourceGroup"])

--- a/templates/iframe.tmpl
+++ b/templates/iframe.tmpl
@@ -151,7 +151,7 @@ function init(scrollwheel) {
     if (!(curSite in sites)) {
         sites[curSite] = [ {{ resourcegroup["Site"]["Latitude"] }},
                            {{ resourcegroup["Site"]["Longitude"] }},
-                           "{{ resourcegroup["Facility"]["Name"] }}",
+                           "{{ resourcegroup["Facility"]["Name"] | encode }}",
                             Array() ]
     }
     


### PR DESCRIPTION
OMG, this took way too long to figure out.

Summary:
(read this [stackoverflow](https://stackoverflow.com/questions/27366479/python-3-os-walk-file-paths-unicodeencodeerror-utf-8-codec-cant-encode-s))
* The filesystem file names come in as not quite unicode, but not quite ascii either.
* Have to convert the not-quite unicode to bytes, then back to real unicode. 