### PR TITLE
Make the downtime time parsing code public & remove dateparser dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 Flask
 gunicorn
 anymarkup
-dateparser
 requests

--- a/template-downtime.yaml
+++ b/template-downtime.yaml
@@ -13,11 +13,11 @@
   # - No Significant Outage Expected
   Severity: <TEXT>
   # Start date and time of the donwtime in the following format:
-  # <MONTH> <DAY>, <YEAR> <TIME> <TIME ZONE>
+  # <MONTH> <DAY>, <YEAR> <TIME> <TIME OFFSET>
   # e.g. Mar 28, 2017 22:00 -0500
   StartTime: <DATE AND TIME>
   # End date and time of the donwtime in the following format:
-  # <MONTH> <DAY>, <YEAR> <TIME> <TIME ZONE>
+  # <MONTH> <DAY>, <YEAR> <TIME> <TIME OFFSET>
   # e.g. Mar 30, 2017 22:00 -0500
   EndTime: <DATE AND TIME>
   # The resource affected by the downtime

--- a/template-downtime.yaml
+++ b/template-downtime.yaml
@@ -14,11 +14,11 @@
   Severity: <TEXT>
   # Start date and time of the donwtime in the following format:
   # <MONTH> <DAY>, <YEAR> <TIME> <TIME ZONE>
-  # e.g. Mar 28, 2017 22:00 UTC
+  # e.g. Mar 28, 2017 22:00 -0500
   StartTime: <DATE AND TIME>
   # End date and time of the donwtime in the following format:
   # <MONTH> <DAY>, <YEAR> <TIME> <TIME ZONE>
-  # e.g. Mar 30, 2017 22:00 UTC
+  # e.g. Mar 30, 2017 22:00 -0500
   EndTime: <DATE AND TIME>
   # The resource affected by the downtime
   ResourceName: <RESOURCE NAME>


### PR DESCRIPTION
Parse the date using the standard library because dateparser's behavior is not predictable enough. Prefer numeric time zones (e.g. -0500) because parsing text time zones like "CDT" is too complicated in Python. (SOFTWARE-3313)