### PR TITLE
Auto-update contacts and topology info

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -55,8 +55,12 @@ class GlobalData:
         if not self.config["NO_GIT"]:
             parent = os.path.dirname(self.config["TOPOLOGY_DATA_DIR"])
             os.makedirs(parent, mode=0o755, exist_ok=True)
-            git_clone_or_pull(self.config["TOPOLOGY_DATA_REPO"], self.config["TOPOLOGY_DATA_DIR"],
-                              self.config["TOPOLOGY_DATA_BRANCH"])
+            ok = git_clone_or_pull(self.config["TOPOLOGY_DATA_REPO"], self.config["TOPOLOGY_DATA_DIR"],
+                                   self.config["TOPOLOGY_DATA_BRANCH"])
+            if ok:
+                app.logger.debug("topology repo update ok")
+            else:
+                app.logger.warning("topology repo update failed")
         for d in [self.projects_dir, self.topology_dir, self.vos_dir]:
             if not os.path.exists(d):
                 raise FileNotFoundError(d)
@@ -67,8 +71,12 @@ class GlobalData:
                 raise RuntimeError("Contacts data requires an SSH key")
             parent = os.path.dirname(self.config["CONTACT_DATA_DIR"])
             os.makedirs(parent, mode=0o700, exist_ok=True)
-            git_clone_or_pull(self.config["CONTACT_DATA_REPO"], self.config["CONTACT_DATA_DIR"],
-                              self.config["CONTACT_DATA_BRANCH"], self.config["GIT_SSH_KEY"])
+            ok = git_clone_or_pull(self.config["CONTACT_DATA_REPO"], self.config["CONTACT_DATA_DIR"],
+                                   self.config["CONTACT_DATA_BRANCH"], self.config["GIT_SSH_KEY"])
+            if ok:
+                app.logger.debug("contact repo update ok")
+            else:
+                app.logger.warning("contact repo update failed")
         if not os.path.exists(self.contacts_file):
             raise FileNotFoundError(self.contacts_file)
 

--- a/src/app.py
+++ b/src/app.py
@@ -115,7 +115,8 @@ default_authorized = False
 app = Flask(__name__)
 app.config.from_object(default_config)
 app.config.from_pyfile("config.py", silent=True)
-app.config.from_envvar("TOPOLOGY_CONFIG", silent=True)
+if "TOPOLOGY_CONFIG" in os.environ:
+    app.config.from_envvar("TOPOLOGY_CONFIG", silent=False)
 global_data = GlobalData(app.config)
 
 

--- a/src/app.py
+++ b/src/app.py
@@ -31,16 +31,18 @@ class DataError(Exception): pass
 class CachedData:
     MAX_DATA_AGE = 60 * 15
 
-    def __init__(self, data=None, timestamp=0):
+    def __init__(self, data=None, timestamp=0, force_update=True):
         self.data = data
         self.timestamp = timestamp
+        self.force_update = force_update
 
     def should_update(self):
-        return not self.data or time.time() - self.timestamp > self.MAX_DATA_AGE
+        return self.force_update or (not self.data or time.time() - self.timestamp > self.MAX_DATA_AGE)
 
     def update(self, data):
         self.data = data
         self.timestamp = time.time()
+        self.force_update = False
 
 
 class GlobalData:

--- a/src/app.py
+++ b/src/app.py
@@ -3,12 +3,8 @@ Application File
 """
 import flask
 from flask import Flask, Response, request, render_template
-import configparser
-import tempfile
-import anymarkup
 import os
 import re
-import subprocess
 import sys
 import time
 from typing import Dict, Set
@@ -20,8 +16,6 @@ from webapp.contacts_reader import ContactsData
 from webapp.topology import GRIDTYPE_1, GRIDTYPE_2, Topology
 from webapp.vos_data import VOsData
 
-import sys
-print(sys.path)
 
 class InvalidArgumentsError(Exception): pass
 
@@ -56,8 +50,7 @@ class GlobalData:
 
     def get_contacts_data(self) -> ContactsData:
         """
