### PR TITLE
Prompt users to verify sending email without dry-run

### DIFF
--- a/bin/osg-notify
+++ b/bin/osg-notify
@@ -157,14 +157,18 @@ def main():
     if args.dryrun:
         print(msg)
     else:
-        while True:
-            verify_send = raw_input("Really send mail to {0} recipients? (y/N)".format(len(recipients)))
+        for _ in range(1, 4):
+            try:
+                verify_send = raw_input("Really send mail to {0} recipients? (y/N)".format(len(recipients)))
+            except EOFError:
+                verify_send = 'n'
+
             if verify_send.lower() == 'y':
                 session = smtplib.SMTP('localhost')
                 session.sendmail("help@opensciencegrid.org", recipients, msg)
                 session.quit()
                 break
-            elif verify_send.lower() == 'n' or verify_send.lower() == '':
+            elif verify_send.lower() in ['n', '']:
                 print("Not sending email...")
                 print(msg)
                 break

--- a/bin/osg-notify
+++ b/bin/osg-notify
@@ -157,10 +157,19 @@ def main():
     if args.dryrun:
         print(msg)
     else:
-        session = smtplib.SMTP('localhost')
-        session.sendmail("help@opensciencegrid.org", recipients, msg)
-        session.quit()
-
+        while True:
+            verify_send = raw_input("Really send mail to {0} recipients? (y/N)".format(len(recipients)))
+            if verify_send.lower() == 'y':
+                session = smtplib.SMTP('localhost')
+                session.sendmail("help@opensciencegrid.org", recipients, msg)
+                session.quit()
+                break
+            elif verify_send.lower() == 'n' or verify_send.lower() == '':
+                print("Not sending email...")
+                print(msg)
+                break
+            else:
+                print("Unrecognized answer: '{0}'".format(verify_send))
 
 if __name__ == '__main__':
     main()

--- a/bin/osg-notify
+++ b/bin/osg-notify
@@ -21,6 +21,7 @@ import topology_utils
 # https://stackoverflow.com/questions/10496902/pgp-signing-multipart-e-mails-with-python
 # Licensed under CC-BY-SA
 
+
 def messageFromSignature(signature):
     """
     Given a GnuPG signature, generate a corresponding MIME message.
@@ -52,7 +53,8 @@ def generateFullMessage(subject, to, from_name, message, sign=True, keyid=None):
             raise RuntimeError("GnuPG signature of message failed")
 
         signmsg = messageFromSignature(signature)
-        msg = email.mime.multipart.MIMEMultipart(_subtype="signed", micalg="pgp-sha1", protocol="application/pgp-signature")
+        msg = email.mime.multipart.MIMEMultipart(_subtype="signed", micalg="pgp-sha1",
+                                                 protocol="application/pgp-signature")
         msg.attach(basemsg)
         msg.attach(signmsg)
         msg['Subject'] = subject
@@ -71,35 +73,35 @@ def generateFullMessage(subject, to, from_name, message, sign=True, keyid=None):
 def parseargs():
     oparser = argparse.ArgumentParser()
     oparser.add_argument("--host", dest="host", default="my.opensciencegrid.org",
-                help="Remote topology host (default my.opensciencegrid.org)")
+                         help="Remote topology host (default my.opensciencegrid.org)")
     oparser.add_argument("--cert", dest="cert", help="Client certificate")
     oparser.add_argument("--key", dest="key", help="Client certificate private key")
     oparser.add_argument("--sign", dest="sign", default=True, action="store_true", help="Whether to sign with GPG")
     oparser.add_argument("--no-sign", dest="sign", action="store_false", help="Whether to sign with GPG")
     oparser.add_argument("--sign-id", dest="keyid", help="PGP signing key ID")
-    oparser.add_argument("--type", dest="type", required=True, help="Whether notification is test or production", choices=["test", "production"])
+    oparser.add_argument("--type", dest="type", required=True, choices=["test", "production"],
+                         help="Whether notification is test or production")
     oparser.add_argument("--recipients", dest="recipients", required=True,
-        help="Recipients of notification email")
+                         help="Recipients of notification email")
     oparser.add_argument("--oim-recipients", dest="oim_recipients", action="append", choices=["resources", "vos"])
     oparser.add_argument("--message", dest="message", help="File containing message contents", required=True)
     oparser.add_argument("--subject", dest="subject", help="Contents of the subject line", required=True)
-    oparser.add_argument("--from", dest="from_name", help="Human-friendly name for 'From' address", choices=["default", "security"], default="default")
-    oparser.add_argument("--dry-run", dest="dryrun", default=False, action="store_true", help="Print out the email instead of sending it.")
+    oparser.add_argument("--from", dest="from_name", help="Human-friendly name for 'From' address",
+                         choices=["default", "security"], default="default")
+    oparser.add_argument("--dry-run", dest="dryrun", default=False, action="store_true",
+                         help="Print out the email instead of sending it.")
 
-    oparser.add_argument("--oim-name-filter", dest="name_filter", action="store",
-        nargs="?", help="Shell expression filter on the VO or resource name")
-    oparser.add_argument( \
-        "--oim-service-filter",
-             dest="provides_service", help="Filter on resources that provide given "
-            "service(s)")
-    oparser.add_argument("--oim-owner-filter",
-        dest="owner_vo", help="Filter on resources that list VO(s) as a "
-        "partial owner")
+    oparser.add_argument("--oim-name-filter", dest="name_filter", action="store", nargs="?",
+                         help="Shell expression filter on the VO or resource name")
+    oparser.add_argument("--oim-service-filter", dest="provides_service",
+                         help="Filter on resources that provide given service(s)")
+    oparser.add_argument("--oim-owner-filter", dest="owner_vo",
+                         help="Filter on resources that list VO(s) as a partial owner")
 
-    oparser.add_argument("--oim-contact-type", default="all",
-                         dest="contact_type", help="Filter on contact type "
-                         "(e.g. administrative, miscellaneous, security, or submitter; "
-                         "default all)", choices=["all", "administrative", "miscellaneous", "security", "submitter"])
+    oparser.add_argument("--oim-contact-type", default="all", dest="contact_type",
+                         choices=["all", "administrative", "miscellaneous", "security", "submitter"],
+                         help="Filter on contact type e.g. administrative, miscellaneous, security, or submitter "
+                         "(default: all)", )
 
     args = oparser.parse_args()
 
@@ -152,7 +154,8 @@ def main():
 ===================================================
 """ + contents
 
-    msg = generateFullMessage(subject=args.subject, to=recipients, from_name = args.from_name, message=contents, sign=args.sign, keyid=args.keyid)
+    msg = generateFullMessage(subject=args.subject, to=recipients, from_name=args.from_name, message=contents,
+                              sign=args.sign, keyid=args.keyid)
 
     if args.dryrun:
         print(msg)
@@ -174,6 +177,7 @@ def main():
                 break
             else:
                 print("Unrecognized answer: '{0}'".format(verify_send))
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
To help avoid accidentally sending mail. We could also detect how many `@opensciencegrid.org` recipients there are to catch how many OSG mailing lists are included.