### PR TITLE
handle net ifaces with no IPv4 addrs (SOFTWARE-3389)

### DIFF
--- a/src/net_name_addr_utils.py
+++ b/src/net_name_addr_utils.py
@@ -72,7 +72,8 @@ def setunion(sets):
 
 def get_iface_ipv4_addrs():
     net_ifaces = get_network_interfaces('*')
-    return dict( (x.name, x.addresses[AF_INET]) for x in net_ifaces )
+    return dict( (x.name, x.addresses[AF_INET]) for x in net_ifaces
+                                                 if AF_INET in x.addresses )
 
 def print_net_info(info):
     print("FQDN: %s" % info.fqdn)


### PR DESCRIPTION
This was raising a KeyError for net interfaces that didn't have IPv4 addrs (ie, `AF_INET`).

So, just filter for the ones that do have that key.

Zalek reported the bug and confirmed that this fixed it for him.