-        Get the contact information.  For now this is from a private github repo, but in the future
-        it could be much more complicated to get the contact details
+        Get the contact information from a private git repo
         """
         if self.contacts_data.should_update():
             # use local copy if it exists

--- a/src/topology-itb.wsgi
+++ b/src/topology-itb.wsgi
@@ -1,3 +1,4 @@
-import sys
+import os, sys
+os.environ['TOPOLOGY_CONFIG'] = '/etc/opt/topology/config-itb.py'
 sys.path.insert(0, '/opt/topology-itb/src')
 from app import app as application

--- a/src/topology.wsgi
+++ b/src/topology.wsgi
@@ -1,3 +1,4 @@
-import sys
+import os, sys
+os.environ['TOPOLOGY_CONFIG'] = '/etc/opt/topology/config-production.py'
 sys.path.insert(0, '/opt/topology/src')
 from app import app as application

--- a/src/webapp/common.py
+++ b/src/webapp/common.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from logging import getLogger
 import hashlib
 import os
 import re
@@ -15,6 +16,9 @@ MISCUSER_SCHEMA_URL = "https://my.opensciencegrid.org/schema/miscuser.xsd"
 RGSUMMARY_SCHEMA_URL = "https://my.opensciencegrid.org/schema/rgsummary.xsd"
 RGDOWNTIME_SCHEMA_URL = "https://my.opensciencegrid.org/schema/rgdowntime.xsd"
 VOSUMMARY_SCHEMA_URL = "https://my.opensciencegrid.org/schema/vosummary.xsd"
+
+
+log = getLogger(__name__)
 
 
 class Filters(object):
@@ -181,8 +185,7 @@ def run_git_cmd(cmd: List, dir=None, ssh_key=None) -> bool:
             # just a locking fail, ignore
             return True
 
-        print("Git failed:\nCommand was {0}\nOutput was:\n{1}".format(full_cmd, git_result.stdout),
-              file=sys.stderr)
+        log.warning("Git failed:\nCommand was {0}\nOutput was:\n{1}".format(full_cmd, git_result.stdout))
         return False
 
     return True

--- a/src/webapp/common.py
+++ b/src/webapp/common.py
@@ -164,6 +164,7 @@ def run_git_cmd(cmd: List, dir=None, ssh_key=None) -> bool:
 
     if ssh_key:
         shell = True
+        # From SO: https://stackoverflow.com/questions/4565700/specify-private-ssh-key-to-use-when-executing-shell-command
         full_cmd = "ssh-agent bash -c " + \
                    shlex.quote("ssh-add {0}; {1}".format(shlex.quote(ssh_key),
                                " ".join([shlex.quote(s) for s in (base_cmd + cmd)])))

--- a/src/webapp/common.py
+++ b/src/webapp/common.py
@@ -175,7 +175,12 @@ def run_git_cmd(cmd: List, dir=None, ssh_key=None) -> bool:
     git_result = subprocess.run(full_cmd, shell=shell, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                                 encoding="utf-8")
     if git_result.returncode != 0:
-        # Git command exited with nonzero!
+        out = git_result.stdout
+        if "error: cannot lock ref" in out \
+                or re.search(r"Unable to create.*\.lock.*File exists", out):
+            # just a locking fail, ignore
+            return True
+
         print("Git failed:\nCommand was {0}\nOutput was:\n{1}".format(full_cmd, git_result.stdout),
               file=sys.stderr)
         return False

--- a/src/webapp/default_config.py
+++ b/src/webapp/default_config.py
@@ -1,10 +1,10 @@
 GIT_SSH_KEY = None
 
-TOPOLOGY_DATA_DIR = "/var/cache/topology/topology"
+TOPOLOGY_DATA_DIR = "/tmp/topology/topology"
 TOPOLOGY_DATA_REPO = "https://github.com/opensciencegrid/topology"
 TOPOLOGY_DATA_BRANCH = "master"
 
-CONTACT_DATA_DIR = "/var/cache/topology/contact"
+CONTACT_DATA_DIR = "/tmp/topology/contact"
 CONTACT_DATA_REPO = "git@bitbucket.org:opensciencegrid/contact.git"
 CONTACT_DATA_BRANCH = "master"
 

--- a/src/webapp/default_config.py
+++ b/src/webapp/default_config.py
@@ -9,3 +9,5 @@ CONTACT_DATA_REPO = "git@bitbucket.org:opensciencegrid/contact.git"
 CONTACT_DATA_BRANCH = "master"
 
 CACHE_LIFETIME = 60 * 15
+
+NO_GIT = False

--- a/src/webapp/default_config.py
+++ b/src/webapp/default_config.py
@@ -1,0 +1,11 @@
+GIT_SSH_KEY = None
+
+TOPOLOGY_DATA_DIR = "/var/cache/topology/topology"
+TOPOLOGY_DATA_REPO = "https://github.com/opensciencegrid/topology"
+TOPOLOGY_DATA_BRANCH = "master"
+
+CONTACT_DATA_DIR = "/var/cache/topology/contact"
+CONTACT_DATA_REPO = "git@bitbucket.org:opensciencegrid/contact.git"
+CONTACT_DATA_BRANCH = "master"
+
+CACHE_LIFETIME = 60 * 15


### PR DESCRIPTION
The Git repos are updated whenever data that has been stale for 15 minutes gets accessed. (This assumes that fetches are cheap.)

Tested this on topology-itb.opensciencegrid.org: set the cache lifetime to 5 min, merged #44, and made sure one of the deleted RG's was no longer in the output.

Requires `/etc/opt/topology/config-production.py`:
```python
GIT_SSH_KEY = <CENSORED>

TOPOLOGY_DATA_DIR = "/var/cache/topology/topology"
CONTACT_DATA_DIR = "/var/cache/topology/contact"
```
and `/etc/opt/topology/config-itb.py`:
```python
GIT_SSH_KEY = <CENSORED>

TOPOLOGY_DATA_DIR = "/var/cache/topology-itb/topology"
CONTACT_DATA_DIR = "/var/cache/topology-itb/contact"
```
`/var/cache/topology` and `/var/cache/topology-itb` must exist and be owned by `apache`.