### PR TITLE
add network checks for osg-notify emails (SOFTWARE-3389)

### DIFF
--- a/bin/network-hostname-ip-check
+++ b/bin/network-hostname-ip-check
@@ -1,0 +1,1 @@
+../src/net_name_addr_utils.py

--- a/bin/osg-notify
+++ b/bin/osg-notify
@@ -16,6 +16,7 @@ import email.mime.multipart
 import gnupg
 
 import topology_utils
+import net_name_addr_utils
 
 # Parts of this implementation are from the following StackOverflow answer:
 # https://stackoverflow.com/questions/10496902/pgp-signing-multipart-e-mails-with-python
@@ -115,6 +116,21 @@ def parseargs():
 
     return args
 
+def network_ok():
+    fqdn, addr, public, fqdn_reverse = net_name_addr_utils.get_fqdn_ip_public_reverse()
+    net_ok = public and fqdn == fqdn_reverse
+    if net_ok:
+        return True
+    else:
+        print("FQDN: %s" % fqdn)
+        print("IPv4: %s" % addr)
+        print("IPv4 is public? %s" % public)
+        matchstr = "match" if fqdn == fqdn_reverse else "mismatch"
+        print("Reverse FQDN: %s (%s)" % (fqdn_reverse, matchstr))
+        print("Refusing to send email without hostname/public DNS match.")
+        print("For more info, see:")
+        print("  https://opensciencegrid.org//operations/services/sending-announcements/")
+        return False
 
 def main():
     args = parseargs()
@@ -159,7 +175,7 @@ def main():
 
     if args.dryrun:
         print(msg)
-    else:
+    elif network_ok():
         for _ in range(1, 4):
             try:
                 verify_send = raw_input("Really send mail to {0} recipients? (y/N)".format(len(recipients)))

--- a/src/net_name_addr_utils.py
+++ b/src/net_name_addr_utils.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+
+# check that hostname fqdn maps to a public IP and reverse dns matches
+
+import sys
+import socket
+
+from socket import AF_INET, NI_NAMEREQD
+from functools import reduce
+
+def ipv4_to_num(ipv4_str):
+    """Compute int value of IPv4 address; partial IPs are zero-extended"""
+    quads = (list(map(int, ipv4_str.split('.'))) + [0]*4)[:4]
+    return reduce((lambda a,b: a<<8 | b), quads)
+
+def netmask_num_from_size(size):
+    return 0xFFFFFFFF & ~(0xFFFFFFFF >> int(size))
+
+def addr_in_netrange(addr, netrange):
+    subnet, size = netrange.split('/')
+    subnet_num = ipv4_to_num(subnet)
+    netmask_num = netmask_num_from_size(size)
+    addr_num = ipv4_to_num(addr)
+
+    return (addr_num & netmask_num) == subnet_num
+
+def addr_is_public(addr):
+    NONPUB = "192.168/16 172.16/12 10/8 127/8".split()
+    return not any( addr_in_netrange(addr, netrange) for netrange in NONPUB )
+
+def get_fqdn_ip_public_reverse():
+    port = 25
+    hostname = socket.gethostname().lower()
+    fqdn = socket.getfqdn(hostname)
+    addr = socket.getaddrinfo(fqdn, port, AF_INET)[0][4][0]
+    public = addr_is_public(addr)
+    try:
+        host_reverse = socket.getnameinfo((addr, port), NI_NAMEREQD)[0].lower()
+        fqdn_reverse = socket.getfqdn(host_reverse).lower()
+    except socket.gaierror:
+        fqdn_reverse = "<UNKNOWN>"
+
+    return fqdn, addr, public, fqdn_reverse
+
+def main():
+    fqdn, addr, public, fqdn_reverse = get_fqdn_ip_public_reverse()
+    print("FQDN: %s" % fqdn)
+    print("IPv4: %s" % addr)
+    print("IPv4 is public? %s" % public)
+    matchstr = "match" if fqdn == fqdn_reverse else "mismatch"
+    print("Reverse FQDN: %s (%s)" % (fqdn_reverse, matchstr))
+
+    return public and fqdn == fqdn_reverse
+
+if __name__ == '__main__':
+    sys.exit(not main())
+


### PR DESCRIPTION
The `bin/network-hostname-ip-check` symlink can be used as a stand-alone script to check the network preconditions for sending an email.

The conditions are:
 - the fqdn of the hostname maps to an IPv4 address that is not in a local or private range
 - the fqdn of the reverse lookup for that IP address matches the original hostname fqdn

The `src/net_name_addr_utils.py` script can also be used as a library; and `osg-notify` now imports it to use these network function checks.