### PR TITLE
Add timezone to downtime timestamps

### DIFF
--- a/src/webapp/topology.py
+++ b/src/webapp/topology.py
@@ -367,7 +367,7 @@ class Downtime(object):
         new_downtime["CreatedTime"] = "Not Available"
         new_downtime["UpdateTime"] = "Not Available"
 
-        fmt = "%b %d, %Y %H:%M %p %Z"
+        fmt = "%b %d, %Y %H:%M %Z"
         new_downtime["StartTime"] = self.start_time.strftime(fmt)
         new_downtime["EndTime"] = self.end_time.strftime(fmt)
 


### PR DESCRIPTION
Noticed by AGIS and Fermi. They also noticed that we dropped the am/pm field but that's redundant so we're not going to bring it back.