### PR TITLE
Display CreatedTime

### DIFF
--- a/bin/format_time
+++ b/bin/format_time
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+time="$*"
+if [[ -z $time ]]; then
+    echo "Usage: ${0##*/} <time>"
+    exit 2
+fi
+
+date +"%b %e, %Y %H:%M %z" -d "$time"

--- a/bin/format_time
+++ b/bin/format_time
@@ -3,7 +3,12 @@
 time="$*"
 if [[ -z $time ]]; then
     echo "Usage: ${0##*/} <time>"
+    echo "where <time> is anything date(1) can understand or 'forever'/'permanent'."
     exit 2
+fi
+
+if [[ $time == forever || $time = perm* ]]; then
+    time=@$(( 0x7fffffff ))
 fi
 
 date +"%b %e, %Y %H:%M %z" -d "$time"

--- a/bin/format_time
+++ b/bin/format_time
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 time="$*"
-if [[ -z $time ]]; then
+if [[ -z $time || $time = -h* ]]; then
     echo "Usage: ${0##*/} <time>"
     echo "where <time> is anything date(1) can understand or 'forever'/'permanent'."
     exit 2

--- a/topology/Fermi National Accelerator Laboratory/FNAL USCMS Tier1/USCMS-FNAL-WC1_downtime.yaml
+++ b/topology/Fermi National Accelerator Laboratory/FNAL USCMS Tier1/USCMS-FNAL-WC1_downtime.yaml
@@ -279,6 +279,7 @@
   - SRMv2
   Severity: Outage
   StartTime: Jul 20, 2018 21:00 +0000
+  CreatedTime: Jul 16, 2018 15:09 -0500
 - Class: SCHEDULED
   Description: Power infrastructure work in FCC compute center
   EndTime: Jul 21, 2018 21:00 +0000
@@ -289,6 +290,7 @@
   - GridFtp
   Severity: Outage
   StartTime: Jul 20, 2018 21:00 +0000
+  CreatedTime: Jul 16, 2018 15:09 -0500
 - Class: SCHEDULED
   Description: Power infrastructure work in FCC compute center
   EndTime: Jul 21, 2018 21:00 +0000
@@ -299,6 +301,7 @@
   - GridFtp
   Severity: Outage
   StartTime: Jul 20, 2018 21:00 +0000
+  CreatedTime: Jul 16, 2018 15:09 -0500
 - Class: SCHEDULED
   Description: Power infrastructure work in FCC compute center
   EndTime: Jul 21, 2018 21:00 +0000
@@ -309,6 +312,7 @@
   - GridFtp
   Severity: Outage
   StartTime: Jul 20, 2018 21:00 +0000
+  CreatedTime: Jul 16, 2018 15:09 -0500
 - Class: SCHEDULED
   Description: Power infrastructure work in FCC compute center
   EndTime: Jul 21, 2018 21:00 +0000
@@ -319,3 +323,4 @@
   - GridFtp
   Severity: Outage
   StartTime: Jul 20, 2018 21:00 +0000
+  CreatedTime: Jul 16, 2018 15:09 -0500

--- a/topology/Fermi National Accelerator Laboratory/FermiGrid/GPGRID_downtime.yaml
+++ b/topology/Fermi National Accelerator Laboratory/FermiGrid/GPGRID_downtime.yaml
@@ -7,6 +7,7 @@
   ResourceName: FNAL_GPGRID_CE_03
   Services:
     - CE
+  CreatedTime: Jul 12, 2018 11:08 -0500
 - Class: SCHEDULED
   ID: 1005690
   Description: There will be a power outage in the machine room due to electrical maintenance.
@@ -16,6 +17,7 @@
   ResourceName: FNAL_GPGRID_CE_04
   Services:
     - CE
+  CreatedTime: Jul 12, 2018 11:08 -0500
 - Class: SCHEDULED
   ID: 1005691
   Description: There will be a power outage in the machine room due to electrical maintenance.
@@ -25,6 +27,7 @@
   ResourceName: FNAL_JOBSUB_01
   Services:
     - Submit Node
+  CreatedTime: Jul 12, 2018 11:08 -0500
 - Class: SCHEDULED
   ID: 1005692
   Description: There will be a power outage in the machine room due to electrical maintenance.
@@ -34,4 +37,5 @@
   ResourceName: FNAL_JOBSUB_02
   Services:
     - Submit Node
+  CreatedTime: Jul 12, 2018 11:08 -0500
 


### PR DESCRIPTION
Tested on topology-itb and Stephan said it was good.

This also adds a simple script named `format_time` which takes a time in any format `date(1)` can understand, and also "forever" or "permanent", and outputs it in the format our YAML files use.