### PR TITLE
Update contacts and machine description

### DIFF
--- a/topology/Syracuse University/SUGWG/SU-SUGAR.yaml
+++ b/topology/Syracuse University/SUGWG/SU-SUGAR.yaml
@@ -8,30 +8,39 @@ Resources:
     ContactLists:
       Administrative Contact:
         Primary:
-          ID: 547c65a6ed5e9e755c023418a47b8b92e88f0523
-          Name: Peter Couvares
-        Secondary:
           ID: 033f0473623bf4d7957155915d39e59e25c29649
           Name: Duncan Brown
+        Secondary:
+          ID: c6023fb07e902f43edffdbaab50d7a13e32ae55e
+          Name: Larne Pekowsky
       Resource Report Contact:
         Primary:
-          ID: 033f0473623bf4d7957155915d39e59e25c29649
-          Name: Duncan Brown
-        Tertiary:
+          ID: c6023fb07e902f43edffdbaab50d7a13e32ae55e
+          Name: Larne Pekowsky
+        Secondary:
           ID: f2f9da2faec208f2e3bfa42d5f9b4c20b1a7c525
           Name: Richard Ameele
+        Tertiary:
+          ID: 033f0473623bf4d7957155915d39e59e25c29649
+          Name: Duncan Brown
       Security Contact:
         Primary:
-          ID: 547c65a6ed5e9e755c023418a47b8b92e88f0523
-          Name: Peter Couvares
+          ID: c6023fb07e902f43edffdbaab50d7a13e32ae55e
+          Name: Larne Pekowsky
         Secondary:
+          ID: f2f9da2faec208f2e3bfa42d5f9b4c20b1a7c525
+          Name: Richard Ameele
+        Tertiary:
           ID: 033f0473623bf4d7957155915d39e59e25c29649
           Name: Duncan Brown
       Submitter Contact:
         Primary:
-          ID: 547c65a6ed5e9e755c023418a47b8b92e88f0523
-          Name: Peter Couvares
-    Description: Sugar cluster submit node for LIGO.
+          ID: 033f0473623bf4d7957155915d39e59e25c29649
+          Name: Duncan Brown
+        Primary:
+          ID: c6023fb07e902f43edffdbaab50d7a13e32ae55e
+          Name: Larne Pekowsky
+    Description: Syracuse University Gravitational Wave Group OSG Submit Node
     Disable: false
     FQDN: sugwg-scitokens.phy.syr.edu
     ID: 771
@@ -47,33 +56,39 @@ Resources:
     ContactLists:
       Administrative Contact:
         Primary:
+          ID: 033f0473623bf4d7957155915d39e59e25c29649
+          Name: Duncan Brown
+        Secondary:
+          ID: c6023fb07e902f43edffdbaab50d7a13e32ae55e
+          Name: Larne Pekowsky
+      Resource Report Contact:
+        Primary:
           ID: c6023fb07e902f43edffdbaab50d7a13e32ae55e
           Name: Larne Pekowsky
         Secondary:
-          ID: 033f0473623bf4d7957155915d39e59e25c29649
-          Name: Duncan Brown
-      Resource Report Contact:
-        Primary:
-          ID: 033f0473623bf4d7957155915d39e59e25c29649
-          Name: Duncan Brown
-        Secondary:
-          ID: 547c65a6ed5e9e755c023418a47b8b92e88f0523
-          Name: Peter Couvares
-        Tertiary:
           ID: f2f9da2faec208f2e3bfa42d5f9b4c20b1a7c525
           Name: Richard Ameele
+        Tertiary:
+          ID: 033f0473623bf4d7957155915d39e59e25c29649
+          Name: Duncan Brown
       Security Contact:
         Primary:
           ID: c6023fb07e902f43edffdbaab50d7a13e32ae55e
           Name: Larne Pekowsky
         Secondary:
+          ID: f2f9da2faec208f2e3bfa42d5f9b4c20b1a7c525
+          Name: Richard Ameele
+        Tertiary:
           ID: 033f0473623bf4d7957155915d39e59e25c29649
           Name: Duncan Brown
       Submitter Contact:
         Primary:
+          ID: 033f0473623bf4d7957155915d39e59e25c29649
+          Name: Duncan Brown
+        Primary:
           ID: c6023fb07e902f43edffdbaab50d7a13e32ae55e
           Name: Larne Pekowsky
-    Description: SL7-Based SUGWG cluster submit node for LIGO.
+    Description: Syracuse University Gravitational Wave Group OSG Submit Node
     Disable: false
     FQDN: sugwg-osg.phy.syr.edu
     ID: 822
@@ -89,33 +104,39 @@ Resources:
     ContactLists:
       Administrative Contact:
         Primary:
-          ID: c6023fb07e902f43edffdbaab50d7a13e32ae55e
-          Name: Larne Pekowsky
-        Secondary:
           ID: 033f0473623bf4d7957155915d39e59e25c29649
           Name: Duncan Brown
+        Secondary:
+          ID: c6023fb07e902f43edffdbaab50d7a13e32ae55e
+          Name: Larne Pekowsky
       Resource Report Contact:
         Primary:
           ID: c6023fb07e902f43edffdbaab50d7a13e32ae55e
           Name: Larne Pekowsky
         Secondary:
-          ID: 547c65a6ed5e9e755c023418a47b8b92e88f0523
-          Name: Peter Couvares
-        Tertiary:
           ID: f2f9da2faec208f2e3bfa42d5f9b4c20b1a7c525
           Name: Richard Ameele
+        Tertiary:
+          ID: 033f0473623bf4d7957155915d39e59e25c29649
+          Name: Duncan Brown
       Security Contact:
         Primary:
           ID: c6023fb07e902f43edffdbaab50d7a13e32ae55e
           Name: Larne Pekowsky
         Secondary:
+          ID: f2f9da2faec208f2e3bfa42d5f9b4c20b1a7c525
+          Name: Richard Ameele
+        Tertiary:
           ID: 033f0473623bf4d7957155915d39e59e25c29649
           Name: Duncan Brown
       Submitter Contact:
         Primary:
+          ID: 033f0473623bf4d7957155915d39e59e25c29649
+          Name: Duncan Brown
+        Primary:
           ID: c6023fb07e902f43edffdbaab50d7a13e32ae55e
           Name: Larne Pekowsky
-    Description: Second SL7-Based SUGWG cluster submit node for LIGO.
+    Description: Syracuse University Gravitational Wave Group OSG Submit Node
     Disable: false
     FQDN: sugwg-condor.phy.syr.edu
     ID: 898


### PR DESCRIPTION
These nodes are no longer used by the LIGO Scientific Collaboration for OSG submission, so I have updated the description to remove mention of LIGO and removed Peter Couvares from the contacts.