### PR TITLE
Simplify GridType attribute in YAMLs

### DIFF
--- a/converters/rg_xml_to_yaml
+++ b/converters/rg_xml_to_yaml
@@ -267,6 +267,13 @@ class Topology(object):
             if self.support_centers[scname] != scid:
                 raise RuntimeError("Identical support centers with different IDs: %s" % scname)
         rg["SupportCenter"] = scname
+        gridtype = rg.pop("GridType", None)
+        if gridtype == "OSG Production Resource":
+            rg["Production"] = True
+        elif gridtype == "OSG Integration Test Bed Resource":
+            rg["Production"] = False
+        else:
+            raise RuntimeError("Missing or invalid GridType attribute")
 
         rg["Resources"] = simplify_attr_list(rg["Resources"]["Resource"], "Name")
         for key, val in rg["Resources"].items():

--- a/template-resourcegroup.yaml
+++ b/template-resourcegroup.yaml
@@ -1,7 +1,7 @@
 # Disable is true if the ResourceGroup is down for maintenance, false otherwise
 Disable: false
-# GridType is either "OSG Production Resource" or "OSG Integration Test Bed Resource"
-GridType: OSG Production Resource
+# Production is true if the resource is for production and not testing use
+Production: true
 # SupportCenterName is one of the support centers in topology/support-centers.yaml
 # with the format "<NAME>: <ID>"
 SupportCenterName: <NAME>

--- a/topology/ANL/ANL ASC/ANLASC.yaml
+++ b/topology/ANL/ANL ASC/ANLASC.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: ANL ASC Tier 3 site
 GroupID: 283
+Production: true
 Resources:
   ANL-ATLAS-GRIDFTP1:
     Active: true

--- a/topology/Arizona State University/OSG_US_ASU_OCTILLO/OSG_US_ASU_OCTILLO.yaml
+++ b/topology/Arizona State University/OSG_US_ASU_OCTILLO/OSG_US_ASU_OCTILLO.yaml
@@ -1,8 +1,8 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Entry for Hosted CE submitting to Arizona State University OCTILLO
   cluster.
 GroupID: 474
+Production: true
 Resources:
   OSG_US_ASU_OCTILLO:
     Active: false

--- a/topology/Baylor University/Baylor University Tier3/Baylor-Tier3.yaml
+++ b/topology/Baylor University/Baylor University Tier3/Baylor-Tier3.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: This resource group will be used as a Tier 3 site for the CMS experiment.
 GroupID: 264
+Production: true
 Resources:
   Baylor-Tier3-CE:
     Active: false

--- a/topology/Baylor University/Baylor University/Baylor-Kodiak.yaml
+++ b/topology/Baylor University/Baylor University/Baylor-Kodiak.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: This resource group will be used as a Baylor University OSG site.
 GroupID: 468
+Production: true
 Resources:
   Baylor-Kodiak-CE:
     Active: true

--- a/topology/Bellarmine University/Bellarmine University/BELLARMINE_TIER2.yaml
+++ b/topology/Bellarmine University/Bellarmine University/BELLARMINE_TIER2.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: LSST Tier2 Site at Bellarmine University
 GroupID: 277
+Production: true
 Resources:
   BELLARMINE_TIER2:
     Active: true

--- a/topology/Boston University/Boston University ATLAS Tier2/BU_ATLAS_Tier2.yaml
+++ b/topology/Boston University/Boston University ATLAS Tier2/BU_ATLAS_Tier2.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: U.S. ATLAS Northeast Tier 2 Center
 GroupID: 8
+Production: true
 Resources:
   BU_ATLAS_Tier2:
     Active: false

--- a/topology/Boston University/Boston University ATLAS Tier2/NET2.yaml
+++ b/topology/Boston University/Boston University ATLAS Tier2/NET2.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: A resource group for Northeast ATLAS T2
 GroupID: 399
+Production: true
 Resources:
   NET2-BU:
     Active: false

--- a/topology/Brandeis University/Brandeis Tier 3/Brandeis-Atlas-T3.yaml
+++ b/topology/Brandeis University/Brandeis Tier 3/Brandeis-Atlas-T3.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Brandeis ATLAS Tier 3
 GroupID: 284
+Production: true
 Resources:
   BRND-HEAD:
     Active: true

--- a/topology/Brookhaven National Laboratory/Brookhaven ATLAS Tier1/BNL-ATLAS-ITB.yaml
+++ b/topology/Brookhaven National Laboratory/Brookhaven ATLAS Tier1/BNL-ATLAS-ITB.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Integration Test Bed Resource
 GroupDescription: This is the BNL ITB resource group, not production services.
 GroupID: 243
+Production: false
 Resources:
   BNL-ps-testbed:
     Active: true

--- a/topology/Brookhaven National Laboratory/Brookhaven ATLAS Tier1/BNL-ATLAS-OPP.yaml
+++ b/topology/Brookhaven National Laboratory/Brookhaven ATLAS Tier1/BNL-ATLAS-OPP.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Opportunistic resources utilized by the Tier 1.
 GroupID: 453
+Production: true
 Resources:
   BNL_CLOUD:
     Active: true

--- a/topology/Brookhaven National Laboratory/Brookhaven ATLAS Tier1/BNL-ATLAS.yaml
+++ b/topology/Brookhaven National Laboratory/Brookhaven ATLAS Tier1/BNL-ATLAS.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: This site is the ATLAS Tier 1 Facility at Brookhaven National Laboratory.
 GroupID: 235
+Production: true
 Resources:
   BNL-LCG2:
     Active: false

--- a/topology/Brookhaven National Laboratory/Brookhaven ATLAS Tier1/BNL_ATLAS_1.yaml
+++ b/topology/Brookhaven National Laboratory/Brookhaven ATLAS Tier1/BNL_ATLAS_1.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Enable per request
 GroupID: 3
+Production: true
 Resources:
   BNL_TEST_UST3:
     Active: true

--- a/topology/Brookhaven National Laboratory/Brookhaven ATLAS Tier1/BNL_ITB_Test1.yaml
+++ b/topology/Brookhaven National Laboratory/Brookhaven ATLAS Tier1/BNL_ITB_Test1.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Integration Test Bed Resource
 GroupDescription: disabling empty resource group
 GroupID: 6
+Production: false
 Resources:
   BNL_ATLAS_5:
     Active: true

--- a/topology/Brookhaven National Laboratory/Brookhaven ATLAS Tier1/BNL_Test_2.yaml
+++ b/topology/Brookhaven National Laboratory/Brookhaven ATLAS Tier1/BNL_Test_2.yaml
@@ -1,10 +1,10 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: This is an ATLAS production testbed. This site runs inside the OSG
   production environment, as far as BDII info publishing and other central services
   are concerned. But its main purpose is to test new ATLAS production workflow, before
   migrating them to the real ATLAS production environment.
 GroupID: 306
+Production: true
 Resources:
   BNL_Test_2_CE_1:
     Active: true

--- a/topology/Brookhaven National Laboratory/Brookhaven Belle-II Tier1/BNL-Belle-II.yaml
+++ b/topology/Brookhaven National Laboratory/Brookhaven Belle-II Tier1/BNL-Belle-II.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: This is the Tier1 for Belle-II at BNL
 GroupID: 478
+Production: true
 Resources:
   BNL_BELLE_II_CE_1:
     Active: true

--- a/topology/Brookhaven National Laboratory/STAR Brookhaven/STAR-BNL.yaml
+++ b/topology/Brookhaven National Laboratory/STAR Brookhaven/STAR-BNL.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 102
+Production: true
 Resources:
   STAR-BNL:
     Active: true

--- a/topology/Brookhaven National Laboratory/STAR-Online/STAR-OnlinePool.yaml
+++ b/topology/Brookhaven National Laboratory/STAR-Online/STAR-OnlinePool.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Small pool of hosts at the STAR experiment, for STAR jobs only.
 GroupID: 426
+Production: true
 Resources:
   STAR-OnlinePool:
     Active: true

--- a/topology/Brown University/Brown-CMS/brown-cms.yaml
+++ b/topology/Brown University/Brown-CMS/brown-cms.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: T3 Computing center for CMS VO.
 GroupID: 241
+Production: true
 Resources:
   brown-cms:
     Active: true

--- a/topology/Brown University/brown-cms-new/brown-cms-new.yaml
+++ b/topology/Brown University/brown-cms-new/brown-cms-new.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: new T3 cluster
 GroupID: 346
+Production: true
 Resources:
   brown-cms-new:
     Active: true

--- a/topology/CBPF/GridLAFEX/PerfSONAR Services.yaml
+++ b/topology/CBPF/GridLAFEX/PerfSONAR Services.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: PerfSONAR services for the CBPF site.
 GroupID: 415
+Production: true
 Resources:
   PerfSONAR_CBPF_bw:
     Active: true

--- a/topology/CENF_NeutrinoPlatform/CENF/CENF_Neutrino_Computing_Cluster.yaml
+++ b/topology/CENF_NeutrinoPlatform/CENF/CENF_Neutrino_Computing_Cluster.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: 'Neutrino Computing Cluster at CERN: https://twiki.cern.ch/twiki/bin/view/CENF/NeutrinoClusterCERN'
 GroupID: 450
+Production: true
 Resources:
   CENF_NeutrinoCluster:
     Active: true

--- a/topology/CILogon_org/CILogon/Certificate Provider.yaml
+++ b/topology/CILogon_org/CILogon/Certificate Provider.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: For certificate provider resources
 GroupID: 444
+Production: true
 Resources:
   CILogon Certificate Provider:
     Active: true

--- a/topology/CUNY Graduate Center/NYSGRID-CUNY-GRID/NYSGRID-CUNY-GRID.yaml
+++ b/topology/CUNY Graduate Center/NYSGRID-CUNY-GRID/NYSGRID-CUNY-GRID.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: disabling empty resource group
 GroupID: 220
+Production: true
 Resources:
   NYSGRID-CUNY-GRID:
     Active: false

--- a/topology/California Institute of Technology/Caltech CMS Tier2/CIT_CMS_Cloud.yaml
+++ b/topology/California Institute of Technology/Caltech CMS Tier2/CIT_CMS_Cloud.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Integration Test Bed Resource
 GroupDescription: Test resource group to be used for cloud tests.
 GroupID: 397
+Production: false
 Resources:
   CIT_ITB2:
     Active: true

--- a/topology/California Institute of Technology/Caltech CMS Tier2/CIT_CMS_T2.yaml
+++ b/topology/California Institute of Technology/Caltech CMS Tier2/CIT_CMS_T2.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 10
+Production: true
 Resources:
   CIT_CMS_SE:
     Active: true

--- a/topology/California Institute of Technology/Caltech CMS Tier2/CIT_ITB_1.yaml
+++ b/topology/California Institute of Technology/Caltech CMS Tier2/CIT_ITB_1.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Integration Test Bed Resource
 GroupDescription: (No resource group description)
 GroupID: 12
+Production: false
 Resources:
   CIT_ITB_1:
     Active: true

--- a/topology/California Institute of Technology/Caltech HEP/CIT_HEP.yaml
+++ b/topology/California Institute of Technology/Caltech HEP/CIT_HEP.yaml
@@ -1,8 +1,8 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: These resources are used and managed by the greater Caltech High
   Energy Physics department.
 GroupID: 292
+Production: true
 Resources:
   CIT_HEP_SE:
     Active: true

--- a/topology/California Institute of Technology/Caltech LIGO/LIGO-CIT-ITB.yaml
+++ b/topology/California Institute of Technology/Caltech LIGO/LIGO-CIT-ITB.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Integration Test Bed Resource
 GroupDescription: disabling empty resource group
 GroupID: 61
+Production: false
 Resources:
   LIGO-CIT-ITB:
     Active: false

--- a/topology/California Institute of Technology/Caltech LIGO/LIGO-CIT-VTB.yaml
+++ b/topology/California Institute of Technology/Caltech LIGO/LIGO-CIT-VTB.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Integration Test Bed Resource
 GroupDescription: (No resource group description)
 GroupID: 62
+Production: false
 Resources:
   LIGO-CIT-VTB:
     Active: false

--- a/topology/California State University, Fresno/CSU Fresno T3/FRESNO-ATLAS-T3.yaml
+++ b/topology/California State University, Fresno/CSU Fresno T3/FRESNO-ATLAS-T3.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Resource group at California State University, Fresno
 GroupID: 340
+Production: true
 Resources:
   FSU-TEST-SE:
     Active: true

--- a/topology/CancerComputer/CCHDV/CancerComputer_Hotel.yaml
+++ b/topology/CancerComputer/CCHDV/CancerComputer_Hotel.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: CE for the HPC cluster at CCHDV
 GroupID: 448
+Production: true
 Resources:
   CancerComputer_Hotel_CE:
     Active: true

--- a/topology/CancerComputer/CCHDV/CancerComputer_Miron.yaml
+++ b/topology/CancerComputer/CCHDV/CancerComputer_Miron.yaml
@@ -1,9 +1,9 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: The original name of the first CCHDV CE Resource.  Keeping this
   record around so that GRACC and related accounting still makes sense.  Actual resources
   are now located under the CancerComputer_Hotel resource name
 GroupID: 469
+Production: true
 Resources:
   CancerComputer_Miron_CE:
     Active: false

--- a/topology/CancerComputer/CCRnD/CancerComputer_Kitchener.yaml
+++ b/topology/CancerComputer/CCRnD/CancerComputer_Kitchener.yaml
@@ -1,8 +1,8 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Virtualized compute cluster at CCRnD, supporting VOs and projects
   dealing with cancer-related research
 GroupID: 479
+Production: true
 Resources:
   CancerComputer_Kitchener_CE:
     Active: true

--- a/topology/Cinvestav/cinvestav/cinvestav.yaml
+++ b/topology/Cinvestav/cinvestav/cinvestav.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: CE for CINVESTAV OSG resources
 GroupID: 9
+Production: true
 Resources:
   cinvestav:
     Active: true

--- a/topology/Clemson University/Clemson IT/Clemson-IT.yaml
+++ b/topology/Clemson University/Clemson IT/Clemson-IT.yaml
@@ -1,10 +1,10 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: |-
   Out of service.
 
   7/26 disabling empty resource group
 GroupID: 13
+Production: true
 Resources:
   Clemson-IT:
     Active: false

--- a/topology/Clemson University/Clemson IT/Clemson-Palmetto.yaml
+++ b/topology/Clemson University/Clemson IT/Clemson-Palmetto.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: osg-ce.clemson.edu
 GroupID: 212
+Production: true
 Resources:
   Clemson-Connect:
     Active: true

--- a/topology/Clemson University/ClemsonCS/Clemson-Birdnest.yaml
+++ b/topology/Clemson University/ClemsonCS/Clemson-Birdnest.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: Cluster which provides virtualized resources to OSG.
 GroupID: 200
+Production: true
 Resources:
   Clemson-Birdnest:
     Active: false

--- a/topology/Clemson University/ClemsonCS/Clemson-ciTeam.yaml
+++ b/topology/Clemson University/ClemsonCS/Clemson-ciTeam.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: Test resource for ciTeam at Clemson University.
 GroupID: 168
+Production: true
 Resources:
   Clemson-ciTeam:
     Active: false

--- a/topology/Columbia University_Nevis Labs/Nevis/Nevis.yaml
+++ b/topology/Columbia University_Nevis Labs/Nevis/Nevis.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Nevis
 GroupID: 296
+Production: true
 Resources:
   Nevis:
     Active: true

--- a/topology/Computer Network Information Center (CNIC)/CAS-CNIC/CNIC-CIGI-OSG.yaml
+++ b/topology/Computer Network Information Center (CNIC)/CAS-CNIC/CNIC-CIGI-OSG.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: CNIC Resources that are participating in OSG through CIGI
 GroupID: 238
+Production: true
 Resources:
   CNIC-OSG:
     Active: true

--- a/topology/Cornell University/NYSGRID Cornell/NYSGRID_CORNELL_NYS1.yaml
+++ b/topology/Cornell University/NYSGRID Cornell/NYSGRID_CORNELL_NYS1.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 81
+Production: true
 Resources:
   NYSGRID_CORNELL_NYS1:
     Active: true

--- a/topology/Donald Danforth Plant Science Center/OSG_US_DANFORTH_ce04/OSG_US_DANFORTH_HOSTED_CE.yaml
+++ b/topology/Donald Danforth Plant Science Center/OSG_US_DANFORTH_ce04/OSG_US_DANFORTH_HOSTED_CE.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Hosted CE for Danforth center cluster
 GroupID: 471
+Production: true
 Resources:
   OSG_US_DANFORTH_ce04:
     Active: true

--- a/topology/Duke_University/DukeTier3/DukeT3.yaml
+++ b/topology/Duke_University/DukeTier3/DukeT3.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Duke University HEP Tier 3 site
 GroupID: 213
+Production: true
 Resources:
   DUKET3-SE:
     Active: false

--- a/topology/Fermi National Accelerator Laboratory/FNAL HPC/Wilson Facility.yaml
+++ b/topology/Fermi National Accelerator Laboratory/FNAL HPC/Wilson Facility.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Wilson Facility is a General Purpose HPC cluster at Fermilab
 GroupID: 455
