### PR TITLE
Fixes for osg-topology and topology_utils (SOFTWARE-3446)

### DIFF
--- a/bin/osg-notify
+++ b/bin/osg-notify
@@ -6,6 +6,8 @@ A simple tool for generating notification emails to the OSG
 """
 from __future__ import print_function
 
+import os
+import sys
 import getpass
 import smtplib
 import argparse
@@ -14,6 +16,10 @@ import email.mime.text
 import email.mime.multipart
 
 import gnupg
+
+if __name__ == "__main__" and __package__ is None:
+    _parent = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path.append(_parent + "/src")
 
 import topology_utils
 import net_name_addr_utils

--- a/bin/osg-topology
+++ b/bin/osg-topology
@@ -12,6 +12,10 @@ import sys
 import fnmatch
 import argparse
 
+if __name__ == "__main__" and __package__ is None:
+    _parent = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path.append(_parent + "/src")
+
 import topology_utils
 
 

--- a/src/topology_utils.py
+++ b/src/topology_utils.py
@@ -36,6 +36,7 @@ def get_auth_session(args):
         key = args.key
 
     session = requests.Session()
+    session.headers.update({'Cache-Control': 'no-cache, no-store, must-revalidate'})
 
     if os.path.exists(cert):
         session.cert = cert

--- a/src/topology_utils.py
+++ b/src/topology_utils.py
@@ -36,7 +36,6 @@ def get_auth_session(args):
         key = args.key
 
     session = requests.Session()
-    session.headers.update({'Cache-Control': 'no-cache, no-store, must-revalidate'})
 
     if os.path.exists(cert):
         session.cert = cert

--- a/src/topology_utils.py
+++ b/src/topology_utils.py
@@ -81,6 +81,9 @@ def get_vo_map(args, session=None):
     Generate a dictionary mapping from the VO name (key) to the
     VO ID (value).
     """
+    old_no_proxy = os.environ.pop('no_proxy', None)
+    os.environ['no_proxy'] = '.opensciencegrid.org'
+
     url = update_url_hostname("https://my.opensciencegrid.org/vosummary"
                               "/xml?all_vos=on&active_value=1", args)
     if session is None:
@@ -88,6 +91,11 @@ def get_vo_map(args, session=None):
             response = session.get(url)
     else:
         response = session.get(url)
+
+    if old_no_proxy is not None:
+        os.environ['no_proxy'] = old_no_proxy
+    else:
+        del os.environ['no_proxy']
 
     if response.status_code != requests.codes.ok:
         raise Exception("MyOSG request failed (status %d): %s" % \
@@ -163,12 +171,20 @@ def get_contacts(args, urltype, roottype):
     """
     Get one type of contacts for OSG.
     """
+    old_no_proxy = os.environ.pop('no_proxy', None)
+    os.environ['no_proxy'] = '.opensciencegrid.org'
+
     base_url = "https://my.opensciencegrid.org/" + urltype + "summary/xml?" \
                "&active=on&active_value=1&disable=on&disable_value=0"
     with get_auth_session(args) as session:
         url = mangle_url(base_url, args, session)
         #print(url)
         response = session.get(url)
+
+    if old_no_proxy is not None:
+        os.environ['no_proxy'] = old_no_proxy
+    else:
+        del os.environ['no_proxy']
 
     if response.status_code != requests.codes.ok:
         print("MyOSG request failed (status %d): %s" % \


### PR DESCRIPTION
- Add the `src` directory to `sys.path` so `bin/osg-topology` finds `topology_utils`
- Never cache the results so we don't get too little info when following up an unauth query with an auth query (or worse, too much info when following up an auth query with an unauth query)