### PR TITLE
Don't put a number in template-SITE.yaml because it confuses next_site_id

### DIFF
--- a/template-SITE.yaml
+++ b/template-SITE.yaml
@@ -5,7 +5,7 @@ Description: Computer Science building of the University of XYZ
 
 # If you have an up-to-date local git clone, fill ID with the output from `bin/next_site_id`
 # Otherwise, leave it blank and we will fill in the appropriate value for you.
-ID: 12345
+ID: <ID>
 
 # AddressLine1 is the street address of the site
 AddressLine1: 1234 Fifth St


### PR DESCRIPTION
If someone copies template-SITE.yaml into a site's SITE.yaml and runs next_site_id, next_site_id will see "12345" and go "that's the largest, next one must be 12346". Let's just put a placeholder in the template.