### PR TITLE
Schedule downtime to reinstall cit-gatekeeper

### DIFF
--- a/topology/California Institute of Technology/Caltech CMS Tier2/CIT_CMS_T2_downtime.yaml
+++ b/topology/California Institute of Technology/Caltech CMS Tier2/CIT_CMS_T2_downtime.yaml
@@ -232,3 +232,14 @@
   - GridFtp
 # ---------------------------------------------------------
 
+- Class: SCHEDULED
+  ID: 47440265
+  Description: reinstalling CE
+  Severity: Outage
+  StartTime: Oct 18, 2018 21:40 +0000
+  EndTime: Oct 19, 2018 02:00 +0000
+  CreatedTime: Oct 16, 2018 21:40 +0000
+  ResourceName: CIT_CMS_T2
+  Services:
+  - CE
+# ---------------------------------------------------------


### PR DESCRIPTION
For CentOS6 -> CentOS7 reinstallation. @juztas