### PR TITLE
Lower CIT_CMS_T2 downtime till 2pm pst

### DIFF
--- a/topology/California Institute of Technology/Caltech CMS Tier2/CIT_CMS_T2_downtime.yaml
+++ b/topology/California Institute of Technology/Caltech CMS Tier2/CIT_CMS_T2_downtime.yaml
@@ -117,7 +117,7 @@
   Description: Networking issues after switch replacement
   Severity: Severe
   StartTime: Sep 12, 2018 21:00 -0700
-  EndTime: Sep 13, 2018 21:00 -0700
+  EndTime: Sep 13, 2018 14:00 -0700
   CreatedTime: Sep 12, 2018 21:00 -0700
   ResourceName: CIT_CMS_SE
   Services:
@@ -129,7 +129,7 @@
   Description: Networking issues after switch replacement
   Severity: Severe
   StartTime: Sep 12, 2018 21:00 -0700
-  EndTime: Sep 13, 2018 21:00 -0700
+  EndTime: Sep 13, 2018 14:00 -0700
   CreatedTime: Sep 12, 2018 21:00 -0700
   ResourceName: CIT_CMS_T2B
   Services:
@@ -141,7 +141,7 @@
   Description: Networking issues after switch replacement
   Severity: Severe
   StartTime: Sep 12, 2018 21:00 -0700
-  EndTime: Sep 13, 2018 21:00 -0700
+  EndTime: Sep 13, 2018 14:00 -0700
   CreatedTime: Sep 12, 2018 21:00 -0700
   ResourceName: CIT_CMS_T2_Squid
   Services:
@@ -153,7 +153,7 @@
   Description: Networking issues after switch replacement
   Severity: Severe
   StartTime: Sep 12, 2018 21:00 -0700
-  EndTime: Sep 13, 2018 21:00 -0700
+  EndTime: Sep 13, 2018 14:00 -0700
   CreatedTime: Sep 12, 2018 21:00 -0700
   ResourceName: CIT_CMS_T2_2_Squid
   Services:
@@ -165,7 +165,7 @@
   Description: Networking issues after switch replacement
   Severity: Severe
   StartTime: Sep 12, 2018 21:00 -0700
-  EndTime: Sep 13, 2018 21:00 -0700
+  EndTime: Sep 13, 2018 14:00 -0700
   CreatedTime: Sep 12, 2018 21:00 -0700
   ResourceName: CIT_HEP_CE
   Services:


### PR DESCRIPTION
All services seem to be back up. I set this downtime to expire in 1h from now on, just to give a bit room for all systems to propagate this.