### PR TITLE
replace Manoj contact with Majid (SOFTWARE-3313)

### DIFF
--- a/topology/Purdue University/Purdue CMS/Purdue-Conte.yaml
+++ b/topology/Purdue University/Purdue CMS/Purdue-Conte.yaml
@@ -25,8 +25,8 @@ Resources:
           Name: Erik Gough
       Submitter Contact:
         Primary:
-          ID: 167abf29d6c33c7a0da9f23be10756203afa8f36
-          Name: Manoj Kumar Jha
+          ID: 0a7745a628485f60a61a841b3f3b6ea2b40a5891
+          Name: Majid Arabgol
     Description: |-
       Computing element for Purdue Conte cluster.
       http://www.rcac.purdue.edu/userinfo/resources/conte/

--- a/topology/Purdue University/Purdue CMS/Purdue-Hadoop.yaml
+++ b/topology/Purdue University/Purdue CMS/Purdue-Hadoop.yaml
@@ -7,23 +7,20 @@ Resources:
     ContactLists:
       Miscellaneous Contact:
         Secondary:
-          ID: 167abf29d6c33c7a0da9f23be10756203afa8f36
-          Name: Manoj Kumar Jha
+          ID: 0a7745a628485f60a61a841b3f3b6ea2b40a5891
+          Name: Majid Arabgol
       Resource Report Contact:
         Secondary:
           ID: 0a7745a628485f60a61a841b3f3b6ea2b40a5891
           Name: Majid Arabgol
-        Tertiary:
-          ID: 167abf29d6c33c7a0da9f23be10756203afa8f36
-          Name: Manoj Kumar Jha
       Security Contact:
         Secondary:
           ID: 0a7745a628485f60a61a841b3f3b6ea2b40a5891
           Name: Majid Arabgol
       Submitter Contact:
         Primary:
-          ID: 167abf29d6c33c7a0da9f23be10756203afa8f36
-          Name: Manoj Kumar Jha
+          ID: 0a7745a628485f60a61a841b3f3b6ea2b40a5891
+          Name: Majid Arabgol
     Description: Computing element for CMS Hadoop cluster at Purdue University.
     Disable: false
     FQDN: hadoop-osg.rcac.purdue.edu
@@ -75,8 +72,8 @@ Resources:
           Name: Majid Arabgol
       Submitter Contact:
         Primary:
-          ID: 167abf29d6c33c7a0da9f23be10756203afa8f36
-          Name: Manoj Kumar Jha
+          ID: 0a7745a628485f60a61a841b3f3b6ea2b40a5891
+          Name: Majid Arabgol
     Description: This is the HTCE for clusters managed by PBS batch system at Purdue
       Tier-2.
     Disable: false
@@ -111,8 +108,8 @@ Resources:
           Name: Majid Arabgol
       Submitter Contact:
         Primary:
-          ID: 167abf29d6c33c7a0da9f23be10756203afa8f36
-          Name: Manoj Kumar Jha
+          ID: 0a7745a628485f60a61a841b3f3b6ea2b40a5891
+          Name: Majid Arabgol
     Description: HTCondor CE at Purdue Tier-2
     Disable: true
     FQDN: cms-ce1-osg.rcac.purdue.edu
@@ -162,8 +159,8 @@ Resources:
           Name: Erik Gough
       Submitter Contact:
         Primary:
-          ID: 167abf29d6c33c7a0da9f23be10756203afa8f36
-          Name: Manoj Kumar Jha
+          ID: 0a7745a628485f60a61a841b3f3b6ea2b40a5891
+          Name: Majid Arabgol
     Description: Storage element for CMS Hadoop cluster at Purdue University.
     Disable: true
     FQDN: srm.rcac.purdue.edu
@@ -239,8 +236,8 @@ Resources:
           ID: f11eeb608313b242e14f5aee602b3aff91839ace
           Name: Erik Gough
         Tertiary:
-          ID: 167abf29d6c33c7a0da9f23be10756203afa8f36
-          Name: Manoj Kumar Jha
+          ID: 0a7745a628485f60a61a841b3f3b6ea2b40a5891
+          Name: Majid Arabgol
       Security Contact:
         Primary:
           ID: 0a7745a628485f60a61a841b3f3b6ea2b40a5891