+Production: true
 Resources:
   FNAL_WILSON:
     Active: true

--- a/topology/Fermi National Accelerator Laboratory/FNAL USCMS Tier1/USCMS-FNAL-ITB.yaml
+++ b/topology/Fermi National Accelerator Laboratory/FNAL USCMS Tier1/USCMS-FNAL-ITB.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Integration Test Bed Resource
 GroupDescription: USCMS Fermilab ITB Resources
 GroupID: 263
+Production: false
 Resources:
   USCMS-FNAL-ITB:
     Active: true

--- a/topology/Fermi National Accelerator Laboratory/FNAL USCMS Tier1/USCMS-FNAL-WC1.yaml
+++ b/topology/Fermi National Accelerator Laboratory/FNAL USCMS Tier1/USCMS-FNAL-WC1.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 210
+Production: true
 Resources:
   FNAL NRTB PerfSONAR Bandwidth:
     Active: true

--- a/topology/Fermi National Accelerator Laboratory/FermiGrid/FNAL_FAPL_ITB_SE.yaml
+++ b/topology/Fermi National Accelerator Laboratory/FermiGrid/FNAL_FAPL_ITB_SE.yaml
@@ -1,5 +1,4 @@
 Disable: true
-GridType: OSG Integration Test Bed Resource
 GroupDescription: |-
   I didn't register this resource
   and it doesn't show up in my Resource view but I
@@ -9,6 +8,7 @@ GroupDescription: |-
 
   In any case this SE should be marked inactive.
 GroupID: 18
+Production: false
 Resources:
   FNAL_FAPL_ITB_SE:
     Active: false

--- a/topology/Fermi National Accelerator Laboratory/FermiGrid/FNAL_FERMIGRID.yaml
+++ b/topology/Fermi National Accelerator Laboratory/FermiGrid/FNAL_FERMIGRID.yaml
@@ -1,10 +1,10 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: |-
   This is the FermiGrid site gateway and includes
   the site gatekeeper and all the hidden CE's that are
   attached
 GroupID: 19
+Production: true
 Resources:
   FNAL_CDFOSG_0:
     Active: false

--- a/topology/Fermi National Accelerator Laboratory/FermiGrid/FNAL_FERMIGRID_ITB.yaml
+++ b/topology/Fermi National Accelerator Laboratory/FermiGrid/FNAL_FERMIGRID_ITB.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Integration Test Bed Resource
 GroupDescription: (No resource group description)
 GroupID: 20
+Production: false
 Resources:
   FNAL-ITB-GIP-TEST1:
     Active: false

--- a/topology/Fermi National Accelerator Laboratory/FermiGrid/FNAL_FERMIGRID_TEST.yaml
+++ b/topology/Fermi National Accelerator Laboratory/FermiGrid/FNAL_FERMIGRID_TEST.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Integration Test Bed Resource
 GroupDescription: (No resource group description)
 GroupID: 21
+Production: false
 Resources:
   FNAL_FERMIGRID_TEST:
     Active: false

--- a/topology/Fermi National Accelerator Laboratory/FermiGrid/FNAL_FIFE_SUBMIT.yaml
+++ b/topology/Fermi National Accelerator Laboratory/FermiGrid/FNAL_FIFE_SUBMIT.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: submit nodes
 GroupID: 381
+Production: true
 Resources:
   FIFEBATCH2:
     Active: false

--- a/topology/Fermi National Accelerator Laboratory/FermiGrid/FNAL_GPFARM.yaml
+++ b/topology/Fermi National Accelerator Laboratory/FermiGrid/FNAL_GPFARM.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 22
+Production: true
 Resources:
   FNAL_GPFARM:
     Active: false

--- a/topology/Fermi National Accelerator Laboratory/FermiGrid/FNAL_GPGRID_1.yaml
+++ b/topology/Fermi National Accelerator Laboratory/FermiGrid/FNAL_GPGRID_1.yaml
@@ -1,5 +1,4 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: |-
   This resource replaces FNAL_GPFARM.
   It is the General Purpose Grid Cluster at Fermilab,
@@ -8,6 +7,7 @@ GroupDescription: |-
   on this cluster through request to the FermiGrid management.
   All VO\'s are supported at the level of at least 1 slot.
 GroupID: 172
+Production: true
 Resources:
   FNAL_GPGRID_1:
     Active: false

--- a/topology/Fermi National Accelerator Laboratory/FermiGrid/FNAL_IF_GRIDFTP.yaml
+++ b/topology/Fermi National Accelerator Laboratory/FermiGrid/FNAL_IF_GRIDFTP.yaml
@@ -1,8 +1,8 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: A collection of GridFTP servers for the Intensity Frontier experiments
   at Fermilab, all of which report to Gratia.
 GroupID: 368
+Production: true
 Resources:
   FNAL_IF_GRIDFTP_NOVA:
     Active: false

--- a/topology/Fermi National Accelerator Laboratory/FermiGrid/FNAL_PUBLIC_DCACHE.yaml
+++ b/topology/Fermi National Accelerator Laboratory/FermiGrid/FNAL_PUBLIC_DCACHE.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Machines associated with Fermilab public dCache
 GroupID: 369
+Production: true
 Resources:
   Fermilab Public dCache:
     Active: true

--- a/topology/Fermi National Accelerator Laboratory/FermiGrid/GPGRID.yaml
+++ b/topology/Fermi National Accelerator Laboratory/FermiGrid/GPGRID.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: This is the General Purpose Grid cluster at Fermilab.
 GroupID: 476
+Production: true
 Resources:
   FNAL_GPGRID_CE_03:
     Active: true

--- a/topology/Fermi National Accelerator Laboratory/FermiGrid/GRATIA-OSG.yaml
+++ b/topology/Fermi National Accelerator Laboratory/FermiGrid/GRATIA-OSG.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: The OSG Gratia services as provided by FermiGrid at FNAL.
 GroupID: 255
+Production: true
 Resources:
   GRATIA-OSG-DAILY:
     Active: false

--- a/topology/Fermi National Accelerator Laboratory/FermiGrid/ITB-ReSS.yaml
+++ b/topology/Fermi National Accelerator Laboratory/FermiGrid/ITB-ReSS.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Integration Test Bed Resource
 GroupDescription: OSG-ITB Resource Selection Machines
 GroupID: 234
+Production: false
 Resources:
   ITB-ReSS:
     Active: false

--- a/topology/Fermi National Accelerator Laboratory/FermiGrid/ITB_INSTALL_TEST.yaml
+++ b/topology/Fermi National Accelerator Laboratory/FermiGrid/ITB_INSTALL_TEST.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Integration Test Bed Resource
 GroupDescription: (No resource group description)
 GroupID: 45
+Production: false
 Resources:
   ITB_INSTALL_TEST:
     Active: true

--- a/topology/Fermi National Accelerator Laboratory/FermiGrid/ITB_INSTALL_TEST_2.yaml
+++ b/topology/Fermi National Accelerator Laboratory/FermiGrid/ITB_INSTALL_TEST_2.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Integration Test Bed Resource
 GroupDescription: (No resource group description)
 GroupID: 46
+Production: false
 Resources:
   ITB_INSTALL_TEST_2:
     Active: true

--- a/topology/Fermi National Accelerator Laboratory/FermiGrid/ITB_INSTALL_TEST_3.yaml
+++ b/topology/Fermi National Accelerator Laboratory/FermiGrid/ITB_INSTALL_TEST_3.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Integration Test Bed Resource
 GroupDescription: (No resource group description)
 GroupID: 47
+Production: false
 Resources:
   ITB_INSTALL_TEST_3:
     Active: true

--- a/topology/Fermi National Accelerator Laboratory/FermiGrid/OSG-ReSS.yaml
+++ b/topology/Fermi National Accelerator Laboratory/FermiGrid/OSG-ReSS.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: OSG Production Resource Selection machines
 GroupID: 233
+Production: true
 Resources:
   OSG-ReSS-PROD:
     Active: false

--- a/topology/Fermi National Accelerator Laboratory/FermiGrid/vomsopensciencegridorg.yaml
+++ b/topology/Fermi National Accelerator Laboratory/FermiGrid/vomsopensciencegridorg.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 190
+Production: true
 Resources:
   OSG_VOMRS:
     Active: false

--- a/topology/Fermi National Accelerator Laboratory/USCMS-FNAL-XEN/OSG_INSTALL_TEST_2.yaml
+++ b/topology/Fermi National Accelerator Laboratory/USCMS-FNAL-XEN/OSG_INSTALL_TEST_2.yaml
@@ -1,11 +1,11 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: |-
   Changing site of resource group so it is not a part of fermigrid.
 
   Disabled per John Weigand (8-25-2014)
   https://ticket.grid.iu.edu/22201
 GroupID: 83
+Production: true
 Resources:
   OSG_INSTALL_TEST_2:
     Active: false

--- a/topology/Fermi National Accelerator Laboratory/USCMS-FNAL-XEN/USCMS-FNAL-XEN.yaml
+++ b/topology/Fermi National Accelerator Laboratory/USCMS-FNAL-XEN/USCMS-FNAL-XEN.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Single virtual xen node for Tier 3 support
 GroupID: 232
+Production: true
 Resources:
   USCMS-FNAL-XEN:
     Active: true

--- a/topology/Florida A&M University/APCR-DRDL/FloridaAMUniversity.yaml
+++ b/topology/Florida A&M University/APCR-DRDL/FloridaAMUniversity.yaml
@@ -1,10 +1,10 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: |-
   Site for FAMU's Engagement resource.
 
   7/26 disabling empty resource group
 GroupID: 297
+Production: true
 Resources:
   FloridaAMUniversity_CE:
     Active: false

--- a/topology/Florida Institute of Technology/Florida Tech/FLTECH.yaml
+++ b/topology/Florida Institute of Technology/Florida Tech/FLTECH.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Compute Cluster at the Florida Tech High Energy Physics lab
 GroupID: 163
+Production: true
 Resources:
   FLTECH:
     Active: true

--- a/topology/Florida International University/CHEPREO/FIU-PG.yaml
+++ b/topology/Florida International University/CHEPREO/FIU-PG.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 16
+Production: true
 Resources:
   FIU-PG:
     Active: false

--- a/topology/Florida International University/FIU CMS Tier3/FIUPG.yaml
+++ b/topology/Florida International University/FIU CMS Tier3/FIUPG.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Tier3 site at Florida International University
 GroupID: 307
+Production: true
 Resources:
   FIU_CE:
     Active: true

--- a/topology/Florida International University/FIU HPC/HPCOSG.yaml
+++ b/topology/Florida International University/FIU HPC/HPCOSG.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Resources group for OSG VO
 GroupID: 425
+Production: true
 Resources:
   FIU_HPCOSG_CE:
     Active: true

--- a/topology/Florida State University/FSU_HNPGRID/OSG_US_FSU_HNPGRID.yaml
+++ b/topology/Florida State University/FSU_HNPGRID/OSG_US_FSU_HNPGRID.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Hosted CE for GlueX and OSG support
 GroupID: 475
+Production: true
 Resources:
   OSG_US_FSU_HNPGRID:
     Active: true

--- a/topology/Florida State University/Florida State HEP/FSU-HEP.yaml
+++ b/topology/Florida State University/Florida State HEP/FSU-HEP.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: FSU CMS tier3 computing center.
 GroupID: 23
+Production: true
 Resources:
   FSU-HEP:
     Active: true

--- a/topology/Georgia Institute of Technology/Georgia Tech/Georgia Tech LIGO.yaml
+++ b/topology/Georgia Institute of Technology/Georgia Tech/Georgia Tech LIGO.yaml
@@ -1,8 +1,8 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Submit-side resources dedicated to serving the local LIGO group
   @ Georgia Tech.
 GroupID: 424
+Production: true
 Resources:
   Georgia_Tech_LIGO_Submit_1:
     Active: true

--- a/topology/Georgia Institute of Technology/Georgia Tech/Georgia Tech PACE.yaml
+++ b/topology/Georgia Institute of Technology/Georgia Tech/Georgia Tech PACE.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Resources in the Georgia Tech PACE cluster, to be used by LIGO.
 GroupID: 423
+Production: true
 Resources:
   Georgia_Tech_PACE_CE_1:
     Active: true

--- a/topology/Georgia Institute of Technology/PuNDIT/GaTech_Testbed.yaml
+++ b/topology/Georgia Institute of Technology/PuNDIT/GaTech_Testbed.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: PuNDIT Testbed nodes in Georgia Tech
 GroupID: 413
+Production: true
 Resources:
   perfSONAR_GT_testbed_latency:
     Active: false

--- a/topology/Georgia State University/Georgia State University Research Computing/OSG_TEST_CE.yaml
+++ b/topology/Georgia State University/Georgia State University Research Computing/OSG_TEST_CE.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Test CE
 GroupID: 370
+Production: true
 Resources:
   OSG_TEST_CE:
     Active: false

--- a/topology/Georgia State University/OSG_US_GSU_ACORE/OSG_US_GSU_ACORE.yaml
+++ b/topology/Georgia State University/OSG_US_GSU_ACORE/OSG_US_GSU_ACORE.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Hosted CE for ACORE resource
 GroupID: 470
+Production: true
 Resources:
   OSG_US_GSU_ACORE:
     Active: true

--- a/topology/Gridplexus/OSG_GP_CE01/Gridplexus.yaml
+++ b/topology/Gridplexus/OSG_GP_CE01/Gridplexus.yaml
@@ -1,10 +1,10 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: |-
   new resource is under construction (OSG 1.0)
 
   7/26 disabling empty resource group
 GroupID: 157
+Production: true
 Resources:
   Gridplexus:
     Active: false

--- a/topology/Hampton University PPCF/PPCF_ATLAS/Hampton PPCF ATLAS.yaml
+++ b/topology/Hampton University PPCF/PPCF_ATLAS/Hampton PPCF ATLAS.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: Hampton ATLAS Tier3
 GroupID: 305
+Production: true
 Resources:
   Hampton_ATLAS_CE:
     Active: true

--- a/topology/Harvard Medical School/HMS/HMS-Orchestra.yaml
+++ b/topology/Harvard Medical School/HMS/HMS-Orchestra.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Resources that are part of the Research IT Group's cluster, "Orchestra."
 GroupID: 312
+Production: true
 Resources:
   HMS-Orchestra-Dev:
     Active: false

--- a/topology/Harvard University/Harvard SBGRID/SBGrid-Harvard-East.yaml
+++ b/topology/Harvard University/Harvard SBGRID/SBGrid-Harvard-East.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: 21 dual AMD Opteron Processor 240 1.4GHz, 2 GB RAM
 GroupID: 142
+Production: true
 Resources:
   SBGrid-Harvard-East:
     Active: false

--- a/topology/Harvard University/Harvard SBGRID/SBGrid-Harvard-Exp.yaml
+++ b/topology/Harvard University/Harvard SBGRID/SBGrid-Harvard-Exp.yaml
@@ -1,9 +1,9 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: 3 node, 20 core site.  2.4 GHz x86_64, 300 GB local storage, 300
   GB shared storage, 1 GB RAM/core.  All VOs welcome.  gsi-ssh available by request
   to allow debugging.
 GroupID: 143
+Production: true
 Resources:
   SBGrid-Harvard-Exp:
     Active: false

--- a/topology/Harvard University/Harvard SBGRID/SBGrid-Harvard-Infrastructure.yaml
+++ b/topology/Harvard University/Harvard SBGRID/SBGrid-Harvard-Infrastructure.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Various infrastructure services for SBGrid.
 GroupID: 339
+Production: true
 Resources:
   SBGrid-Harvard-Security:
     Active: true

--- a/topology/Harvard University/Harvard SBGRID/SBGrid-Harvard.yaml
+++ b/topology/Harvard University/Harvard SBGRID/SBGrid-Harvard.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Integration Test Bed Resource
 GroupDescription: (No resource group description)
 GroupID: 97
+Production: false
 Resources:
   SBGrid-GlideinWMS-Frontend:
     Active: true

--- a/topology/Harvard University/Harvard SBGRID/WQCG-Harvard-OSG.yaml
+++ b/topology/Harvard University/Harvard SBGRID/WQCG-Harvard-OSG.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: disabled 1/26
 GroupID: 229
+Production: true
 Resources:
   WQCG-Harvard-OSG:
     Active: false

--- a/topology/Harvard University/Harvard University/HU_ATLAS_Tier2.yaml
+++ b/topology/Harvard University/Harvard University/HU_ATLAS_Tier2.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: US ATLAS Tier2
 GroupID: 182
+Production: true
 Resources:
   HU_ATLAS_Tier2:
     Active: true

--- a/topology/High Performance Computing Facility - University of Puerto Rico/High Performance Computing Facility - University of Puerto Rico/UPR_HPCF.yaml
+++ b/topology/High Performance Computing Facility - University of Puerto Rico/High Performance Computing Facility - University of Puerto Rico/UPR_HPCF.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: HPCF Resource Group
 GroupID: 385
