### PR TITLE
Change UFlorida perfSONAR resource IDs to be in order

### DIFF
--- a/topology/University of Florida/UF CMS Tier2/UFlorida-PG.yaml
+++ b/topology/University of Florida/UF CMS Tier2/UFlorida-PG.yaml
@@ -90,7 +90,7 @@ Resources:
           Name: Bockjoo Kim
     Description: perfSONAR bandwidth
     FQDN: perfsonar2.ihepa.ufl.edu
-    ID: 5741
+    ID: 946
     Services:
       net.perfSONAR.Bandwidth:
         Description: perfSONAR Bandwidth monitoring node
@@ -121,7 +121,7 @@ Resources:
           Name: Bockjoo Kim
     Description: perfSONAR IPv6 bandwidth
     FQDN: cmsps1.rc.ufl.edu
-    ID: 5742
+    ID: 947
     Services:
       net.perfSONAR.Bandwidth:
         Description: perfSONAR IPv6 Bandwidth monitoring node


### PR DESCRIPTION
We don't have 5700+ resources so the resource IDs should not be that
high. These resources are fairly new so the change shouldn't break anything.
You can't query by resource ID anyway.