@@ -265,23 +262,20 @@ Resources:
     ContactLists:
       Miscellaneous Contact:
         Secondary:
-          ID: 167abf29d6c33c7a0da9f23be10756203afa8f36
-          Name: Manoj Kumar Jha
+          ID: 0a7745a628485f60a61a841b3f3b6ea2b40a5891
+          Name: Majid Arabgol
       Resource Report Contact:
         Primary:
           ID: 0a7745a628485f60a61a841b3f3b6ea2b40a5891
           Name: Majid Arabgol
-        Tertiary:
-          ID: 167abf29d6c33c7a0da9f23be10756203afa8f36
-          Name: Manoj Kumar Jha
       Security Contact:
         Primary:
           ID: 0a7745a628485f60a61a841b3f3b6ea2b40a5891
           Name: Majid Arabgol
       Submitter Contact:
         Primary:
-          ID: 167abf29d6c33c7a0da9f23be10756203afa8f36
-          Name: Manoj Kumar Jha
+          ID: 0a7745a628485f60a61a841b3f3b6ea2b40a5891
+          Name: Majid Arabgol
     Description: This is a computing element used for testing  CMS VO at Purdue University.
     Disable: false
     FQDN: cmstest1.rcac.purdue.edu
@@ -328,8 +322,8 @@ Resources:
           Name: Majid Arabgol
       Submitter Contact:
         Primary:
-          ID: 167abf29d6c33c7a0da9f23be10756203afa8f36
-          Name: Manoj Kumar Jha
+          ID: 0a7745a628485f60a61a841b3f3b6ea2b40a5891
+          Name: Majid Arabgol
     Description: This is the squid services at Purdue Tier-2.  This host runs two  instances
       of squid services.
     Disable: false
@@ -350,9 +344,6 @@ Resources:
         Secondary:
           ID: 0a7745a628485f60a61a841b3f3b6ea2b40a5891
           Name: Majid Arabgol
-        Tertiary:
-          ID: 167abf29d6c33c7a0da9f23be10756203afa8f36
-          Name: Manoj Kumar Jha
       Resource Report Contact:
         Secondary:
           ID: 0a7745a628485f60a61a841b3f3b6ea2b40a5891
@@ -363,8 +354,8 @@ Resources:
           Name: Majid Arabgol
       Submitter Contact:
         Primary:
-          ID: 167abf29d6c33c7a0da9f23be10756203afa8f36
-          Name: Manoj Kumar Jha
+          ID: 0a7745a628485f60a61a841b3f3b6ea2b40a5891
+          Name: Majid Arabgol
     Description: This is the squid server at Purdue Tier-2.  This host runs two instance
       of squid services.
     Disable: false
@@ -401,8 +392,8 @@ Resources:
           Name: Majid Arabgol
       Submitter Contact:
         Primary:
-          ID: 167abf29d6c33c7a0da9f23be10756203afa8f36
-          Name: Manoj Kumar Jha
+          ID: 0a7745a628485f60a61a841b3f3b6ea2b40a5891
+          Name: Majid Arabgol
     Description: This is squid server at Purdue Tier-2.  There are two instances of
       squid services running on this host.
     Disable: false
@@ -425,8 +416,8 @@ Resources:
           Name: Majid Arabgol
       Submitter Contact:
         Primary:
-          ID: 167abf29d6c33c7a0da9f23be10756203afa8f36
-          Name: Manoj Kumar Jha
+          ID: 0a7745a628485f60a61a841b3f3b6ea2b40a5891
+          Name: Majid Arabgol
     Description: Perfsonar bandwidth node for Purdue Tier-2 CMS center.
     Disable: false
     FQDN: perfsonar-cms2.itns.purdue.edu
@@ -476,8 +467,8 @@ Resources:
           Name: Erik Gough
       Submitter Contact:
         Primary:
-          ID: 167abf29d6c33c7a0da9f23be10756203afa8f36
-          Name: Manoj Kumar Jha
+          ID: 0a7745a628485f60a61a841b3f3b6ea2b40a5891
+          Name: Majid Arabgol
     Description: Perfsonar latency node for CMS clusters at Purdue University.
     Disable: false
     FQDN: perfsonar-cms1.itns.purdue.edu