+Production: true
 Resources:
   Nanobio_CE:
     Active: true

--- a/topology/INFN-PADOVA/INFN-PADOVA/SBGrid.yaml
+++ b/topology/INFN-PADOVA/INFN-PADOVA/SBGrid.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: SBGrid VO resources
 GroupID: 338
+Production: true
 Resources:
   INFNPD-GlideinWMS-Schedd:
     Active: true

--- a/topology/Illinois Institute of Technology/IIT - Illinois Institute of Technology/IIT.yaml
+++ b/topology/Illinois Institute of Technology/IIT - Illinois Institute of Technology/IIT.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: HPC & HTC computing resources at IIT
 GroupID: 445
+Production: true
 Resources:
   IIT_CE:
     Active: true

--- a/topology/Indiana University/GOC Staff VM/ECHISM-GOC.yaml
+++ b/topology/Indiana University/GOC Staff VM/ECHISM-GOC.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Integration Test Bed Resource
 GroupDescription: Services hosted by Elizabeth's VMs
 GroupID: 352
+Production: false
 Resources:
   ECE:
     Active: true

--- a/topology/Indiana University/GOC Staff VM/KAGROSS-GOC.yaml
+++ b/topology/Indiana University/GOC Staff VM/KAGROSS-GOC.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Integration Test Bed Resource
 GroupDescription: kagross.grid.iu.edu VM
 GroupID: 345
+Production: false
 Resources:
   LLAMA-LLAMA-GOC:
     Active: true

--- a/topology/Indiana University/GOC Staff VM/VJNEAL-GOC.yaml
+++ b/topology/Indiana University/GOC Staff VM/VJNEAL-GOC.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Integration Test Bed Resource
 GroupDescription: vince's VM set
 GroupID: 391
+Production: false
 Resources:
   VJNEAL_CE:
     Active: true

--- a/topology/Indiana University/ILS/Jupiter.yaml
+++ b/topology/Indiana University/ILS/Jupiter.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: ILS compute cluster
 GroupID: 362
+Production: true
 Resources:
   ILS_compute:
     Active: true

--- a/topology/Indiana University/ILS/cns.yaml
+++ b/topology/Indiana University/ILS/cns.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Cyberinfrastructure for Network Science Center
 GroupID: 380
+Production: true
 Resources:
   cns1:
     Active: true

--- a/topology/Indiana University/IU GOC GLIDEIN/GOC glidein.yaml
+++ b/topology/Indiana University/IU GOC GLIDEIN/GOC glidein.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: The GOC hosted, UCSD maintained glidein factory.
 GroupID: 308
+Production: true
 Resources:
   GOC glidein:
     Active: true

--- a/topology/Indiana University/IU UITS/CSIU Services.yaml
+++ b/topology/Indiana University/IU UITS/CSIU Services.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Resources for CSIU Campus Grid
 GroupID: 358
+Production: true
 Resources:
   CSIU Submit:
     Active: true

--- a/topology/Indiana University/IU UITS/Condor collectors.yaml
+++ b/topology/Indiana University/IU UITS/Condor collectors.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Condor collectors for the HTCondor CE
 GroupID: 406
+Production: true
 Resources:
   collector1:
     Active: true

--- a/topology/Indiana University/IU UITS/GOC Accounting Reporter.yaml
+++ b/topology/Indiana University/IU UITS/GOC Accounting Reporter.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Web server to display various accounting reports
 GroupID: 418
+Production: true
 Resources:
   Accounting_Reporter:
     Active: true

--- a/topology/Indiana University/IU UITS/GOC Perfsonar Toolkits.yaml
+++ b/topology/Indiana University/IU UITS/GOC Perfsonar Toolkits.yaml
@@ -1,8 +1,8 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Hosts perfsonar toolkit instances to help administrators to troubleshoot
   network connectivity issues between GOC and their sites.
 GroupID: 371
+Production: true
 Resources:
   GOC_Perfsonar_Bandwidth:
     Active: true

--- a/topology/Indiana University/IU UITS/GOC_Authorization_Services.yaml
+++ b/topology/Indiana University/IU UITS/GOC_Authorization_Services.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: This resource group will contain the GOC-run VOMS server, etc.
 GroupID: 248
+Production: true
 Resources:
   GOC_Auth_Services:
     Active: true

--- a/topology/Indiana University/IU UITS/GOC_BDII.yaml
+++ b/topology/Indiana University/IU UITS/GOC_BDII.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Group of BDIIs run by the GOC to serve both OSG and WLCG users.
 GroupID: 247
+Production: true
 Resources:
   GOC_BDII_1:
     Active: false

--- a/topology/Indiana University/IU UITS/GOC_BDII_ITB.yaml
+++ b/topology/Indiana University/IU UITS/GOC_BDII_ITB.yaml
@@ -1,8 +1,8 @@
 Disable: false
-GridType: OSG Integration Test Bed Resource
 GroupDescription: Group of BDIIs run by the GOC to serve both OSG-ITB and WLCG-PPS
   users.
 GroupID: 256
+Production: false
 Resources:
   GOC_BDII_ITB_1:
     Active: true

--- a/topology/Indiana University/IU UITS/GOC_Event.yaml
+++ b/topology/Indiana University/IU UITS/GOC_Event.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Resource group for the message bus
 GroupID: 477
+Production: true
 Resources:
   RabbitMQ message bus:
     Active: true

--- a/topology/Indiana University/IU UITS/GOC_OIM.yaml
+++ b/topology/Indiana University/IU UITS/GOC_OIM.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Resource group for the OIM topology system
 GroupID: 266
+Production: true
 Resources:
   GOC_OIM:
     Active: true

--- a/topology/Indiana University/IU UITS/GOC_RSV_Collector.yaml
+++ b/topology/Indiana University/IU UITS/GOC_RSV_Collector.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: The Gratia based RSV collector hosted by the GOC
 GroupID: 250
+Production: true
 Resources:
   RSV1:
     Active: false

--- a/topology/Indiana University/IU UITS/GOC_RSV_Collector_ITB.yaml
+++ b/topology/Indiana University/IU UITS/GOC_RSV_Collector_ITB.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Integration Test Bed Resource
 GroupDescription: The Gratia based RSV-ITB collector hosted by the GOC.
 GroupID: 251
+Production: false
 Resources:
   RSV_Collector_ITB:
     Active: true

--- a/topology/Indiana University/IU UITS/GOC_Repo.yaml
+++ b/topology/Indiana University/IU UITS/GOC_Repo.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: A place to store RPM distributions
 GroupID: 325
+Production: true
 Resources:
   GOC_Repo_1:
     Active: true

--- a/topology/Indiana University/IU UITS/GOC_Repo_ITB.yaml
+++ b/topology/Indiana University/IU UITS/GOC_Repo_ITB.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Integration Test Bed Resource
 GroupDescription: Repo ITB
 GroupID: 431
+Production: false
 Resources:
   GOC_Repo_ITB:
     Active: true

--- a/topology/Indiana University/IU UITS/GOC_Software_Cache.yaml
+++ b/topology/Indiana University/IU UITS/GOC_Software_Cache.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: For getting OSG software
 GroupID: 270
+Production: true
 Resources:
   GOC_Software_Cache_1:
     Active: true

--- a/topology/Indiana University/IU UITS/GOC_Software_Cache_ITB.yaml
+++ b/topology/Indiana University/IU UITS/GOC_Software_Cache_ITB.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Integration Test Bed Resource
 GroupDescription: For getting OSG software
 GroupID: 271
+Production: false
 Resources:
   GOC_Software_Cache_ITB:
     Active: true

--- a/topology/Indiana University/IU UITS/GOC_Ticket.yaml
+++ b/topology/Indiana University/IU UITS/GOC_Ticket.yaml
@@ -1,8 +1,8 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Resource group that contains the resources that host the OSG ticketing
   system GOCTicket
 GroupID: 265
+Production: true
 Resources:
   GOC_Ticket_1:
     Active: true

--- a/topology/Indiana University/IU UITS/GOC_VOMS.yaml
+++ b/topology/Indiana University/IU UITS/GOC_VOMS.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: A VOMS run by the GOC for the VOs CSIU, mis and osgedu
 GroupID: 344
+Production: true
 Resources:
   GOC Voms:
     Active: true

--- a/topology/Indiana University/IU UITS/Gratia_Web.yaml
+++ b/topology/Indiana University/IU UITS/Gratia_Web.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: To be used for monitoring
 GroupID: 401
+Production: true
 Resources:
   GratiaWeb 1:
     Active: true

--- a/topology/Indiana University/IU UITS/ITB VM hosts.yaml
+++ b/topology/Indiana University/IU UITS/ITB VM hosts.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Integration Test Bed Resource
 GroupDescription: VM hosts for ITB services
 GroupID: 442
+Production: false
 Resources:
   DEVM01:
     Active: true

--- a/topology/Indiana University/IU UITS/IUB-VTB.yaml
+++ b/topology/Indiana University/IU UITS/IUB-VTB.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Integration Test Bed Resource
 GroupDescription: (No resource group description)
 GroupID: 48
+Production: false
 Resources:
   IUB-VTB:
     Active: false

--- a/topology/Indiana University/IU UITS/IUB_ITB.yaml
+++ b/topology/Indiana University/IU UITS/IUB_ITB.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Integration Test Bed Resource
 GroupDescription: (No resource group description)
 GroupID: 49
+Production: false
 Resources:
   IUB_ITB:
     Active: false

--- a/topology/Indiana University/IU UITS/IUB_ITB2.yaml
+++ b/topology/Indiana University/IU UITS/IUB_ITB2.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Integration Test Bed Resource
 GroupDescription: (No resource group description)
 GroupID: 50
+Production: false
 Resources:
   IUB_ITB2:
     Active: false

--- a/topology/Indiana University/IU UITS/IUB_ITB_AG.yaml
+++ b/topology/Indiana University/IU UITS/IUB_ITB_AG.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Integration Test Bed Resource
 GroupDescription: (No resource group description)
 GroupID: 51
+Production: false
 Resources:
   IUB_ITB_AG:
     Active: false

--- a/topology/Indiana University/IU UITS/IUPUI-ITB.yaml
+++ b/topology/Indiana University/IU UITS/IUPUI-ITB.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Integration Test Bed Resource
 GroupDescription: 7/26 disabling empty resource group
 GroupID: 52
+Production: false
 Resources:
   IUPUI-ITB:
     Active: false

--- a/topology/Indiana University/IU UITS/IU_COBRA_ITB.yaml
+++ b/topology/Indiana University/IU UITS/IU_COBRA_ITB.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Integration Test Bed Resource
 GroupDescription: A dev CE
 GroupID: 54
+Production: false
 Resources:
   IU_COBRA_ITB:
     Active: false

--- a/topology/Indiana University/IU UITS/IU_OSG.yaml
+++ b/topology/Indiana University/IU UITS/IU_OSG.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: https://ticket.grid.iu.edu/24249
 GroupID: 56
+Production: true
 Resources:
   IU_OSG:
     Active: false

--- a/topology/Indiana University/IU UITS/IU_iuatlas.yaml
+++ b/topology/Indiana University/IU UITS/IU_iuatlas.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Integration Test Bed Resource
 GroupDescription: (No resource group description)
 GroupID: 55
+Production: false
 Resources:
   IU_iuatlas:
     Active: false

--- a/topology/Indiana University/IU UITS/MyOSG.yaml
+++ b/topology/Indiana University/IU UITS/MyOSG.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: The central MyOSG service accessible at http://myosg.grid.iu.edu
 GroupID: 246
+Production: true
 Resources:
   MyOSG_1:
     Active: true

--- a/topology/Indiana University/IU UITS/OSG Oasis.yaml
+++ b/topology/Indiana University/IU UITS/OSG Oasis.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: OSG stratum0 server
 GroupID: 364
+Production: true
 Resources:
   Oasis:
     Active: true

--- a/topology/Indiana University/IU UITS/OSG blogs.yaml
+++ b/topology/Indiana University/IU UITS/OSG blogs.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: OSG blogs, production instance
 GroupID: 422
+Production: true
 Resources:
   OSG blog:
     Active: true

