### PR TITLE
Adding downtime for AGLT2_SL6

### DIFF
--- a/topology/University of Michigan/AGLT2/AGLT2_downtime.yaml
+++ b/topology/University of Michigan/AGLT2/AGLT2_downtime.yaml
@@ -602,3 +602,11 @@
   - SRMv2
   Severity: No Significant Outage Expected
   StartTime: Apr 12, 2018 12:00 +0000
+- Class: SCHEDULED
+  Description: Turning down/off our SL6 queues, hopefully permanently
+  Severity: Outage
+  StartTime: Jul 11, 2018 13:00 +0000
+  EndTime: Sep 11, 2018 13:00 +0000
+  ResourceName: AGLT2_SL6
+  Services:
+  - CE


### PR DESCRIPTION
Setting up AGLT2_SL6 downtime in preparation for turning down all remaining AGLT2 SL6 Panda Queues.
