### PR TITLE
Remove nanohub & lqcd voms servers & disable LQCD

### DIFF
--- a/virtual-organizations/LQCD.yaml
+++ b/virtual-organizations/LQCD.yaml
@@ -1,7 +1,7 @@
 AppDescription: Grid file transfers for members of USQCD.
 CertificateOnly: true
 Community: Members of the USQCD lattice QCD collaboration.
-Disable: false
+Disable: true
 FieldsOfScience:
   PrimaryFields:
   - High Energy Physics
@@ -9,9 +9,7 @@ FieldsOfScience:
   - Nuclear Physics
 ID: 95
 LongName: USQCD collaboration Lattice QCD VO
-MembershipServicesURL: https://voms.fnal.gov:8443/voms/lqcd
 OASIS:
   UseOASIS: false
-PrimaryURL: https://voms.fnal.gov:8443/voms/lqcd/
 ReportingGroups:
 - LQCD

--- a/virtual-organizations/nanoHUB.yaml
+++ b/virtual-organizations/nanoHUB.yaml
@@ -24,7 +24,6 @@ FieldsOfScience:
   - Physics and astronomy
 ID: 26
 LongName: nanoHUB Network for Computational Nanotechnology (NCN)
-MembershipServicesURL: https://voms.opensciencegrid.org:8443/voms/nanohub/admin/home.action
 OASIS:
   Managers:
     Scott Teige:


### PR DESCRIPTION
Steve Timm wrote in SOFTWARE-3182 that those VOMS servers were turned
off and the LCQD VO was deactivated.