### PR TITLE
Display placeholder for missing GH account & add who to contact for fixing info

### DIFF
--- a/src/templates/contacts.html.j2
+++ b/src/templates/contacts.html.j2
@@ -34,7 +34,7 @@ OSG Contacts
           {{ user.Profile|replace("\n", "<br>") }}
           <br>
           {%- else -%}
-          <span class="text-danger">(no profile)</span>
+          <span class="text-danger" data-toggle="tooltip" title="Mail help@opensciencegrid.org to update">(no profile)</span>
           {%- endif %}
         </p>
       </div>

--- a/src/templates/contacts.html.j2
+++ b/src/templates/contacts.html.j2
@@ -1,3 +1,4 @@
+{% set want_js = true %}
 {% extends "base.html.j2" %}
 {% block title -%}
 OSG Contacts
@@ -43,7 +44,7 @@ OSG Contacts
           {% if user.GitHub -%}
           <a href="https://github.com/{{user.GitHub}}">{{ user.GitHub }}</a>
           {%- else -%}
-          <span class="text-danger">(none)</span>
+          <span class="text-danger" data-toggle="tooltip" title="Mail help@opensciencegrid.org to register">(none)</span>
           {%- endif %}
         </div>
       </div>
@@ -75,4 +76,10 @@ OSG Contacts
 {% endfor -%}{# user in users #}
 </div>
 {% endblock %}
-
+{% block last %}
+<script>
+$(function () {
+  $('[data-toggle="tooltip"]').tooltip()
+})
+</script>
+{% endblock %}

--- a/src/templates/contacts.html.j2
+++ b/src/templates/contacts.html.j2
@@ -11,6 +11,7 @@ OSG Contacts
   {% endif %}
   <div class="alert alert-info" role="alert">
     Profile information is provided by the user and may be out of date.
+    To update your information, please contact <a href="mailto:help@opensciencegrid.org">help@opensciencegrid.org</a>.
   </div>
 </div>
 <div class="container">
@@ -36,12 +37,16 @@ OSG Contacts
           {%- endif %}
         </p>
       </div>
-      {% if user.GitHub -%}
       <div class="row">
         <div class="col-sm-3"><span class="font-weight-bold">GitHub:</span></div>
-        <div class="col-sm"><a href="https://github.com/{{user.GitHub}}">{{ user.GitHub }}</a></div>
+        <div class="col-sm">
+          {% if user.GitHub -%}
+          <a href="https://github.com/{{user.GitHub}}">{{ user.GitHub }}</a>
+          {%- else -%}
+          <span class="text-danger">(none)</span>
+          {%- endif %}
+        </div>
       </div>
-      {%- endif %}
       {% if authorized -%}
         <div class="row">
           <div class="col-sm-3"><span class="font-weight-bold">Primary Email:</span></div>


### PR DESCRIPTION
Hopefully the "GitHub: (none)" in people's contact info will serve as a hint to get people to send us their info?