--- a/topology/Purdue University/Purdue CMS/Purdue-Hammer.yaml
+++ b/topology/Purdue University/Purdue CMS/Purdue-Hammer.yaml
@@ -32,8 +32,8 @@ Resources:
           Name: Erik Gough
       Submitter Contact:
         Primary:
-          ID: 167abf29d6c33c7a0da9f23be10756203afa8f36
-          Name: Manoj Kumar Jha
+          ID: 0a7745a628485f60a61a841b3f3b6ea2b40a5891
+          Name: Majid Arabgol
     Description: This is the gatekeeper for accessing computing  resources of high
       throughput community cluster Hammer at Purdue University.
     Disable: false

--- a/topology/Purdue University/Purdue CMS/Purdue-Hansen.yaml
+++ b/topology/Purdue University/Purdue CMS/Purdue-Hansen.yaml
@@ -17,16 +17,10 @@ Resources:
         Primary:
           ID: 0a7745a628485f60a61a841b3f3b6ea2b40a5891
           Name: Majid Arabgol
-        Secondary:
-          ID: 167abf29d6c33c7a0da9f23be10756203afa8f36
-          Name: Manoj Kumar Jha
       Security Contact:
         Primary:
           ID: 0a7745a628485f60a61a841b3f3b6ea2b40a5891
           Name: Majid Arabgol
-        Secondary:
-          ID: 167abf29d6c33c7a0da9f23be10756203afa8f36
-          Name: Manoj Kumar Jha
       Submitter Contact:
         Primary:
           ID: 4fc95aafd347aa59450057af01eaeeec070648cf

--- a/topology/Purdue University/Purdue CMS/Purdue-RCAC.yaml
+++ b/topology/Purdue University/Purdue CMS/Purdue-RCAC.yaml
@@ -50,36 +50,24 @@ Resources:
     ContactLists:
       Administrative Contact:
         Primary:
-          ID: 167abf29d6c33c7a0da9f23be10756203afa8f36
-          Name: Manoj Kumar Jha
-        Secondary:
           ID: 0a7745a628485f60a61a841b3f3b6ea2b40a5891
           Name: Majid Arabgol
       Miscellaneous Contact:
         Primary:
-          ID: 167abf29d6c33c7a0da9f23be10756203afa8f36
-          Name: Manoj Kumar Jha
-        Secondary:
           ID: 0a7745a628485f60a61a841b3f3b6ea2b40a5891
           Name: Majid Arabgol
       Resource Report Contact:
         Primary:
-          ID: 167abf29d6c33c7a0da9f23be10756203afa8f36
-          Name: Manoj Kumar Jha
-        Secondary:
           ID: 0a7745a628485f60a61a841b3f3b6ea2b40a5891
           Name: Majid Arabgol
       Security Contact:
         Primary:
-          ID: 167abf29d6c33c7a0da9f23be10756203afa8f36
-          Name: Manoj Kumar Jha
-        Secondary:
           ID: 0a7745a628485f60a61a841b3f3b6ea2b40a5891
           Name: Majid Arabgol
       Submitter Contact:
         Primary:
-          ID: 167abf29d6c33c7a0da9f23be10756203afa8f36
-          Name: Manoj Kumar Jha
+          ID: 0a7745a628485f60a61a841b3f3b6ea2b40a5891
+          Name: Majid Arabgol
     Description: Test instance for CMS  computing element
     Disable: true
     FQDN: cmstest1.rcac.purdue.edu

--- a/topology/Purdue University/Purdue CMS/Purdue-Rossmann.yaml
+++ b/topology/Purdue University/Purdue CMS/Purdue-Rossmann.yaml
@@ -18,8 +18,8 @@ Resources:
           ID: f7bf61cf10278ef2f77d09aeef2fa56b52b53248
           Name: Preston Smith
         Secondary:
-          ID: 167abf29d6c33c7a0da9f23be10756203afa8f36
-          Name: Manoj Kumar Jha
+          ID: 0a7745a628485f60a61a841b3f3b6ea2b40a5891
+          Name: Majid Arabgol
       Submitter Contact:
         Primary:
           ID: f7bf61cf10278ef2f77d09aeef2fa56b52b53248


### PR DESCRIPTION
Came up while fixing downtimes.

In some instances the Manoj contact was dropped if Majid would be listed
as Primary AND Secondary, or Secondary AND Tertiary.