### PR TITLE
Put email_to_id() in separate file that's Py2-compatible

### DIFF
--- a/bin/email-hash
+++ b/bin/email-hash
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
+from __future__ import print_function
 
 import os
 import sys
@@ -9,7 +10,7 @@ if __name__ == "__main__" and __package__ is None:
     sys.path.append(_parent + "/src")
 
 
-from webapp.common import email_to_id
+from webapp.email_to_id import email_to_id
 
 if len(sys.argv) < 2:
     sys.exit("usage: %s <EMAIL> [<EMAIL 2>..<EMAIL N>]" % sys.argv[0])

--- a/src/converters/rg_xml_to_yaml
+++ b/src/converters/rg_xml_to_yaml
@@ -47,7 +47,8 @@ import anymarkup
 if __name__ == "__main__" and __package__ is None:
     sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from webapp.common import is_null, ensure_list, simplify_attr_list, trim_space, email_to_id
+from webapp.common import is_null, ensure_list, simplify_attr_list, trim_space
+from webapp.email_to_id import email_to_id
 
 
 def to_file_name(name: str) -> str:

--- a/src/converters/sc_table_to_yaml
+++ b/src/converters/sc_table_to_yaml
@@ -11,7 +11,8 @@ import anymarkup
 if __name__ == "__main__" and __package__ is None:
     sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from webapp.common import trim_space, email_to_id
+from webapp.common import trim_space
+from webapp.email_to_id import email_to_id
 
 
 def main():

--- a/src/converters/vo_xml_to_yaml
+++ b/src/converters/vo_xml_to_yaml
@@ -11,7 +11,8 @@ from typing import Dict, Union
 if __name__ == "__main__" and __package__ is None:
     sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from webapp.common import is_null, simplify_attr_list, ensure_list, trim_space, email_to_id
+from webapp.common import is_null, simplify_attr_list, ensure_list, trim_space
+from webapp.email_to_id import email_to_id
 
 
 def is_true_str(a_str: Union[str, None]) -> bool:

--- a/src/webapp/common.py
+++ b/src/webapp/common.py
@@ -154,10 +154,6 @@ def trim_space(s: str) -> str:
     return ret
 
 
-def email_to_id(email: str) -> str:
-    return hashlib.sha1(email.strip().lower().encode()).hexdigest()
-
-
 def run_git_cmd(cmd: List, dir=None, ssh_key=None) -> bool:
     if ssh_key and not os.path.exists(ssh_key):
         log.critical("ssh key not found at %s: unable to update secure repo",

--- a/src/webapp/email_to_id.py
+++ b/src/webapp/email_to_id.py
@@ -5,16 +5,7 @@ import sys
 def email_to_id(email):
     email = email.strip().lower()
 
-    if sys.version_info[0] >= 3:
-        if isinstance(email, str):
-            email_bytes = email.encode()
-        else:
-            email_bytes = email
-    else:
-        if isinstance(email, unicode):
-            email_bytes = email.encode()
-        else:
-            email_bytes = email
+    email_bytes = email if isinstance(email, bytes) else email.encode()
 
     return hashlib.sha1(email_bytes).hexdigest()
 

--- a/src/webapp/email_to_id.py
+++ b/src/webapp/email_to_id.py
@@ -1,0 +1,20 @@
+import hashlib
+import sys
+
+
+def email_to_id(email):
+    email = email.strip().lower()
+
+    if sys.version_info[0] >= 3:
+        if isinstance(email, str):
+            email_bytes = email.encode()
+        else:
+            email_bytes = email
+    else:
+        if isinstance(email, unicode):
+            email_bytes = email.encode()
+        else:
+            email_bytes = email
+
+    return hashlib.sha1(email_bytes).hexdigest()
+

--- a/src/webapp/email_to_id.py
+++ b/src/webapp/email_to_id.py
@@ -1,6 +1,4 @@
 import hashlib
-import sys
-
 
 def email_to_id(email):
     email = email.strip().lower()


### PR DESCRIPTION
This allows users to run bin/email-hash without installing Python 3 or
any of our other dependencies.