--- a/topology/Indiana University/IU UITS/OSG_DOCDB.yaml
+++ b/topology/Indiana University/IU UITS/OSG_DOCDB.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: OSG DOCDB Homepage (http://osg-docdb.opensciencegrid.org)
 GroupID: 281
+Production: true
 Resources:
   OSG_DOCDB_1:
     Active: true

--- a/topology/Indiana University/IU UITS/OSG_Display.yaml
+++ b/topology/Indiana University/IU UITS/OSG_Display.yaml
@@ -1,8 +1,8 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: This resource group consists of resources that provide the "OSG
   Display" service.
 GroupID: 261
+Production: true
 Resources:
   OSG_Display_1:
     Active: true

--- a/topology/Indiana University/IU UITS/OSG_Homepage.yaml
+++ b/topology/Indiana University/IU UITS/OSG_Homepage.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: OSG Homepage (http://opensciencegrid.org)
 GroupID: 280
+Production: true
 Resources:
   OSG_Homepage_1:
     Active: true

--- a/topology/Indiana University/IU UITS/OSG_JIRA.yaml
+++ b/topology/Indiana University/IU UITS/OSG_JIRA.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: JIRA ticket system for OSG staff
 GroupID: 334
+Production: true
 Resources:
   jira:
     Active: true

--- a/topology/Indiana University/IU UITS/OSG_TWiki.yaml
+++ b/topology/Indiana University/IU UITS/OSG_TWiki.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: OSG Documentation OSG Collaborative Team space
 GroupID: 197
+Production: true
 Resources:
   Image_Server:
     Active: false

--- a/topology/Indiana University/IU UITS/OSG_XD.yaml
+++ b/topology/Indiana University/IU UITS/OSG_XD.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Allows OSG to be a Resource Provider for XSEDE
 GroupID: 336
+Production: true
 Resources:
   OSG_FLOCK:
     Active: true

--- a/topology/Indiana University/IU UITS/Oasis Replica.yaml
+++ b/topology/Indiana University/IU UITS/Oasis Replica.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: The stratum 1 component of the Oasis service
 GroupID: 366
+Production: true
 Resources:
   OSG Oasis replica:
     Active: true

--- a/topology/Indiana University/IU UITS/Oasis login nodes.yaml
+++ b/topology/Indiana University/IU UITS/Oasis login nodes.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Oasis login nodes resource group
 GroupID: 409
+Production: true
 Resources:
   oasis-login:
     Active: true

--- a/topology/Indiana University/IU UITS/Perfsonar components.yaml
+++ b/topology/Indiana University/IU UITS/Perfsonar components.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Perfsonar components operated by the GOC
 GroupID: 432
+Production: true
 Resources:
   Cassandra 1:
     Active: true

--- a/topology/Indiana University/IU UITS/Perfsonar-itb components.yaml
+++ b/topology/Indiana University/IU UITS/Perfsonar-itb components.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Integration Test Bed Resource
 GroupDescription: ITB version of production components
 GroupID: 434
+Production: false
 Resources:
   Cassandra-itb1:
     Active: true

--- a/topology/Indiana University/IU UITS/Production VM hosts.yaml
+++ b/topology/Indiana University/IU UITS/Production VM hosts.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Resource group for production VM hosts
 GroupID: 441
+Production: true
 Resources:
   VM01:
     Active: true

--- a/topology/Indiana University/Indiana University Physics/Indiana_ATLAS_Tier3.yaml
+++ b/topology/Indiana University/Indiana University Physics/Indiana_ATLAS_Tier3.yaml
@@ -1,10 +1,10 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: |-
   Indiana University Physics Department cluster for ATLAS.
 
   7/26 disabling empty resource group
 GroupID: 290
+Production: true
 Resources:
   Indiana_Physics_ATLAS:
     Active: false

--- a/topology/Indiana University/JetStream/Jetstream.yaml
+++ b/topology/Indiana University/JetStream/Jetstream.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Jetstream resource Group
 GroupID: 466
+Production: true
 Resources:
   Jetstream-CE-1:
     Active: true

--- a/topology/Indiana University/MWT2 ATLAS IU/IU_ATLAS_Tier2.yaml
+++ b/topology/Indiana University/MWT2 ATLAS IU/IU_ATLAS_Tier2.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 53
+Production: true
 Resources:
   IU_ATLAS_Tier2:
     Active: false

--- a/topology/Indiana University/MWT2 ATLAS IU/MWT2_IU.yaml
+++ b/topology/Indiana University/MWT2 ATLAS IU/MWT2_IU.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 68
+Production: true
 Resources:
   MWT2_IU:
     Active: false

--- a/topology/Indiana University/OSG GOC/Condor_Collectors.yaml
+++ b/topology/Indiana University/OSG GOC/Condor_Collectors.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Integration Test Bed Resource
 GroupDescription: HTCondor collector
 GroupID: 403
+Production: false
 Resources:
   collector-itb:
     Active: true

--- a/topology/Indiana University/OSG GOC/GOC_ITB.yaml
+++ b/topology/Indiana University/OSG GOC/GOC_ITB.yaml
@@ -1,10 +1,10 @@
 Disable: false
-GridType: OSG Integration Test Bed Resource
 GroupDescription: ITB Resource Group provided by Grid Operations Center. The purpose
   of this resource group is to host ITB instances of CE, SE, and other OSG resources
   in order to test new OSG components / train our GOC staff with the latest OSG (&
   Grid in general) technologies.
 GroupID: 299
+Production: false
 Resources:
   GOC_ITB_CE:
     Active: false

--- a/topology/Indiana University/OSG GOC/IPAS_OSG.yaml
+++ b/topology/Indiana University/OSG GOC/IPAS_OSG.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Integration Test Bed Resource
 GroupDescription: (No resource group description)
 GroupID: 43
+Production: false
 Resources:
   IPAS_OSG:
     Active: false

--- a/topology/Indiana University/OSG GOC/Monitored Caches.yaml
+++ b/topology/Indiana University/OSG GOC/Monitored Caches.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: A collection of monitored StashCaches
 GroupID: 433
+Production: true
 Resources:
   BNL Atlas StashCache instance:
     Active: true

--- a/topology/Indiana University/OSG GOC/Monitored Origins.yaml
+++ b/topology/Indiana University/OSG GOC/Monitored Origins.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: A place for monitoring stash cache origin servers
 GroupID: 454
+Production: true
 Resources:
   Caltech StashCache instance:
     Active: true

--- a/topology/Indiana University/OSG GOC/Monitored Redirectors.yaml
+++ b/topology/Indiana University/OSG GOC/Monitored Redirectors.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Changing name
 GroupID: 430
+Production: true
 Resources:
   Indiana StashCache Redirector 1:
     Active: true

--- a/topology/Indiana University/OSG GOC/OSG blogs ITB.yaml
+++ b/topology/Indiana University/OSG GOC/OSG blogs ITB.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Integration Test Bed Resource
 GroupDescription: Blog aggregator, ITB instance
 GroupID: 421
+Production: false
 Resources:
   osg-blogs:
     Active: true

--- a/topology/Indiana University/OSG GOC/Test Grouop.yaml
+++ b/topology/Indiana University/OSG GOC/Test Grouop.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Integration Test Bed Resource
 GroupDescription: This is a resource group used to host test resources
 GroupID: 396
+Production: false
 Resources:
   Soichi_Test_Resource:
     Active: false

--- a/topology/Indiana University/OSG GOC/stash-itb.yaml
+++ b/topology/Indiana University/OSG GOC/stash-itb.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Integration Test Bed Resource
 GroupDescription: stash at the GOC
 GroupID: 419
+Production: false
 Resources:
   stash-itb1:
     Active: true

--- a/topology/Indiana University/OSG GOC/yahoo.yaml
+++ b/topology/Indiana University/OSG GOC/yahoo.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Integration Test Bed Resource
 GroupDescription: Registering yahoo as a resource to test testing infrastructure
 GroupID: 447
+Production: false
 Resources:
   Yahoo:
     Active: true

--- a/topology/Indiana University/OSG Security Services/OSG_SECURITY_MONITOR.yaml
+++ b/topology/Indiana University/OSG Security Services/OSG_SECURITY_MONITOR.yaml
@@ -1,10 +1,10 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: This resource group will include virtual resources that are mapped
   to CA/CRL-testing services. The OSG security group will use this resource group's
   status to keep track of whether CA/CRL processes work, as well as to keep track
   of CA/CRL content problems.
 GroupID: 257
+Production: true
 Resources:
   SECMON_CADIST_GOC:
     Active: true

--- a/topology/Institute of Physics ASCR/FZU/FZU.yaml
+++ b/topology/Institute of Physics ASCR/FZU/FZU.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: NOvA production site
 GroupID: 387
+Production: true
 Resources:
   FZU_NOVA:
     Active: false

--- a/topology/Institute of Plasma Physics, Chinese Academy of Sciences/shenma high performance computing at IPP CAS/TRANSP_simulations_for_EAST.yaml
+++ b/topology/Institute of Plasma Physics, Chinese Academy of Sciences/shenma high performance computing at IPP CAS/TRANSP_simulations_for_EAST.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: to do TRANSP simulations for EAST discharges
 GroupID: 459
+Production: true
 Resources:
   shenma_duhongfei:
     Active: true

--- a/topology/Inter-University Centre for Astronomy and Astrophysics/IUCAA Sarathi Cluster/OSG_IN_IUCAA_SARATHI.yaml
+++ b/topology/Inter-University Centre for Astronomy and Astrophysics/IUCAA Sarathi Cluster/OSG_IN_IUCAA_SARATHI.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Hosted CE submitting to Sarathi Cluster
 GroupID: 481
+Production: true
 Resources:
   OSG_IN_IUCAA_SARATHI:
     Active: true

--- a/topology/Iowa State University/ISU HEP/isuhep.yaml
+++ b/topology/Iowa State University/ISU HEP/isuhep.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: isuhep deactivated https://oim.grid.iu.edu/gocticket/viewer?id=6356
 GroupID: 44
+Production: true
 Resources:
   isuhep:
     Active: false

--- a/topology/JINR/JINR_Cloud/JINR_CLOUD.yaml
+++ b/topology/JINR/JINR_Cloud/JINR_CLOUD.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: A computing element for the JINR cloud.
 GroupID: 458
+Production: true
 Resources:
   JINR_CONDOR_CE:
     Active: true

--- a/topology/JINR/JINR_Tier2/JINR-Tier2.yaml
+++ b/topology/JINR/JINR_Tier2/JINR-Tier2.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: CE for the JINR_Tier2 site
 GroupID: 427
+Production: true
 Resources:
   JINR_Tier2_CE1:
     Active: true

--- a/topology/Kansas State University/Beocat/Beocat.yaml
+++ b/topology/Kansas State University/Beocat/Beocat.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: The Beocat Cluster at Kansas State University
 GroupID: 278
+Production: true
 Resources:
   Beocat_CE:
     Active: true

--- a/topology/Kansas University/GPN Kansas/GPN_KSU_CLUSTER.yaml
+++ b/topology/Kansas University/GPN Kansas/GPN_KSU_CLUSTER.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: 7/26 disabling empty resource group
 GroupID: 205
+Production: true
 Resources:
   GPN_KSU_CLUSTER:
     Active: false

--- a/topology/Kansas University/GPN Kansas/gpnjayhawk.yaml
+++ b/topology/Kansas University/GPN Kansas/gpnjayhawk.yaml
@@ -1,8 +1,8 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: De-commissioned by AG per Rob Quick\'s request (ticket 5116) - AG
   2008-06-19
 GroupID: 28
+Production: true
 Resources:
   gpnjayhawk:
     Active: false

--- a/topology/Kansas University/KANSAS_HOSTED/KANSAS_HOSTED_BOSCO_CE.yaml
+++ b/topology/Kansas University/KANSAS_HOSTED/KANSAS_HOSTED_BOSCO_CE.yaml
@@ -1,8 +1,8 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Entry for hosted CE running at UChicago but submitting to KU cluster
   resources
 GroupID: 462
+Production: true
 Resources:
   HOSTED_KANSAS_CE:
     Active: true

--- a/topology/Kennesaw State University/Kennesaw State University/Kennesaw_Dell_Nodes.yaml
+++ b/topology/Kennesaw State University/Kennesaw State University/Kennesaw_Dell_Nodes.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: 10 Dual Quad-Core Dell R410 blades
 GroupID: 375
+Production: true
 Resources:
   Kennesaw_Dell_Nodes:
     Active: true

--- a/topology/Korea Institute of Science and Technology Information/KISTI-NSDC/KISTI-NSDC-01.yaml
+++ b/topology/Korea Institute of Science and Technology Information/KISTI-NSDC/KISTI-NSDC-01.yaml
@@ -1,9 +1,9 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: |-
   CDF
   provided by KISTI-NSDC project
 GroupID: 245
+Production: true
 Resources:
   KISTI-NSDC-CE03:
     Active: false

--- a/topology/Korea Institute of Science and Technology Information/T3_KR_KISTI/T3_KR_KISTI.yaml
+++ b/topology/Korea Institute of Science and Technology Information/T3_KR_KISTI/T3_KR_KISTI.yaml
@@ -1,9 +1,9 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: |-
   KISTI_CMS_T3_CE
   KISTI_CMS_T3_SE
 GroupID: 394
+Production: true
 Resources:
   KISTI-NSDC-GUMS:
     Active: false

--- a/topology/LHCONE/GEANT-AMS/Geant perfSONAR.yaml
+++ b/topology/LHCONE/GEANT-AMS/Geant perfSONAR.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: perfSONAR LHCONE instance in Amsterdam
 GroupID: 407
+Production: true
 Resources:
   AMS_GEANT LHCONE:
     Active: true

--- a/topology/LHCONE/LBL_ESnet/LBL_Testbed.yaml
+++ b/topology/LHCONE/LBL_ESnet/LBL_Testbed.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: perfSONAR testbed
 GroupID: 417
+Production: true
 Resources:
   LBL_nettest:
     Active: true

--- a/topology/LHCONE/MANLAN/MANLAN perfSONAR.yaml
+++ b/topology/LHCONE/MANLAN/MANLAN perfSONAR.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: LHCONE perfSONAR instances at MANLAN
 GroupID: 408
+Production: true
 Resources:
   BNL/ESnet perfSONAR:
     Active: true

--- a/topology/LHCONE/STAR/Starlight perfSONARs.yaml
+++ b/topology/LHCONE/STAR/Starlight perfSONARs.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: perfSONAR instances at Starlight
 GroupID: 410
+Production: true
 Resources:
   ESnet Starlight perfSONAR:
     Active: true

--- a/topology/LHCONE/WIX/WIX PerfSONAR.yaml
+++ b/topology/LHCONE/WIX/WIX PerfSONAR.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: WIX PerfSONAR
 GroupID: 405
+Production: true
 Resources:
   ESnet LHCONE perfSONAR Washington:
     Active: true

--- a/topology/Langston University/LU HEP/LUHEP_OSG.yaml
+++ b/topology/Langston University/LU HEP/LUHEP_OSG.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Langston University HEP
 GroupID: 249
+Production: true
 Resources:
   LUHEP_OSG:
     Active: true

--- a/topology/Langston University/LUCCRE/LUCILLE.yaml
+++ b/topology/Langston University/LUCCRE/LUCILLE.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: CE & SE
 GroupID: 379
+Production: true
 Resources:
   Lucille-squid:
     Active: true

--- a/topology/Lawrence Berkley National Laboratory/LBNL/LBNL_DSD_ITB.yaml
+++ b/topology/Lawrence Berkley National Laboratory/LBNL/LBNL_DSD_ITB.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Integration Test Bed Resource
 GroupDescription: (No resource group description)
 GroupID: 58
+Production: false
 Resources:
   LBNL_DSD_ITB:
     Active: true

--- a/topology/Lawrence Berkley National Laboratory/LBNL/LBNL_VTB.yaml
+++ b/topology/Lawrence Berkley National Laboratory/LBNL/LBNL_VTB.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Integration Test Bed Resource
 GroupDescription: (No resource group description)
 GroupID: 59
+Production: false
 Resources:
   LBNL_VTB:
     Active: true

--- a/topology/Lawrence Livermore National Laboratory/Livermore Computing/LC-glcc.yaml
+++ b/topology/Lawrence Livermore National Laboratory/Livermore Computing/LC-glcc.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: glcc is the "Green Linux Collaboration Cluster" in LC
 GroupID: 286
+Production: true
 Resources:
   LC-glcc:
     Active: true

--- a/topology/Lehigh University/Lehigh Coral/Lehigh_coral.yaml
+++ b/topology/Lehigh University/Lehigh Coral/Lehigh_coral.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 60
+Production: true
 Resources:
   Lehigh_coral:
     Active: true

--- a/topology/Louisiana State University/LONI_LSU/LONI_OSG1.yaml
+++ b/topology/Louisiana State University/LONI_LSU/LONI_OSG1.yaml
@@ -1,8 +1,8 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: OSG resources connected to the LONI Eric 5TF cluster at LSU in Baton
   Rouge, LA.
 GroupID: 151
+Production: true
 Resources:
   LONI_OSG1:
     Active: false

--- a/topology/Louisiana State University/LONI_LSU/LONI_OSG2.yaml
+++ b/topology/Louisiana State University/LONI_LSU/LONI_OSG2.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: OSG Compute Element to support LIGO workflow submission using pegasus
 GroupID: 179
+Production: true
 Resources:
   LONI_OSG2:
     Active: true

--- a/topology/Louisiana Tech University/LaTech/LTU_CCT.yaml
+++ b/topology/Louisiana Tech University/LaTech/LTU_CCT.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: Rob confirmed to Arvind that this is a de-activated resource. 2008-06-06
 GroupID: 63
+Production: true
 Resources:
   LTU_CCT:
     Active: false

--- a/topology/Louisiana Tech University/LaTech/LTU_Tier3.yaml
+++ b/topology/Louisiana Tech University/LaTech/LTU_Tier3.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: ATLAS Tier 3 Computing Center at Louisiana Tech University
 GroupID: 64
+Production: true
 Resources:
   LTU_OSG:
     Active: false

--- a/topology/Massachusetts Institute of Technology/MIT CMS T3/MIT_CMS_T3.yaml
+++ b/topology/Massachusetts Institute of Technology/MIT CMS T3/MIT_CMS_T3.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: MIT CMS Tier3 cluster.
 GroupID: 367
+Production: true
 Resources:
   MIT_CMS_T3-CE1:
     Active: true

--- a/topology/Massachusetts Institute of Technology/MIT CMS/MIT_CMS.yaml
+++ b/topology/Massachusetts Institute of Technology/MIT CMS/MIT_CMS.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 66
+Production: true
 Resources:
   MIT_CMS:
     Active: true

--- a/topology/Massachusetts Institute of Technology/MIT LIGO/OSG_LIGO_MIT.yaml
+++ b/topology/Massachusetts Institute of Technology/MIT LIGO/OSG_LIGO_MIT.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 84
+Production: true
 Resources:
   OSG_LIGO_GUMS:
     Active: false

--- a/topology/Massachusetts Institute of Technology/MIT_SUBMIT/MIT_SUBMIT.yaml
+++ b/topology/Massachusetts Institute of Technology/MIT_SUBMIT/MIT_SUBMIT.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Submission hub to on- and off-campus resources.
 GroupID: 449
+Production: true
 Resources:
   MIT_SUBMIT_SCHEDD:
     Active: true

--- a/topology/McGill University/McGill HEP/MCGILL_HEP.yaml
+++ b/topology/McGill University/McGill HEP/MCGILL_HEP.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: 7/26 disabling empty resource group
 GroupID: 65
+Production: true
 Resources:
   MCGILL_HEP:
     Active: false

--- a/topology/Michigan State University High Energy Physics/MSU OSG/MSU-OSG.yaml
+++ b/topology/Michigan State University High Energy Physics/MSU OSG/MSU-OSG.yaml
@@ -1,8 +1,8 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Added manually by Arvind from old RegDB - please update if need
   be.
 GroupID: 149
+Production: true
 Resources:
   MSU-OSG:
     Active: true

--- a/topology/Michigan State University High Energy Physics/MSU OSG/MSU-OSG_SE.yaml
+++ b/topology/Michigan State University High Energy Physics/MSU OSG/MSU-OSG_SE.yaml
@@ -1,8 +1,8 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Added manually by Arvind from old RegDB - please update if need
   be.
 GroupID: 150
+Production: true
 Resources:
   MSU-OSG_SE:
     Active: true

--- a/topology/NSF DC/NSF/OCI-NSF.yaml
+++ b/topology/NSF DC/NSF/OCI-NSF.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: Added manually by Arvind from old regDB - please update if you can!
 GroupID: 145
+Production: true
 Resources:
   OCI-NSF:
     Active: false

--- a/topology/National Energy Research Scientific Computing Center/NERSC/NERSC-Carver.yaml
+++ b/topology/National Energy Research Scientific Computing Center/NERSC/NERSC-Carver.yaml
@@ -1,11 +1,11 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: "Carver contains 800 Intel Nehalem quad-core processors, for a total\
   \ of 3,200 cores. The system\u2019s 400 compute nodes are interconnected by 4X QDR\
   \ InfiniBand technology, meaning that 32 Gb/s of point-to-point bandwidth is available\
   \ for high-performance message passing and access to the global File System (NGF),\
   \ which holds Carver\u2019s home, system and scratch storage."
 GroupID: 269
+Production: true
 Resources:
   NERSC-Carver:
     Active: false

--- a/topology/National Energy Research Scientific Computing Center/NERSC/NERSC-Davinci.yaml
+++ b/topology/National Energy Research Scientific Computing Center/NERSC/NERSC-Davinci.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: 7/26 disabling empty resource group
 GroupID: 72
+Production: true
 Resources:
   NERSC-Davinci:
     Active: false

--- a/topology/National Energy Research Scientific Computing Center/NERSC/NERSC-Franklin.yaml
+++ b/topology/National Energy Research Scientific Computing Center/NERSC/NERSC-Franklin.yaml
@@ -1,5 +1,4 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: |-
   The NERSC Cray XT4 system, named Franklin, is a massively parallel processing (MPP) system with 9,660 compute nodes. Each node has dual processor cores, and the entire system has a total of 19,320 processor cores available for scientific applications. The system is named in honor of Benjamin Franklin.
 
@@ -7,6 +6,7 @@ GroupDescription: |-
 
   Franklin uses two different operating systems. Full-featured SuSE Linux is run on service nodes (16 login nodes and other I/O, network and system nodes). A light weight OS based on Linux, Compute Node Linux (CNL), is run on each compute node. CNL reduces system overhead, and is critical for the system to scale to very large concurrency. The Parallel file system on Franklin is provided by Lustre with approximately 350 TBytes of user disk space.
 GroupID: 180
+Production: true
 Resources:
   NERSC-Franklin:
     Active: false

--- a/topology/National Energy Research Scientific Computing Center/NERSC/NERSC-ITB.yaml
+++ b/topology/National Energy Research Scientific Computing Center/NERSC/NERSC-ITB.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Integration Test Bed Resource
 GroupDescription: (No resource group description)
 GroupID: 73
+Production: false
 Resources:
   NERSC-ITB:
     Active: false

--- a/topology/National Energy Research Scientific Computing Center/NERSC/NERSC-Jacquard.yaml
+++ b/topology/National Energy Research Scientific Computing Center/NERSC/NERSC-Jacquard.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: disabled
 GroupID: 74
+Production: true
 Resources:
   NERSC-Jacquard:
     Active: false

--- a/topology/National Energy Research Scientific Computing Center/NERSC/NERSC-PDSF.yaml
+++ b/topology/National Energy Research Scientific Computing Center/NERSC/NERSC-PDSF.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 75
+Production: true
 Resources:
   NERSC-PDSF:
     Active: true

--- a/topology/National Energy Research Scientific Computing Center/NERSC/NERSC-PDSFSRM.yaml
+++ b/topology/National Energy Research Scientific Computing Center/NERSC/NERSC-PDSFSRM.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 76
+Production: true
 Resources:
   NERSC-PDSFDTN:
     Active: true

--- a/topology/National Energy Research Scientific Computing Center/NERSC/NERSC-VM-VTB0.yaml
+++ b/topology/National Energy Research Scientific Computing Center/NERSC/NERSC-VM-VTB0.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Integration Test Bed Resource
 GroupDescription: (No resource group description)
 GroupID: 77
+Production: false
 Resources:
   NERSC-VM-VTB0:
     Active: true

--- a/topology/National Energy Research Scientific Computing Center/NERSC/Perfsonar Services.yaml
+++ b/topology/National Energy Research Scientific Computing Center/NERSC/Perfsonar Services.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Perfsonar Services
 GroupID: 456
+Production: true
 Resources:
   perfSONAR_NERSC_bw:
     Active: true

--- a/topology/New York University/NYU ATLAS Tier3/NYU-ATLAS.yaml
+++ b/topology/New York University/NYU ATLAS Tier3/NYU-ATLAS.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Resource Group for the NYU ATLAS Tier3 site
 GroupID: 304
+Production: true
 Resources:
   NYU_ATLAS_NFS:
     Active: true

--- a/topology/Niagara University/GRASE Niagra/GRASE-NU-CARTMAN.yaml
+++ b/topology/Niagara University/GRASE Niagra/GRASE-NU-CARTMAN.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 34
+Production: true
 Resources:
   GRASE-NU-CARTMAN:
     Active: false

--- a/topology/North Dakota State University/OSG_US_NDSU_CCAST_CLUSTER2/OSG_US_NDSU_CCAST_CLUSTER2.yaml
+++ b/topology/North Dakota State University/OSG_US_NDSU_CCAST_CLUSTER2/OSG_US_NDSU_CCAST_CLUSTER2.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Hosted CE for NDSU CCAST's Cluster 2
 GroupID: 480
+Production: true
 Resources:
   OSG_US_NDSU_CCAST_CLUSTER2:
     Active: true

--- a/topology/Northeastern University/T3_US_NEU/T3_US_NEU.yaml
+++ b/topology/Northeastern University/T3_US_NEU/T3_US_NEU.yaml
@@ -1,8 +1,8 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: The resource corresponding to the Northeastern University CMS group
   Tier 3
 GroupID: 392
+Production: true
 Resources:
   NEU T3 cluster:
     Active: true

--- a/topology/Northern Illinois University/NIU ATLAS T3/NIU_ATLAS_CE.yaml
+++ b/topology/Northern Illinois University/NIU ATLAS T3/NIU_ATLAS_CE.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Compute element for atlas vo
 GroupID: 443
+Production: true
 Resources:
   NIU_atlas_CE:
     Active: true

--- a/topology/Northwestern University/NU Tier3/NU_CMS_TIER3_CE.yaml
+++ b/topology/Northwestern University/NU Tier3/NU_CMS_TIER3_CE.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Compute Element for Tier3
 GroupID: 376
+Production: true
 Resources:
   NU_CMS_TIER3_CE:
     Active: true

--- a/topology/Northwestern University/NU Tier3/NU_CMS_TIER3_SE.yaml
+++ b/topology/Northwestern University/NU Tier3/NU_CMS_TIER3_SE.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Storage Element Tier3
 GroupID: 377
+Production: true
 Resources:
   NU_CMS_TIER3_SE:
     Active: true

--- a/topology/Northwestern University/NUMEP-OSG/NUMEP-OSG.yaml
+++ b/topology/Northwestern University/NUMEP-OSG/NUMEP-OSG.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Northwestern University Medium Energy Physics Group Computing Cluster
 GroupID: 390
+Production: true
 Resources:
   NUMEP_CE:
     Active: true

--- a/topology/Oak Rigde National Labortory/ORNL NSTG/ORNL_NSTG.yaml
+++ b/topology/Oak Rigde National Labortory/ORNL NSTG/ORNL_NSTG.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: 7/26 disabling empty resource group
 GroupID: 82
+Production: true
 Resources:
   ORNL_NSTG:
     Active: false

--- a/topology/Ohio Supercomputer Center/OSC/OSC_OSG.yaml
+++ b/topology/Ohio Supercomputer Center/OSC/OSC_OSG.yaml
@@ -1,8 +1,8 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: This is the general OSG resource group at OSC.  It is designed to
   support multiple VOs.
 GroupID: 384
+Production: true
 Resources:
   OSC_OSG_CE:
     Active: true

--- a/topology/Ohio Supercomputer Center/OSC/OSC_SuperB.yaml
+++ b/topology/Ohio Supercomputer Center/OSC/OSC_SuperB.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: Resource group at OSC for the SuperB collaboration.
 GroupID: 353
+Production: true
 Resources:
   OSC_SuperB_CE:
     Active: true

--- a/topology/Oklahoma State University/Oklahoma_Hosted_Site/OSU_HOSTED_BOSCO_CE.yaml
+++ b/topology/Oklahoma State University/Oklahoma_Hosted_Site/OSU_HOSTED_BOSCO_CE.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Entry for BOSCO CE submitting to Cowboy cluster at Oklahoma State
 GroupID: 464
+Production: true
 Resources:
   OSG_US_OSU_COWBOY:
     Active: false

--- a/topology/PNNL/PNNL_DC/PNNL_BelleII.yaml
+++ b/topology/PNNL/PNNL_DC/PNNL_BelleII.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Belle2 Computing
 GroupID: 349
+Production: true
 Resources:
   Belle_CE_2:
     Active: false

--- a/topology/PNNL/PNNL_DC/PNNL_HEP.yaml
+++ b/topology/PNNL/PNNL_DC/PNNL_HEP.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: General PNNL HEP resource
 GroupID: 429
+Production: true
 Resources:
   PNNL_HEP_CE00:
     Active: true

--- a/topology/PNNL/PNNL_OSG2/PNNL_OSG2.yaml
+++ b/topology/PNNL/PNNL_OSG2/PNNL_OSG2.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: PNNL Grid Resources
 GroupID: 355
+Production: true
 Resources:
   PNNL_OSG-Misregistered:
     Active: false

--- a/topology/Penn State University/PSU LIGO/OSG_LIGO_PSU.yaml
+++ b/topology/Penn State University/PSU LIGO/OSG_LIGO_PSU.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 85
+Production: true
 Resources:
   OSG_LIGO_PSU:
     Active: false

--- a/topology/Pontificia Universidad Javeriana/GC_PUJ/GCVO_PUJ.yaml
+++ b/topology/Pontificia Universidad Javeriana/GC_PUJ/GCVO_PUJ.yaml
@@ -1,9 +1,9 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: |-
   Support for GCVO and GCEDU VO
   Pontificia Universidad Javeriana, GridColombia
 GroupID: 303
+Production: true
 Resources:
   GCVO_PUJ_CE:
     Active: false

--- a/topology/Princeton University/Princeton_ICSE/Princeton_ICSE_T3_CMS.yaml
+++ b/topology/Princeton University/Princeton_ICSE/Princeton_ICSE_T3_CMS.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: CMS Tier3 site at Princeton
 GroupID: 268
+Production: true
 Resources:
   Princeton_ICSE_T3_CMS_SE:
     Active: true

--- a/topology/Purdue University/Purdue CMS/Purdue-Brown.yaml
+++ b/topology/Purdue University/Purdue CMS/Purdue-Brown.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: requested in https://ticket.grid.iu.edu/35669
 GroupID: 482
+Production: true
 Resources:
   Purdue-Brown:
     Active: true

--- a/topology/Purdue University/Purdue CMS/Purdue-Carter.yaml
+++ b/topology/Purdue University/Purdue CMS/Purdue-Carter.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: The Purdue Carter Cluster --http://www.rcac.purdue.edu/userinfo/resources/carter/
 GroupID: 354
+Production: true
 Resources:
   Purdue-Carter:
     Active: true

--- a/topology/Purdue University/Purdue CMS/Purdue-Conte.yaml
+++ b/topology/Purdue University/Purdue CMS/Purdue-Conte.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: The Purdue Conte cluster -- http://www.rcac.purdue.edu/userinfo/resources/conte/
 GroupID: 389
+Production: true
 Resources:
   Purdue-Conte:
     Active: true

--- a/topology/Purdue University/Purdue CMS/Purdue-Hadoop.yaml
+++ b/topology/Purdue University/Purdue CMS/Purdue-Hadoop.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: CMS Hadoop cluster at Purdue University, West Lafayette, IN.
 GroupID: 393
+Production: true
 Resources:
   Purdue-Hadoop-CE:
     Active: true

--- a/topology/Purdue University/Purdue CMS/Purdue-Halstead.yaml
+++ b/topology/Purdue University/Purdue CMS/Purdue-Halstead.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Purdue Halstead
 GroupID: 461
+Production: true
 Resources:
   Purdue-Halstead:
     Active: true

--- a/topology/Purdue University/Purdue CMS/Purdue-Hammer.yaml
+++ b/topology/Purdue University/Purdue CMS/Purdue-Hammer.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: A high throughput community clusters at Purdue
 GroupID: 412
+Production: true
 Resources:
   Purdue-Hammer-CE:
     Active: true

--- a/topology/Purdue University/Purdue CMS/Purdue-Hansen.yaml
+++ b/topology/Purdue University/Purdue CMS/Purdue-Hansen.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: Purdue Hansen Cluster
 GroupID: 324
+Production: true
 Resources:
   Purdue-Hansen:
     Active: true

--- a/topology/Purdue University/Purdue CMS/Purdue-ITB.yaml
+++ b/topology/Purdue University/Purdue CMS/Purdue-ITB.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Integration Test Bed Resource
 GroupDescription: (No resource group description)
 GroupID: 93
+Production: false
 Resources:
   Purdue-ITB:
     Active: true

--- a/topology/Purdue University/Purdue CMS/Purdue-RCAC.yaml
+++ b/topology/Purdue University/Purdue CMS/Purdue-RCAC.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: Enabled for April. Disabling https://ticket.grid.iu.edu/20663
 GroupID: 96
+Production: true
 Resources:
   Purdue-CMS-SE:
     Active: true

--- a/topology/Purdue University/Purdue CMS/Purdue-Rice.yaml
+++ b/topology/Purdue University/Purdue CMS/Purdue-Rice.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: https://www.rcac.purdue.edu/compute/rice/
 GroupID: 446
+Production: true
 Resources:
   Purdue-Rice:
     Active: true

--- a/topology/Purdue University/Purdue CMS/Purdue-Rossmann.yaml
+++ b/topology/Purdue University/Purdue CMS/Purdue-Rossmann.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Purdue Rossmann Cluster
 GroupID: 275
+Production: true
 Resources:
   Purdue-Rossmann:
     Active: false

--- a/topology/Purdue University/Purdue CMS/Purdue-Steele.yaml
+++ b/topology/Purdue University/Purdue CMS/Purdue-Steele.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: deprecated 3/8/13
 GroupID: 94
+Production: true
 Resources:
   Purdue-Steele:
     Active: false

--- a/topology/Purdue University/Purdue NWICG/Purdue-Caesar.yaml
+++ b/topology/Purdue University/Purdue NWICG/Purdue-Caesar.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: 7/26 disabling empty resource group
 GroupID: 92
+Production: true
 Resources:
   Purdue-Caesar:
     Active: false

--- a/topology/Purdue University/Purdue Physics/Purdue-Physics.yaml
+++ b/topology/Purdue University/Purdue Physics/Purdue-Physics.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: 7/26 disabling empty resource group
 GroupID: 95
+Production: true
 Resources:
   Purdue-LSST:
     Active: true

--- a/topology/Rice University/OSG-Rice/Rice.yaml
+++ b/topology/Rice University/OSG-Rice/Rice.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 216
+Production: true
 Resources:
   OSG-Rice:
     Active: true

--- a/topology/Rochester Institute of Technology/NYSGRID RIT/NYSGRID_RIT.yaml
+++ b/topology/Rochester Institute of Technology/NYSGRID RIT/NYSGRID_RIT.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: Ticket 8128
 GroupID: 198
+Production: true
 Resources:
   NYSGRID_RIT:
     Active: false

--- a/topology/Rutgers University/rutgers-cms/rutgers-cms.yaml
+++ b/topology/Rutgers University/rutgers-cms/rutgers-cms.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Tier-3 computing center
 GroupID: 236
+Production: true
 Resources:
   rutgers-cms:
     Active: true

--- a/topology/SUNY Albany/NYSGRID_ALBANY/NYSGRID-ALBANY-ATHENA.yaml
+++ b/topology/SUNY Albany/NYSGRID_ALBANY/NYSGRID-ALBANY-ATHENA.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: disabled  03-01-2011
 GroupID: 224
+Production: true
 Resources:
   NYSGRID-ALBANY-ATHENA:
     Active: false

--- a/topology/SUNY Geneseo/GRASE-GENESEO/GRASE-GENESEO-ROCKS.yaml
+++ b/topology/SUNY Geneseo/GRASE-GENESEO/GRASE-GENESEO-ROCKS.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: GRASE-GENESEO-ROCKS
 GroupID: 31
+Production: true
 Resources:
   GRASE-GENESEO-ROCKS:
     Active: false

--- a/topology/Southern Methodist University/SMU Physics/SMU_PHY.yaml
+++ b/topology/Southern Methodist University/SMU Physics/SMU_PHY.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Integration Test Bed Resource
 GroupDescription: Disabling this Resource as it is decommissioned.
 GroupID: 98
+Production: false
 Resources:
   SMU_PHY:
     Active: true

--- a/topology/Southern Methodist University/SMU_HPC/SMU_HPC.yaml
+++ b/topology/Southern Methodist University/SMU_HPC/SMU_HPC.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Southern Methodist University HPC
 GroupID: 242
+Production: true
 Resources:
   SMU_ManeFrame_CE:
     Active: true

--- a/topology/Southern Methodist University/SMU_HPC/SMU_HPC_ITB.yaml
+++ b/topology/Southern Methodist University/SMU_HPC/SMU_HPC_ITB.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Integration Test Bed Resource
 GroupDescription: Resources in ITB group
 GroupID: 416
+Production: false
 Resources:
   SMU_HPC:
     Active: true

--- a/topology/Stanford University/SLAC/WT2.yaml
+++ b/topology/Stanford University/SLAC/WT2.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 91
+Production: true
 Resources:
   SLAC:
     Active: true

--- a/topology/Stanford University/STANFORD_HOSTED/STANFORD_HOSTED_BOSCO_CE.yaml
+++ b/topology/Stanford University/STANFORD_HOSTED/STANFORD_HOSTED_BOSCO_CE.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: hosted nodes
 GroupID: 460
+Production: true
 Resources:
   HOSTED_STANFORD:
     Active: true

--- a/topology/Stony Brook University/SBU Atlas Tier3/SBU_Tier3.yaml
+++ b/topology/Stony Brook University/SBU Atlas Tier3/SBU_Tier3.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Stony Brook Atlas Tier3
 GroupID: 285
+Production: true
 Resources:
   SBU_ATLAS_GRIDFTP1:
     Active: true

--- a/topology/Susquehanna University/SUSQU/SUSQU-ATLAS-T3.yaml
+++ b/topology/Susquehanna University/SUSQU/SUSQU-ATLAS-T3.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: SUSQU-ATLAS-T3
 GroupID: 302
+Production: true
 Resources:
   SUSQU-ATLAS-T3:
     Active: true

--- a/topology/Syracuse University/SU ITS/SU-ITS.yaml
+++ b/topology/Syracuse University/SU ITS/SU-ITS.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Syracuse University Information Technology Services Research Clusters
 GroupID: 404
+Production: true
 Resources:
   SU-ITS-CE2:
     Active: true

--- a/topology/Syracuse University/SUGWG/SU-SUGAR.yaml
+++ b/topology/Syracuse University/SUGWG/SU-SUGAR.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: SUGWG SUGAR Cluster
 GroupID: 435
+Production: true
 Resources:
   SU_SUGAR_Submit_1:
     Active: true

--- a/topology/Texas A&M University/TAMU Academy/TAMU_BRAZOS.yaml
+++ b/topology/Texas A&M University/TAMU Academy/TAMU_BRAZOS.yaml
@@ -1,8 +1,8 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: The 300+ node Brazos cluster, a shared stakeholder resource for
   Texas A&M and OSG researchers.
 GroupID: 273
+Production: true
 Resources:
   TAMU_BRAZOS:
     Active: false

--- a/topology/Texas A&M University/TAMU Mathematics/TAMU_Calclab.yaml
+++ b/topology/Texas A&M University/TAMU Mathematics/TAMU_Calclab.yaml
@@ -1,8 +1,8 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: This is the 200+ node cluster consisting of desktop lab computers
   running Linux.  Generally available after hours and on weekends.
 GroupID: 298
+Production: true
 Resources:
   TAMU_Calclab:
     Active: true

--- a/topology/Texas Tech University/TIGRE TTU/TTU-ANTAEUS.yaml
+++ b/topology/Texas Tech University/TIGRE TTU/TTU-ANTAEUS.yaml
@@ -1,10 +1,10 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Primary OSG compute element resource at TTU.  Consists of a mix
   of dual-core dual-cpu and quad-core dual-cpu Xeons, 240 cores total, operating at
   2.5 to 3.0 GHz and associated with a cluster-wide Lustre file system.  The file
   system is also accessible through the associated TTU-SIGMORGH storage element.
 GroupID: 105
+Production: true
 Resources:
   TTU-ANTAEUS:
     Active: true

--- a/topology/Texas Tech University/TIGRE TTU/TTU-TESTWULF.yaml
+++ b/topology/Texas Tech University/TIGRE TTU/TTU-TESTWULF.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Integration Test Bed Resource
 GroupDescription: OSG Integration Test Bed resource at TTU.
 GroupID: 107
+Production: false
 Resources:
   TTU-TESTWULF:
     Active: true

--- a/topology/Texas Tech University/TIGRE TTU/TTU-TINGE.yaml
+++ b/topology/Texas Tech University/TIGRE TTU/TTU-TINGE.yaml
@@ -1,8 +1,8 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: New rpm-based OSG 3 Compute Element to replace the old pacman-based
   CE TTU-ANTAEUS.
 GroupID: 365
+Production: true
 Resources:
   TTU-TINGE:
     Active: true

--- a/topology/The Ohio State University/OSU-CMS/osu-cms.yaml
+++ b/topology/The Ohio State University/OSU-CMS/osu-cms.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: CMS Tier3 at The Ohio State University
 GroupID: 237
+Production: true
 Resources:
   T3_US_OSU:
     Active: false

--- a/topology/Thomas Jefferson National Accelerator Facility/JLAB/Thomas Jefferson National Accelerator Facility GLUEX Glidein.yaml
+++ b/topology/Thomas Jefferson National Accelerator Facility/JLAB/Thomas Jefferson National Accelerator Facility GLUEX Glidein.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Glidein submit nodes for GLUEX
 GroupID: 465
+Production: true
 Resources:
   scosg16:
     Active: true

--- a/topology/Tufts University/Tufts_ATLAS_Tier3/Tufts_ATLAS_Tier3.yaml
+++ b/topology/Tufts University/Tufts_ATLAS_Tier3/Tufts_ATLAS_Tier3.yaml
@@ -1,9 +1,9 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: |-
   Tufts University Linux Cluster
   Red Hat EL5.4
 GroupID: 267
+Production: true
 Resources:
   Tufts_ATLAS_Tier3:
     Active: true

--- a/topology/UC Irvine/UCIT3/University of California Irvine.yaml
+++ b/topology/UC Irvine/UCIT3/University of California Irvine.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: UCI ATLAS Tier-3
 GroupID: 287
+Production: true
 Resources:
   UCI_ATLAS_GRIDFTP:
     Active: true

--- a/topology/UC Santa Barbara/ucsb-hep/ucsb-cms.yaml
+++ b/topology/UC Santa Barbara/ucsb-hep/ucsb-cms.yaml
@@ -1,10 +1,10 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: |-
   CMS Tier 3.
   7/26 disabling empty resource group
   4/28/15 re-enabling, new resources added
 GroupID: 300
+Production: true
 Resources:
   UCSB_CE:
     Active: true

--- a/topology/UCSB/UCSB_MRL/GLOW_MINIOSG_UCSB.yaml
+++ b/topology/UCSB/UCSB_MRL/GLOW_MINIOSG_UCSB.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 201
+Production: true
 Resources:
   GLOW_MINIOSG_UCSB:
     Active: false

--- a/topology/UMSNH/UMSNH/umsnh-ce.yaml
+++ b/topology/UMSNH/UMSNH/umsnh-ce.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: CE at UMSNH Morelia Michoacan
 GroupID: 372
+Production: true
 Resources:
   umsnh_ce_se:
     Active: true

--- a/topology/Universidad Autonoma de Manizales/ASGC/ASGC_OSG.yaml
+++ b/topology/Universidad Autonoma de Manizales/ASGC/ASGC_OSG.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: 7/26 disabling empty resource group
 GroupID: 2
+Production: true
 Resources:
   ASGC_OSG:
     Active: false

--- a/topology/Universidad Autonoma de Manizales/GC_UAM/GCVO_UAM.yaml
+++ b/topology/Universidad Autonoma de Manizales/GC_UAM/GCVO_UAM.yaml
@@ -1,8 +1,8 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Support for GCVO and GCEDU VO Universidad Autonoma de Manizales,
   GridColombia
 GroupID: 323
+Production: true
 Resources:
   GCVO_UAM_CE:
     Active: false

--- a/topology/Universidad Autonoma del Caribe/GC_UAC/GCVO_UAC.yaml
+++ b/topology/Universidad Autonoma del Caribe/GC_UAC/GCVO_UAC.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Support for GCVO and GCEDU VO Universidad Autonoma del Caribe, GridColombia
 GroupID: 326
+Production: true
 Resources:
   GCVO_UAC_CE:
     Active: false

--- a/topology/Universidad Catolica de Colombia/GC_UC/GCVO_UC.yaml
+++ b/topology/Universidad Catolica de Colombia/GC_UC/GCVO_UC.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Support for GCVO and GCEDU VO Universidad Catolica, GridColombia
 GroupID: 315
+Production: true
 Resources:
   GCVO_UC_CE:
     Active: false

--- a/topology/Universidad Industrial de Santander/GC_UIS/GCVO_UIS.yaml
+++ b/topology/Universidad Industrial de Santander/GC_UIS/GCVO_UIS.yaml
@@ -1,8 +1,8 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Support for GCVO and GCEDU VO Universidad Industrial de Santander,
   GridColombia
 GroupID: 328
+Production: true
 Resources:
   GCVO_UIS_CE:
     Active: false

--- a/topology/Universidad Pontificia Bolivariana/GC_UPB/GCVO_UPB.yaml
+++ b/topology/Universidad Pontificia Bolivariana/GC_UPB/GCVO_UPB.yaml
@@ -1,8 +1,8 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Support for GCVO and GCEDU VO Universidad Pontificia Bolivariana,
   GridColombia
 GroupID: 319
+Production: true
 Resources:
   GCVO_UPB_CE:
     Active: false

--- a/topology/Universidad Tecnologica de Bolivar/GC_UTB/GCVO_UTB.yaml
+++ b/topology/Universidad Tecnologica de Bolivar/GC_UTB/GCVO_UTB.yaml
@@ -1,8 +1,8 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Support for GCVO and GCEDU VO Universidad Tecnologica de Bolivar,
   GridColombia
 GroupID: 317
+Production: true
 Resources:
   GCVO_UTB_CE:
     Active: false

--- a/topology/Universidad de Caldas/GC_UCALDAS/GCVO_UCALDAS.yaml
+++ b/topology/Universidad de Caldas/GC_UCALDAS/GCVO_UCALDAS.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Support for GCVO and GCEDU VO Universidad de Caldas, GridColombia
 GroupID: 316
+Production: true
 Resources:
   GCVO_UCALDAS_CE:
     Active: false

--- a/topology/Universidad de Medellin/GC_UDEM/GCVO_UDEM.yaml
+++ b/topology/Universidad de Medellin/GC_UDEM/GCVO_UDEM.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Support for GCVO and GCEDU VO Universidad de Medellin, GridColombia
 GroupID: 321
+Production: true
 Resources:
   GCVO_UDEM_CE:
     Active: false

--- a/topology/Universidad de los Andes/GC_UNIANDES/GCVO_Uniandes.yaml
+++ b/topology/Universidad de los Andes/GC_UNIANDES/GCVO_Uniandes.yaml
@@ -1,8 +1,8 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Support for GCVO, GCEDU, CMS, Biomed and Auger VO Universidad de
   los Andes, GridColombia
 GroupID: 318
+Production: true
 Resources:
   GCVO_UNIANDES_CE:
     Active: false

--- a/topology/Universidad del Valle/GC_UV/GCVO_UV.yaml
+++ b/topology/Universidad del Valle/GC_UV/GCVO_UV.yaml
@@ -1,8 +1,8 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Support for GCVO and GCEDU VO Universidad Tecnologica de Bolivar,
   GridColombia
 GroupID: 327
+Production: true
 Resources:
   GCVO_UV_CE:
     Active: false

--- a/topology/Universidade Estadual Paulista/GridUNESP/GridUNESP.yaml
+++ b/topology/Universidade Estadual Paulista/GridUNESP/GridUNESP.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: The central site of GridUNESP infrastructure.
 GroupID: 259
+Production: true
 Resources:
   GridUNESP:
     Active: true

--- a/topology/Universidade Estadual Paulista/GridUNESP/GridUNESP_SPO.yaml
+++ b/topology/Universidade Estadual Paulista/GridUNESP/GridUNESP_SPO.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Integration Test Bed Resource
 GroupDescription: A secundary cluster at GridUNESP main site.
 GroupID: 272
+Production: false
 Resources:
   GridUNESP_SPO:
     Active: true

--- a/topology/Universidade Estadual Paulista/SPRACE/SPRACE.yaml
+++ b/topology/Universidade Estadual Paulista/SPRACE/SPRACE.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 99
+Production: true
 Resources:
   BR-Sprace BW:
     Active: true

--- a/topology/Universidade de Sao Paulo/SAMPA/perfSONAR Services.yaml
+++ b/topology/Universidade de Sao Paulo/SAMPA/perfSONAR Services.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: PerfSONAR Services of SAMPA Group
 GroupID: 414
+Production: true
 Resources:
   SAMPA PerfSONAR Bandwidth:
     Active: false

--- a/topology/Universidade de São Paulo - Laboratório de Computação Científica Avançada/USP - LCCA/USP-LCCA.yaml
+++ b/topology/Universidade de São Paulo - Laboratório de Computação Científica Avançada/USP - LCCA/USP-LCCA.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Integration Test Bed Resource
 GroupDescription: USP - LCCA tier 3 datacenter
 GroupID: 295
+Production: false
 Resources:
   USP-LCCA-CE-test:
     Active: true

--- a/topology/Universidade do Estado do Rio de Janeiro/T2_BR_UERJ/UERJ.yaml
+++ b/topology/Universidade do Estado do Rio de Janeiro/T2_BR_UERJ/UERJ.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: UERJ Resource Group.
 GroupID: 42
+Production: true
 Resources:
   UERJ_CE:
     Active: true

--- a/topology/University of Alabama at Birmingham/UAB Research Computing/Advanced Technology Lab.yaml
+++ b/topology/University of Alabama at Birmingham/UAB Research Computing/Advanced Technology Lab.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Lab resources for testing
 GroupID: 331
+Production: true
 Resources:
   ATLab testing node:
     Active: true

--- a/topology/University of Arizona/Arizona Tier 3/Arizona.yaml
+++ b/topology/University of Arizona/Arizona Tier 3/Arizona.yaml
@@ -1,9 +1,9 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: |-
   University of Arizona  Tier 3
   US ATLAS Event service
 GroupID: 428
+Production: true
 Resources:
   Arizona Squid:
     Active: true

--- a/topology/University of Arkansas/UARK ACE/UARK_ACE.yaml
+++ b/topology/University of Arkansas/UARK ACE/UARK_ACE.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 108
+Production: true
 Resources:
   UARK_ACE:
     Active: false

--- a/topology/University of Bern/UNIBE-LHEP/UNIBE-LHEP.yaml
+++ b/topology/University of Bern/UNIBE-LHEP/UNIBE-LHEP.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: MicroBooNE resources in Bern, CH
 GroupID: 436
+Production: true
 Resources:
   Bern ce01:
     Active: false

--- a/topology/University of Birmingham/STAR Birmingham/STAR-Bham.yaml
+++ b/topology/University of Birmingham/STAR Birmingham/STAR-Bham.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: 7/26 disabling empty resource group
 GroupID: 101
+Production: true
 Resources:
   STAR-Bham:
     Active: false

--- a/topology/University of Buffalo/GRASE Buffalo/GRASE-ALBANY-NYS.yaml
+++ b/topology/University of Buffalo/GRASE Buffalo/GRASE-ALBANY-NYS.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 29
+Production: true
 Resources:
   GRASE-ALBANY-NYS:
     Active: false

--- a/topology/University of Buffalo/GRASE Buffalo/GRASE-BINGHAMTON.yaml
+++ b/topology/University of Buffalo/GRASE Buffalo/GRASE-BINGHAMTON.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 30
+Production: true
 Resources:
   GRASE-BINGHAMTON:
     Active: false

--- a/topology/University of Buffalo/GRASE Buffalo/GRASE-CSE-MAGIC.yaml
+++ b/topology/University of Buffalo/GRASE Buffalo/GRASE-CSE-MAGIC.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: https://ticket.opensciencegrid.org/24224
 GroupID: 222
+Production: true
 Resources:
   GRASE-CSE-MAGIC:
     Active: false

--- a/topology/University of Buffalo/GRASE Buffalo/GRASE-HWI-IDUN.yaml
+++ b/topology/University of Buffalo/GRASE Buffalo/GRASE-HWI-IDUN.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 32
+Production: true
 Resources:
   GRASE-HWI-IDUN:
     Active: false

--- a/topology/University of Buffalo/GRASE Buffalo/GRASE-MARIST-nysgrid11.yaml
+++ b/topology/University of Buffalo/GRASE Buffalo/GRASE-MARIST-nysgrid11.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 33
+Production: true
 Resources:
   GRASE-MARIST-nysgrid11:
     Active: false

--- a/topology/University of Buffalo/GRASE Buffalo/GRASE-NYU-BENCH.yaml
+++ b/topology/University of Buffalo/GRASE Buffalo/GRASE-NYU-BENCH.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 35
+Production: true
 Resources:
   GRASE-NYU-BENCH:
     Active: false

--- a/topology/University of Buffalo/GRASE Buffalo/GRASE-RIT-GCLUSTER.yaml
+++ b/topology/University of Buffalo/GRASE Buffalo/GRASE-RIT-GCLUSTER.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 36
+Production: true
 Resources:
   GRASE-RIT-GCLUSTER:
     Active: false

--- a/topology/University of Buffalo/GRASE Buffalo/GRASE-SU-CLUSTER04.yaml
+++ b/topology/University of Buffalo/GRASE Buffalo/GRASE-SU-CLUSTER04.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 37
+Production: true
 Resources:
   GRASE-SU-CLUSTER04:
     Active: false

--- a/topology/University of Buffalo/GRASE Buffalo/GRASE-UR-NEBULA.yaml
+++ b/topology/University of Buffalo/GRASE Buffalo/GRASE-UR-NEBULA.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 38
+Production: true
 Resources:
   GRASE-UR-NEBULA:
     Active: false

--- a/topology/University of Buffalo/NYSGRID Buffalo/NYSGRID-CCR-U2.yaml
+++ b/topology/University of Buffalo/NYSGRID Buffalo/NYSGRID-CCR-U2.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 80
+Production: true
 Resources:
   NYSGRID-CCR-U2:
     Active: true

--- a/topology/University of California Davis/UC Davis CMS T3/Davis_CMS.yaml
+++ b/topology/University of California Davis/UC Davis CMS T3/Davis_CMS.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: Rob confirmed to Arvind this resource is de-activated. 2008-06-06
 GroupID: 15
+Production: true
 Resources:
   Davis_CMS:
     Active: false

--- a/topology/University of California Davis/UC Davis CMS T3/UCD.yaml
+++ b/topology/University of California Davis/UC Davis CMS T3/UCD.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: UC Davis T3 CMS SE and CE nodes
 GroupID: 239
+Production: true
 Resources:
   UCD:
     Active: true

--- a/topology/University of California Los Angeles/UCLA CMS Tier3/UCLA_Saxon_Tier3.yaml
+++ b/topology/University of California Los Angeles/UCLA CMS Tier3/UCLA_Saxon_Tier3.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: 7/26 disabling empty resource group
 GroupID: 109
+Production: true
 Resources:
   UCLA_Saxon_Tier3:
     Active: false

--- a/topology/University of California Riverside/UCR HEP/UCR-HEP.yaml
+++ b/topology/University of California Riverside/UCR HEP/UCR-HEP.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 110
+Production: true
 Resources:
   UCR-HEP:
     Active: true

--- a/topology/University of California San Diego/UCSD CMS Tier2/UCSD CMS Glideins.yaml
+++ b/topology/University of California San Diego/UCSD CMS Tier2/UCSD CMS Glideins.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: This group holds the glidein-related resources for CMS.
 GroupID: 359
+Production: true
 Resources:
   UAF 1:
     Active: true

--- a/topology/University of California San Diego/UCSD CMS Tier2/UCSDT2-ITB.yaml
+++ b/topology/University of California San Diego/UCSD CMS Tier2/UCSDT2-ITB.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Integration Test Bed Resource
 GroupDescription: ITB Resources for UCSDT2
 GroupID: 262
+Production: false
 Resources:
   UCSDT2-ITB1:
     Active: true

--- a/topology/University of California San Diego/UCSD CMS Tier2/UCSDT2.yaml
+++ b/topology/University of California San Diego/UCSD CMS Tier2/UCSDT2.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 113
+Production: true
 Resources:
   UCSDCMST2-2-squid:
     Active: true

--- a/topology/University of California San Diego/UCSD OSG/CrossOSG Nodes.yaml
+++ b/topology/University of California San Diego/UCSD OSG/CrossOSG Nodes.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: This group contains the Cross OSG nodes.
 GroupID: 343
+Production: true
 Resources:
   CrossOSG-CE-UCSD:
     Active: true

--- a/topology/University of California San Diego/UCSD OSG/Submitters.yaml
+++ b/topology/University of California San Diego/UCSD OSG/Submitters.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: This group is for the Submitter nodes at UCSD.
 GroupID: 337
+Production: true
 Resources:
   Physics Computing Facility UCSD Submit Host:
     Active: true

--- a/topology/University of California San Diego/UCSD OSG/UCSD glidein.yaml
+++ b/topology/University of California San Diego/UCSD OSG/UCSD glidein.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: UCSD glidein factory
 GroupID: 329
+Production: true
 Resources:
   UCSD glidein:
     Active: true

--- a/topology/University of California Santa Cruz/UC Santa Cruz ATLAS Tier-3/UCSCT3.yaml
+++ b/topology/University of California Santa Cruz/UC Santa Cruz ATLAS Tier-3/UCSCT3.yaml
@@ -1,10 +1,10 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: |-
   Resource for UC Santa Cruz ATLAS Tier-3.
 
   7/26 disabling empty resource group
 GroupID: 291
+Production: true
 Resources:
   UCSC_ATLAS_GRIDFTP2:
     Active: true

--- a/topology/University of Chicago/MWT2 ATLAS UC/MWT2.yaml
+++ b/topology/University of Chicago/MWT2 ATLAS UC/MWT2.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Placeholder for MWT2
 GroupID: 310
+Production: true
 Resources:
   MWT2:
     Active: true

--- a/topology/University of Chicago/MWT2 ATLAS UC/MWT2_UC.yaml
+++ b/topology/University of Chicago/MWT2 ATLAS UC/MWT2_UC.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: 7/26 disabling empty resource group
 GroupID: 69
+Production: true
 Resources:
   MWT2_UC:
     Active: false

--- a/topology/University of Chicago/MWT2 ATLAS UC/UC_ATLAS_MWT2.yaml
+++ b/topology/University of Chicago/MWT2 ATLAS UC/UC_ATLAS_MWT2.yaml
@@ -1,10 +1,10 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: |-
   disabling by request
 
   https://ticket.grid.iu.edu/30682
 GroupID: 116
+Production: true
 Resources:
   UC_ATLAS_MWT2:
     Active: false

--- a/topology/University of Chicago/MWT2 ATLAS UC/UC_ITB_SE_BESTMAN.yaml
+++ b/topology/University of Chicago/MWT2 ATLAS UC/UC_ITB_SE_BESTMAN.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Integration Test Bed Resource
 GroupDescription: (No resource group description)
 GroupID: 218
+Production: false
 Resources:
   UC_ITB_SE_BESTMAN:
     Active: true

--- a/topology/University of Chicago/MWT2 ATLAS UC/UC_ITB_SE_DCACHE.yaml
+++ b/topology/University of Chicago/MWT2 ATLAS UC/UC_ITB_SE_DCACHE.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Integration Test Bed Resource
 GroupDescription: (No resource group description)
 GroupID: 219
+Production: false
 Resources:
   UC_ITB_SE_DCACHE:
     Active: true

--- a/topology/University of Chicago/MWT2 ATLAS UC/UC_T2DEV_ITB.yaml
+++ b/topology/University of Chicago/MWT2 ATLAS UC/UC_T2DEV_ITB.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Integration Test Bed Resource
 GroupDescription: (No resource group description)
 GroupID: 118
+Production: false
 Resources:
   UC_T2DEV_ITB:
     Active: false

--- a/topology/University of Chicago/OSGSC_UC/GC1.yaml
+++ b/topology/University of Chicago/OSGSC_UC/GC1.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Integration Test Bed Resource
 GroupDescription: ITB cluster for Tier 3 and small sites prototyping and testing
 GroupID: 294
+Production: false
 Resources:
   GC1_CE:
     Active: true

--- a/topology/University of Chicago/UC Teraport/UC_Teraport.yaml
+++ b/topology/University of Chicago/UC Teraport/UC_Teraport.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: 7/26 disabling empty resource group
 GroupID: 119
+Production: true
 Resources:
   UC_Teraport:
     Active: false

--- a/topology/University of Chicago/UChicago/OSG_UChicago.yaml
+++ b/topology/University of Chicago/UChicago/OSG_UChicago.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: OSG resources at UChicago
 GroupID: 374
+Production: true
 Resources:
   OSG UChicago VO Frontend:
     Active: true

--- a/topology/University of Chicago/UChicago/UC3.yaml
+++ b/topology/University of Chicago/UChicago/UC3.yaml
@@ -1,9 +1,9 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: |-
   University of Chicago Computing Cooperative
   https://uc3.uchicago.edu/
 GroupID: 373
+Production: true
 Resources:
   UC3 UChicago VO Frontend:
     Active: true

--- a/topology/University of Chicago/UChicago/UC_ITB.yaml
+++ b/topology/University of Chicago/UChicago/UC_ITB.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Integration Test Bed Resource
 GroupDescription: UChicago ITB
 GroupID: 117
+Production: false
 Resources:
   UC_ITB_CONDOR:
     Active: true

--- a/topology/University of Colorado/UColorado_HEP/UColorado_HEP.yaml
+++ b/topology/University of Colorado/UColorado_HEP/UColorado_HEP.yaml
@@ -1,8 +1,8 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Renamed to UColorado_HEP by agopu after Doug agreed it was ok. 2008-07-18.
   Assigned appropriate site as well.
 GroupID: 177
+Production: true
 Resources:
   UColorado_HEP:
     Active: true

--- a/topology/University of Colorado/UColorado_HEP/UColorado_HEP_ITB.yaml
+++ b/topology/University of Colorado/UColorado_HEP/UColorado_HEP_ITB.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Integration Test Bed Resource
 GroupDescription: This resource group is for ITB testing at University of Colorado
 GroupID: 253
+Production: false
 Resources:
   UColorado_ITB:
     Active: true

--- a/topology/University of Colorado/UColorado_HEP/UColorado_SE.yaml
+++ b/topology/University of Colorado/UColorado_HEP/UColorado_SE.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 204
+Production: true
 Resources:
   UColorado_SE_Hadoop:
     Active: true

--- a/topology/University of Connecticut Health Center/UCHC_CBG/UCHC_CBG.yaml
+++ b/topology/University of Connecticut Health Center/UCHC_CBG/UCHC_CBG.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: University of Connecticut Health Center - CE
 GroupID: 217
+Production: true
 Resources:
   UCHC_CBG:
     Active: true

--- a/topology/University of Connecticut/UConn-OSG/UConn-OSG.yaml
+++ b/topology/University of Connecticut/UConn-OSG/UConn-OSG.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: UConn Physics Cluster Computing Group
 GroupID: 254
+Production: true
 Resources:
   Gluex_VOMS:
     Active: true

--- a/topology/University of Florida/UF CMS Tier2/UFlorida-IHEPA.yaml
+++ b/topology/University of Florida/UF CMS Tier2/UFlorida-IHEPA.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: 7/26 disabling empty resource group
 GroupID: 121
+Production: true
 Resources:
   UFlorida-IHEPA:
     Active: false

--- a/topology/University of Florida/UF CMS Tier2/UFlorida-PG.yaml
+++ b/topology/University of Florida/UF CMS Tier2/UFlorida-PG.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 122
+Production: true
 Resources:
   UFlorida-PG:
     Active: true

--- a/topology/University of Florida/UF HPC/UFlorida-HPC.yaml
+++ b/topology/University of Florida/UF HPC/UFlorida-HPC.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 120
+Production: true
 Resources:
   T2_Florida_BW:
     Active: true

--- a/topology/University of Florida/UF HPC/UFlorida-SSERCA.yaml
+++ b/topology/University of Florida/UF HPC/UFlorida-SSERCA.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: SSERCA resources at UF HPC.
 GroupID: 348
+Production: true
 Resources:
   UFlorida-SSERCA:
     Active: false

--- a/topology/University of Georgia/UGA Research Computing Center/UGA_SGrid.yaml
+++ b/topology/University of Georgia/UGA Research Computing Center/UGA_SGrid.yaml
@@ -1,8 +1,8 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: This is the SGE submit host for UGA's SURAGrid queues on our local
   linux cluster.
 GroupID: 301
+Production: true
 Resources:
   UGA_Sgrid_CE:
     Active: true

--- a/topology/University of Illinois Chicago/UIC Physics/UIC_PHYSICS.yaml
+++ b/topology/University of Illinois Chicago/UIC Physics/UIC_PHYSICS.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: Disabled
 GroupID: 124
+Production: true
 Resources:
   UIC_PHYSICS:
     Active: false

--- a/topology/University of Illinois at Urbana Champaign/CIGI/CIGI-OSG.yaml
+++ b/topology/University of Illinois at Urbana Champaign/CIGI/CIGI-OSG.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Production resources of CIGI VO
 GroupID: 244
+Production: true
 Resources:
   CIGI-VOMS:
     Active: true

--- a/topology/University of Illinois at Urbana Champaign/Illinois High Energy Physics/IllinoisHEP.yaml
+++ b/topology/University of Illinois at Urbana Champaign/Illinois High Energy Physics/IllinoisHEP.yaml
@@ -1,8 +1,8 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Tier3gs installation which consists of a CE, SE and a cluster of
   worker nodes
 GroupID: 147
+Production: true
 Resources:
   IllinoisHEP:
     Active: true

--- a/topology/University of Illinois at Urbana Champaign/NCSA/CIGI-ITB.yaml
+++ b/topology/University of Illinois at Urbana Champaign/NCSA/CIGI-ITB.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Integration Test Bed Resource
 GroupDescription: (No resource group description)
 GroupID: 154
+Production: false
 Resources:
   CIGI-ITB:
     Active: true

--- a/topology/University of Illinois at Urbana Champaign/NCSA/NCSA_TUNGSTEN.yaml
+++ b/topology/University of Illinois at Urbana Champaign/NCSA/NCSA_TUNGSTEN.yaml
@@ -1,10 +1,10 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: |-
   Added manually by Arvind from old RegDB - please update if need be.
 
   7/26 disabling empty resource group
 GroupID: 148
+Production: true
 Resources:
   NCSA_TUNGSTEN:
     Active: false

--- a/topology/University of Iowa/GROW/GROW-ITB.yaml
+++ b/topology/University of Iowa/GROW/GROW-ITB.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Integration Test Bed Resource
 GroupDescription: Rob confirmed to Arvind this resource is de-activated. 2008-06-06
 GroupID: 39
+Production: false
 Resources:
   GROW-ITB:
     Active: false

--- a/topology/University of Iowa/GROW/GROW-PROD.yaml
+++ b/topology/University of Iowa/GROW/GROW-PROD.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: University of Iowa Tier 3 cluster
 GroupID: 40
+Production: true
 Resources:
   GROW-GRID:
     Active: true

--- a/topology/University of Iowa/GROW/UIOWA-OSG-PROD.yaml
+++ b/topology/University of Iowa/GROW/UIOWA-OSG-PROD.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: Rob confirmed to Arvind that this is a de-activated resource. 2008-06-06
 GroupID: 125
+Production: true
 Resources:
   UIOWA-OSG-PROD:
     Active: false

--- a/topology/University of Johannesburg/UJ Research Cluster/UJ-OSG.yaml
+++ b/topology/University of Johannesburg/UJ Research Cluster/UJ-OSG.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 215
+Production: true
 Resources:
   UJ-OSG:
     Active: true

--- a/topology/University of Maryland/UMD-CMS/umd-cms.yaml
+++ b/topology/University of Maryland/UMD-CMS/umd-cms.yaml
@@ -1,8 +1,8 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Tier-3 computing center.  Priority given to local users, but opportunistic
   use by CMS VO allowed.
 GroupID: 159
+Production: true
 Resources:
   UMD_GUMS:
     Active: true

--- a/topology/University of Maryland/UMD-IGS/UMD-IGS.yaml
+++ b/topology/University of Maryland/UMD-IGS/UMD-IGS.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: diagcomputing.org
 GroupID: 382
+Production: true
 Resources:
   UMD-IGS-CE:
     Active: true

--- a/topology/University of Michigan/AGLT2/AGLT2.yaml
+++ b/topology/University of Michigan/AGLT2/AGLT2.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 1
+Production: true
 Resources:
   AGLT2-squid:
     Active: true

--- a/topology/University of Michigan/AGLT2/AGLT2_TEST.yaml
+++ b/topology/University of Michigan/AGLT2/AGLT2_TEST.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Testing Resource Group
 GroupID: 351
+Production: true
 Resources:
   AGLT2_TEST_CE:
     Active: true

--- a/topology/University of Minnesota/School of Physics and Astronomy/UMN-CMS.yaml
+++ b/topology/University of Minnesota/School of Physics and Astronomy/UMN-CMS.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: University of Minnesota CMS Resources
 GroupID: 357
+Production: true
 Resources:
   UMN-CMS-CE:
     Active: true

--- a/topology/University of Mississippi/UMissHEP/UMissHEP.yaml
+++ b/topology/University of Mississippi/UMissHEP/UMissHEP.yaml
@@ -1,8 +1,8 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Added manually by Arvind from old RegDB - please update if need
   be.
 GroupID: 146
+Production: true
 Resources:
   UMissHEP:
     Active: true

--- a/topology/University of Nebraska/Nebraska-CMS/CMS Glidein Systems.yaml
+++ b/topology/University of Nebraska/Nebraska-CMS/CMS Glidein Systems.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: CMS glidein submitter nodes
 GroupID: 361
+Production: true
 Resources:
   Nebraska_glidein_hcc_crabserver:
     Active: true

--- a/topology/University of Nebraska/Nebraska-CMS/Nebraska-CMS-ITB.yaml
+++ b/topology/University of Nebraska/Nebraska-CMS/Nebraska-CMS-ITB.yaml
@@ -1,10 +1,10 @@
 Disable: true
-GridType: OSG Integration Test Bed Resource
 GroupDescription: |-
   ITB Group for Nebraska CMS.
 
   7/26 disabling empty resource group
 GroupID: 313
+Production: false
 Resources:
   red-gateway3-ITB:
     Active: false

--- a/topology/University of Nebraska/Nebraska-CMS/Nebraska.yaml
+++ b/topology/University of Nebraska/Nebraska-CMS/Nebraska.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Nebraska CMS T2 Resource.
 GroupID: 71
+Production: true
 Resources:
   GPN-HUSKER:
     Active: true

--- a/topology/University of Nebraska/Nebraska-Lincoln/HCC Submitters.yaml
+++ b/topology/University of Nebraska/Nebraska-Lincoln/HCC Submitters.yaml
@@ -1,8 +1,8 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: This is the group of HCC Submitters that submit jobs through the
   HCC GlideinWMS machine.
 GroupID: 332
+Production: true
 Resources:
   HCC GlideinWMS Frontend:
     Active: true

--- a/topology/University of Nebraska/Nebraska-Lincoln/Sandhills.yaml
+++ b/topology/University of Nebraska/Nebraska-Lincoln/Sandhills.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Sandhills Cluster
 GroupID: 230
+Production: true
 Resources:
   Sandhills:
     Active: true

--- a/topology/University of Nebraska/Nebraska-Omaha/Crane.yaml
+++ b/topology/University of Nebraska/Nebraska-Omaha/Crane.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Crane Cluster
 GroupID: 388
+Production: true
 Resources:
   Crane-CE1:
     Active: true

--- a/topology/University of Nebraska/Nebraska-Omaha/Firefly.yaml
+++ b/topology/University of Nebraska/Nebraska-Omaha/Firefly.yaml
@@ -1,8 +1,8 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: The Firefly cluster at the Holland Computer Center, located at the
   University of Nebraska at Omaha.
 GroupID: 231
+Production: true
 Resources:
   Firefly:
     Active: false

--- a/topology/University of Nebraska/Nebraska-Omaha/Tusker.yaml
+++ b/topology/University of Nebraska/Nebraska-Omaha/Tusker.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: The Tusker HPC Cluster.
 GroupID: 333
+Production: true
 Resources:
   Tusker:
     Active: false

--- a/topology/University of New Mexico/UNM HPC/UNM_HPC.yaml
+++ b/topology/University of New Mexico/UNM HPC/UNM_HPC.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 126
+Production: true
 Resources:
   UNM_HPC:
     Active: true

--- a/topology/University of North Carolina/RENCI/Engagement Infrastructure.yaml
+++ b/topology/University of North Carolina/RENCI/Engagement Infrastructure.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: A collection of Engagement infrastructure hosts
 GroupID: 322
+Production: true
 Resources:
   Engage-Submit3-Frontend:
     Active: false

--- a/topology/University of North Carolina/RENCI/Engagement_VOMS.yaml
+++ b/topology/University of North Carolina/RENCI/Engagement_VOMS.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: disabled 4/3
 GroupID: 185
+Production: true
 Resources:
   Engagement_VOMS:
     Active: false

--- a/topology/University of North Carolina/RENCI/RENCI-Engagement.yaml
+++ b/topology/University of North Carolina/RENCI/RENCI-Engagement.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: Engagement
 GroupID: 199
+Production: true
 Resources:
   RENCI-Engagement:
     Active: false

--- a/topology/University of North Carolina/RENCI/RENCI.yaml
+++ b/topology/University of North Carolina/RENCI/RENCI.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: Resource Group for all RENCI Clusters @ University of North Carolina
 GroupID: 330
+Production: true
 Resources:
   RENCI-Blueberry:
     Active: false

--- a/topology/University of Northern Iowa/GROW-UNI/UNI-OSGEDU.yaml
+++ b/topology/University of Northern Iowa/GROW-UNI/UNI-OSGEDU.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: 7/26 disabling empty resource group
 GroupID: 41
+Production: true
 Resources:
   UNI-OSGEDU:
     Active: false

--- a/topology/University of Notre Dame/NWICG_NDCMS/NWICG_Earth.yaml
+++ b/topology/University of Notre Dame/NWICG_NDCMS/NWICG_Earth.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: NWICG_Earth
 GroupID: 341
+Production: true
 Resources:
   NWICG_Earth:
     Active: true

--- a/topology/University of Notre Dame/NWICG_NDCMS/NWICG_NDCMS.yaml
+++ b/topology/University of Notre Dame/NWICG_NDCMS/NWICG_NDCMS.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: NWICG_NDCMS
 GroupID: 78
+Production: true
 Resources:
   NWICG_NDCCL:
     Active: false

--- a/topology/University of Notre Dame/NWICG_NDCMS/NWICG_NotreDame.yaml
+++ b/topology/University of Notre Dame/NWICG_NDCMS/NWICG_NotreDame.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: https://ticket.grid.iu.edu/goc/12807
 GroupID: 79
+Production: true
 Resources:
   NDCMS_Primeradiant01:
     Active: true

--- a/topology/University of Oklahoma/OU ATLAS/OU_OCHEP_SWT2.yaml
+++ b/topology/University of Oklahoma/OU ATLAS/OU_OCHEP_SWT2.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 88
+Production: true
 Resources:
   OU_OCHEP_SWT2:
     Active: true

--- a/topology/University of Oklahoma/OU ATLAS/OU_OSCER_ATLAS.yaml
+++ b/topology/University of Oklahoma/OU ATLAS/OU_OSCER_ATLAS.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 89
+Production: true
 Resources:
   OU_OSCER_ATLAS:
     Active: true

--- a/topology/University of Oklahoma/OU DOSAR/OU_OSCER_CONDOR.yaml
+++ b/topology/University of Oklahoma/OU DOSAR/OU_OSCER_CONDOR.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 90
+Production: true
 Resources:
   OU_OSCER_CONDOR:
     Active: false

--- a/topology/University of Oklahoma/OU HEP/OUHEP_ITB.yaml
+++ b/topology/University of Oklahoma/OU HEP/OUHEP_ITB.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: OU ITB Resource
 GroupID: 86
+Production: true
 Resources:
   OUHEP_ITB:
     Active: true

--- a/topology/University of Oklahoma/OU HEP/OUHEP_OSG.yaml
+++ b/topology/University of Oklahoma/OU HEP/OUHEP_OSG.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 87
+Production: true
 Resources:
   OUHEP_OSG:
     Active: true

--- a/topology/University of Pennsylvania/Penn ATLAS Tier 3/PennT3.yaml
+++ b/topology/University of Pennsylvania/Penn ATLAS Tier 3/PennT3.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: University of Pennsylvania ATLAS Tier 3 system
 GroupID: 350
+Production: true
 Resources:
   UPENN-T3-SE:
     Active: true

--- a/topology/University of Pittsburgh/UPittTier3/UPittTier3.yaml
+++ b/topology/University of Pittsburgh/UPittTier3/UPittTier3.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: ATLAS Tier3 at University of Pittsburgh
 GroupID: 342
+Production: true
 Resources:
   UPittTier3_DTN:
     Active: true

--- a/topology/University of Puerto Rico - Mayaguez/UPRM_HEP/uprm-cms.yaml
+++ b/topology/University of Puerto Rico - Mayaguez/UPRM_HEP/uprm-cms.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Tier3 Computing Center CMS HEP group
 GroupID: 293
+Production: true
 Resources:
   uprm-cms-ce:
     Active: true

--- a/topology/University of South Dakota/OSG_US_USD_LEGACY/OSG_US_USD_LEGACY.yaml
+++ b/topology/University of South Dakota/OSG_US_USD_LEGACY/OSG_US_USD_LEGACY.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Entry for the hosted CE submitting to USD's legacy cluster
 GroupID: 473
+Production: true
 Resources:
   OSG_US_USD_LEGACY:
     Active: false

--- a/topology/University of Texas Arlington/SWT2 ATLAS UTA/SWT2_CPB.yaml
+++ b/topology/University of Texas Arlington/SWT2 ATLAS UTA/SWT2_CPB.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 139
+Production: true
 Resources:
   SWT2_CPB:
     Active: true

--- a/topology/University of Texas Arlington/SWT2 ATLAS UTA/SWT2_CPB_TEST.yaml
+++ b/topology/University of Texas Arlington/SWT2 ATLAS UTA/SWT2_CPB_TEST.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Testing Resource Group
 GroupID: 411
+Production: true
 Resources:
   perfSONAR_SWT2_CPB_testbed_bandwidth:
     Active: true

--- a/topology/University of Texas Arlington/SWT2 ATLAS UTA/UTA_SWT2.yaml
+++ b/topology/University of Texas Arlington/SWT2 ATLAS UTA/UTA_SWT2.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 134
+Production: true
 Resources:
   UTA_SWT2:
     Active: true

--- a/topology/University of Texas Arlington/UTA ATLAS/UTA_DPCC.yaml
+++ b/topology/University of Texas Arlington/UTA ATLAS/UTA_DPCC.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: No resources left.
 GroupID: 133
+Production: true
 Resources:
   UTA_DPCC:
     Active: false

--- a/topology/University of Texas at Dallas/UTD-HEP/UTD-HEP.yaml
+++ b/topology/University of Texas at Dallas/UTD-HEP/UTD-HEP.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 206
+Production: true
 Resources:
   UTD-HEP:
     Active: true

--- a/topology/University of Utah/CHPC/CHPC Group.yaml
+++ b/topology/University of Utah/CHPC/CHPC Group.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Primary CE for the University of Utah
 GroupID: 440
+Production: true
 Resources:
   OSG_US_UUTAH_EMBER:
     Active: true

--- a/topology/University of Virginia/UVA CS/UVA-sunfire.yaml
+++ b/topology/University of Virginia/UVA CS/UVA-sunfire.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 135
+Production: true
 Resources:
   UVA-sunfire:
     Active: false

--- a/topology/University of Virginia/uva-cms/uva-cms-se.yaml
+++ b/topology/University of Virginia/uva-cms/uva-cms-se.yaml
@@ -1,10 +1,10 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: |-
   Storage Element on the University of Virginia - High Energy Physics Cluster
 
   7/26 disabling empty resource group
 GroupID: 258
+Production: true
 Resources:
   T3_US_UVA:
     Active: true

--- a/topology/University of Washington/UW-IT/Hyak.yaml
+++ b/topology/University of Washington/UW-IT/Hyak.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Hyak is the UW's campus wide shared HPC cluster.
 GroupID: 398
+Production: true
 Resources:
   Hyak_CE:
     Active: true

--- a/topology/University of Wisconsin Milwaukee/UW Milwaukee Physics/LIGO_UWM_NEMO.yaml
+++ b/topology/University of Wisconsin Milwaukee/UW Milwaukee Physics/LIGO_UWM_NEMO.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 158
+Production: true
 Resources:
   LIGO_UWM_NEMO:
     Active: true

--- a/topology/University of Wisconsin Milwaukee/UW Milwaukee Physics/UWMilwaukee.yaml
+++ b/topology/University of Wisconsin Milwaukee/UW Milwaukee Physics/UWMilwaukee.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 136
+Production: true
 Resources:
   UWMilwaukee:
     Active: false

--- a/topology/University of Wisconsin/CHTC/CHTC.yaml
+++ b/topology/University of Wisconsin/CHTC/CHTC.yaml
@@ -1,8 +1,8 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: The University of Wisconsin's Center for High Throughput Computing.  Note
   that CHTC and GLOW are closely related, and in many contexts, they are synonyms.
 GroupID: 314
+Production: true
 Resources:
   CHTC and BATLAB OSG Mirror:
     Active: true

--- a/topology/University of Wisconsin/Discovery/Discovery.yaml
+++ b/topology/University of Wisconsin/Discovery/Discovery.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: stuff
 GroupID: 383
+Production: true
 Resources:
   Discovery_PerfSonar_Bandwidth:
     Active: true

--- a/topology/University of Wisconsin/GLOW ATLAS/GLOW-ATLAS-SRM.yaml
+++ b/topology/University of Wisconsin/GLOW ATLAS/GLOW-ATLAS-SRM.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: 7/26 disabling empty resource group
 GroupID: 178
+Production: true
 Resources:
   GLOW-ATLAS-SRM:
     Active: false

--- a/topology/University of Wisconsin/GLOW ATLAS/GLOW-ATLAS.yaml
+++ b/topology/University of Wisconsin/GLOW ATLAS/GLOW-ATLAS.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Production Resource
 GroupDescription: 7/26 disabling empty resource group
 GroupID: 25
+Production: true
 Resources:
   GLOW-ATLAS:
     Active: false

--- a/topology/University of Wisconsin/GLOW ATLAS/WISC-ATLAS.yaml
+++ b/topology/University of Wisconsin/GLOW ATLAS/WISC-ATLAS.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: A replace name for GLOW-ATLAS.
 GroupID: 274
+Production: true
 Resources:
   WISC-ATLAS:
     Active: true

--- a/topology/University of Wisconsin/GLOW EDU/VDT-ITB.yaml
+++ b/topology/University of Wisconsin/GLOW EDU/VDT-ITB.yaml
@@ -1,7 +1,7 @@
 Disable: true
-GridType: OSG Integration Test Bed Resource
 GroupDescription: Resource group for Wisconsin's persistent ITB site.
 GroupID: 260
+Production: false
 Resources:
   VDT-ITB:
     Active: false

--- a/topology/University of Wisconsin/GLOW EDU/WISC-OSG-EDU.yaml
+++ b/topology/University of Wisconsin/GLOW EDU/WISC-OSG-EDU.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 138
+Production: true
 Resources:
   WISC-OSG-EDU:
     Active: true

--- a/topology/University of Wisconsin/GLOW/GLOW.yaml
+++ b/topology/University of Wisconsin/GLOW/GLOW.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 24
+Production: true
 Resources:
   GLOW:
     Active: true

--- a/topology/University of Wisconsin/WIPAC/IceCube.yaml
+++ b/topology/University of Wisconsin/WIPAC/IceCube.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: IceCube cluster
 GroupID: 437
+Production: true
 Resources:
   IceCube-submit-1:
     Active: true

--- a/topology/Vanderbilt University/Vanderbilt ACCRE/Vanderbilt-ITB.yaml
+++ b/topology/Vanderbilt University/Vanderbilt ACCRE/Vanderbilt-ITB.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Integration Test Bed Resource
 GroupDescription: ITB Resource Group for SE Testing.
 GroupID: 279
+Production: false
 Resources:
   Vanderbilt_ITB_CE:
     Active: true

--- a/topology/Vanderbilt University/Vanderbilt ACCRE/Vanderbilt.yaml
+++ b/topology/Vanderbilt University/Vanderbilt ACCRE/Vanderbilt.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 137
+Production: true
 Resources:
   US-Vanderbilt BW:
     Active: true

--- a/topology/Vanderbilt University/Vanderbilt_EC2/Vanderbilt_EC2.yaml
+++ b/topology/Vanderbilt University/Vanderbilt_EC2/Vanderbilt_EC2.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: A resource
 GroupID: 311
+Production: true
 Resources:
   Vanderbilt_EC2_CE:
     Active: true

--- a/topology/Virginia Tech/VT_OSG/VT_OSG.yaml
+++ b/topology/Virginia Tech/VT_OSG/VT_OSG.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Virginia Tech OSG
 GroupID: 288
+Production: true
 Resources:
   VT_OSG:
     Active: false

--- a/topology/Virginia Tech/Virginia Bioinformatics Institute/NDSSL.yaml
+++ b/topology/Virginia Tech/Virginia Bioinformatics Institute/NDSSL.yaml
@@ -1,8 +1,8 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Campus Infrastructure components managed by the Network Dynamics
   and Simulation Science Laboratory (NDSSL) at VBI.
 GroupID: 335
+Production: true
 Resources:
   VBI_OSG_Submit1:
     Active: true

--- a/topology/Wayne State University/OSG_US_WSU_GRID_ce2/OSG_US_WSU_GRID.yaml
+++ b/topology/Wayne State University/OSG_US_WSU_GRID_ce2/OSG_US_WSU_GRID.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: Wayne State Grid cluster being access through a hosted ce @ UChicago
 GroupID: 472
+Production: true
 Resources:
   OSG_US_WSU_GRID:
     Active: true

--- a/topology/Wayne State University/STAR WSU/STAR-WSU.yaml
+++ b/topology/Wayne State University/STAR WSU/STAR-WSU.yaml
@@ -1,7 +1,7 @@
 Disable: false
-GridType: OSG Production Resource
 GroupDescription: (No resource group description)
 GroupID: 103
+Production: true
 Resources:
   STAR-WSU:
     Active: true

--- a/webapp/topology.py
+++ b/webapp/topology.py
@@ -263,6 +263,11 @@ class ResourceGroup(object):
         new_rg["Site"] = self.site.get_tree()
         new_rg["GroupName"] = self.name
         new_rg["SupportCenter"] = self.support_center
+        production = new_rg.pop("Production")
+        if production:
+            new_rg["GridType"] = "OSG Production Resource"
+        else:
+            new_rg["GridType"] = "OSG Integration Test Bed Resource"
 
         return new_rg
 

--- a/webapp/topology.py
+++ b/webapp/topology.py
@@ -265,9 +265,9 @@ class ResourceGroup(object):
         new_rg["SupportCenter"] = self.support_center
         production = new_rg.pop("Production")
         if production:
-            new_rg["GridType"] = "OSG Production Resource"
+            new_rg["GridType"] = GRIDTYPE_1
         else:
-            new_rg["GridType"] = "OSG Integration Test Bed Resource"
+            new_rg["GridType"] = GRIDTYPE_2
 
         return new_rg
 


### PR DESCRIPTION
Turn the GridType attribute into production:true/false since that's what it means anyway.