### PR TITLE
Revert timezone format change

### DIFF
--- a/src/webapp/topology.py
+++ b/src/webapp/topology.py
@@ -367,7 +367,7 @@ class Downtime(object):
         new_downtime["CreatedTime"] = "Not Available"
         new_downtime["UpdateTime"] = "Not Available"
 
-        fmt = "%b %d, %Y %H:%M"
+        fmt = "%b %d, %Y %H:%M %p %Z"
         new_downtime["StartTime"] = self.start_time.strftime(fmt)
         new_downtime["EndTime"] = self.end_time.strftime(fmt)
 


### PR DESCRIPTION
Let's revert the timezone format change completely so our users can more gracefully transition to the new format