### PR TITLE
add github pull_request webhook handler to app.py (SOFTWARE-3325)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -7,6 +7,8 @@ from flask import Flask, Response, request, render_template
 import logging
 import os
 import re
+import subprocess
+from subprocess import PIPE
 import sys
 import urllib.parse
 
@@ -55,6 +57,7 @@ if not app.config.get("SECRET_KEY"):
 
 global_data = GlobalData(app.config)
 
+src_dir = os.path.abspath(os.path.dirname(__file__))
 
 def _fix_unicode(text):
     """Convert a partial unicode string to full unicode"""
@@ -193,6 +196,87 @@ def generate_downtime():
                        edit_url=edit_url, site_dir_url=site_dir_url,
                        new_url=new_url)
 
+
+@app.route("/pull_request_hook", methods=["POST"])
+def pull_request_hook():
+    event = request.headers.get('X-GitHub-Event')
+    if event == "ping":
+        return Response('Pong')
+    elif event != "pull_request":
+        return Response("Wrong event type", status=400)
+
+    payload = request.get_json()
+    action = payload['action']
+    if action not in ("opened", "edited", "reopened", "synchronize"):
+        return Response("Not Interested")
+    # status=204 : No Content
+
+    sender     = payload['sender']['login']
+
+    head_sha   = payload['pull_request']['head']['sha']
+    head_label = payload['pull_request']['head']['label']
+    head_ref   = payload['pull_request']['head']['ref']
+
+    base_sha   = payload['pull_request']['base']['sha']
+    base_label = payload['pull_request']['base']['label']
+    base_ref   = payload['pull_request']['base']['ref']
+
+    pull_num   = payload['pull_request']['number']
+    pull_url   = payload['pull_request']['html_url']
+
+    pull_ref   = "pull/{pull_num}/head".format(**locals())
+
+    # make sure data repo contains relevant commits
+    stdout, stderr, ret = fetch_data_ref(base_ref, pull_ref)
+
+    if ret == 0:
+        script = src_dir + "/tests/automerge_downtime_ok.py"
+        cmd = [script, base_sha, head_sha, sender]
+        stdout, stderr, ret = runcmd(cmd, cwd=global_data.topology_data_dir)
+
+    OK = "Yes" if ret == 0 else "No"
+
+    subject = "Pull Request {pull_url} {action}".format(**locals())
+
+    out = """\
+In Pull Request: {pull_url}
+GitHub User '{sender}' wants to merge branch {head_label}
+        (at commit {head_sha})
+into {base_label}
+        (at commit {base_sha})
+
+Eligible for downtime automerge? {OK}
+
+automerge_downtime script output:
+---
+{stdout}
+---
+{stderr}
+---
+""".format(**locals())
+
+    recipients = ["edquist@cs.wisc.edu"]
+    _,_,_ = send_mailx_email(subject, out, recipients)
+
+    return Response(out)
+
+
+def runcmd(cmd, input=None, **kw):
+    if input is None:
+        stdin = None
+    else:
+        stdin = PIPE
+    p = subprocess.Popen(cmd, stdout=PIPE, stderr=PIPE, stdin=stdin,
+                         encoding='utf-8', **kw)
+    stdout, stderr = p.communicate(input)
+    return stdout, stderr, p.returncode
+
+def fetch_data_ref(*refs):
+    return runcmd(['git', 'fetch', 'origin'] + list(refs),
+                  cwd=global_data.topology_data_dir)
+
+def send_mailx_email(subject, body, recipients):
+    return runcmd(["mailx", "-s", subject] + recipients, input=body)
 
 def _make_choices(iterable, select_one=False):
     c = [(_fix_unicode(x), _fix_unicode(x)) for x in sorted(iterable)]

--- a/src/app.py
+++ b/src/app.py
@@ -255,7 +255,7 @@ automerge_downtime script output:
 ---
 """.format(**locals())
 
-    recipients = ["edquist@cs.wisc.edu"]
+    recipients = [ x + "@cs.wisc.edu" for x in ("edquist", "matyas", "blin") ]
     _,_,_ = send_mailx_email(subject, out, recipients)
 
     return Response(out)

--- a/src/tests/automerge_downtime_ok.py
+++ b/src/tests/automerge_downtime_ok.py
@@ -65,7 +65,9 @@ def main(args):
                                               resources_affected, contact)
 
     print_errors(errors)
-    sys.exit(len(errors) > 0)
+    return ( 0 if len(errors) == 0   # all checks pass (only DT files modified)
+             else 1 if len(DTs) > 0  # DT file(s) modified, not all checks pass
+             else 2 )                # no DT files modified
 
 def insist(cond):
     if not cond:
@@ -160,5 +162,5 @@ def get_gh_contact(ghuser):
     return gh_contacts[0] if len(gh_contacts) == 1 else None
 
 if __name__ == '__main__':
-    main(sys.argv[1:])
+    sys.exit(main(sys.argv[1:]))
 


### PR DESCRIPTION
This is a squash of edquist:wip/SOFTWARE-3325.downtime-automerge-webhook,
which contains the original history of this webhook.

I'll reference one commit here below from the many squashed, as we may
want to go back to using `pull/N/merge` / `merge_commit_sha`, if we only
want to allow auto-merging the initial PR (action="opened"), rather than
on every push to the head branch (action="synchronize").

---

commit 547d418020fcf4dca30b9fd9915b9dd172b7a9a1
Author: Carl Edquist
Date:   Tue Oct 16 18:38:19 2018 -0500

    use pull/N/head instead of merge_commit_sha (SOFTWARE-3325)

    apparently pull/N/merge and merge_commit_sha only get updated when the
    PR is initially created, and then upon explicit api request, which then
    requires further polling until the mergeable attribute is set ...

    instead we'll just do a separate check that the pull commit contains the
    base commit, and we now explicitly need to fetch both refs.

    https://developer.github.com/enterprise/2.1/changes/2013-04-25-deprecating-merge-commit-sha/

    https://developer.github.com/v3/git/#checking-mergeability-of-pull-requests