### PR TITLE
Remove extraneous contact types from AGLT2

### DIFF
--- a/topology/University of Michigan/AGLT2/AGLT2.yaml
+++ b/topology/University of Michigan/AGLT2/AGLT2.yaml
@@ -10,14 +10,6 @@ Resources:
         Primary:
           ID: a833f94ad3840fe779702409c6b778d79aaed76f
           Name: Shawn McKee
-      Miscellaneous Contact:
-        Primary:
-          ID: c605a5cc0041b50a01473a4195ff6cbbe1743886
-          Name: Bob Ball
-      Resource Report Contact:
-        Primary:
-          ID: ef1e31e182fce56d329c05c9a7cdeb11a572d9f4
-          Name: Benjeman J. Meekhof
       Security Contact:
         Primary:
           ID: a833f94ad3840fe779702409c6b778d79aaed76f
@@ -35,20 +27,6 @@ Resources:
     Active: true
     ContactLists:
       Administrative Contact:
-        Primary:
-          ID: a833f94ad3840fe779702409c6b778d79aaed76f
-          Name: Shawn McKee
-        Secondary:
-          ID: c605a5cc0041b50a01473a4195ff6cbbe1743886
-          Name: Bob Ball
-      Miscellaneous Contact:
-        Primary:
-          ID: a833f94ad3840fe779702409c6b778d79aaed76f
-          Name: Shawn McKee
-        Secondary:
-          ID: c605a5cc0041b50a01473a4195ff6cbbe1743886
-          Name: Bob Ball
-      Resource Report Contact:
         Primary:
           ID: a833f94ad3840fe779702409c6b778d79aaed76f
           Name: Shawn McKee
@@ -92,20 +70,6 @@ Resources:
         Secondary:
           ID: c605a5cc0041b50a01473a4195ff6cbbe1743886
           Name: Bob Ball
-      Miscellaneous Contact:
-        Primary:
-          ID: a833f94ad3840fe779702409c6b778d79aaed76f
-          Name: Shawn McKee
-      Resource Report Contact:
-        Primary:
-          ID: ef1e31e182fce56d329c05c9a7cdeb11a572d9f4
-          Name: Benjeman J. Meekhof
-        Secondary:
-          ID: a833f94ad3840fe779702409c6b778d79aaed76f
-          Name: Shawn McKee
-        Tertiary:
-          ID: c605a5cc0041b50a01473a4195ff6cbbe1743886
-          Name: Bob Ball
       Security Contact:
         Primary:
           ID: c605a5cc0041b50a01473a4195ff6cbbe1743886
@@ -142,20 +106,6 @@ Resources:
         Primary:
           ID: c605a5cc0041b50a01473a4195ff6cbbe1743886
           Name: Bob Ball
-      Miscellaneous Contact:
-        Primary:
-          ID: c605a5cc0041b50a01473a4195ff6cbbe1743886
-          Name: Bob Ball
-        Secondary:
-          ID: a833f94ad3840fe779702409c6b778d79aaed76f
-          Name: Shawn McKee
-      Resource Report Contact:
-        Primary:
-          ID: c605a5cc0041b50a01473a4195ff6cbbe1743886
-          Name: Bob Ball
-        Secondary:
-          ID: a833f94ad3840fe779702409c6b778d79aaed76f
-          Name: Shawn McKee
       Security Contact:
         Primary:
           ID: c605a5cc0041b50a01473a4195ff6cbbe1743886
@@ -187,20 +137,6 @@ Resources:
     Active: true
     ContactLists:
       Administrative Contact:
-        Primary:
-          ID: c605a5cc0041b50a01473a4195ff6cbbe1743886
-          Name: Bob Ball
-        Secondary:
-          ID: a833f94ad3840fe779702409c6b778d79aaed76f
-          Name: Shawn McKee
-      Miscellaneous Contact:
-        Primary:
-          ID: c605a5cc0041b50a01473a4195ff6cbbe1743886
-          Name: Bob Ball
-        Secondary:
-          ID: a833f94ad3840fe779702409c6b778d79aaed76f
-          Name: Shawn McKee
-      Resource Report Contact:
         Primary:
           ID: c605a5cc0041b50a01473a4195ff6cbbe1743886
           Name: Bob Ball

--- a/topology/University of Michigan/AGLT2/AGLT2_TEST.yaml
+++ b/topology/University of Michigan/AGLT2/AGLT2_TEST.yaml
@@ -13,17 +13,6 @@ Resources:
         Secondary:
           ID: a833f94ad3840fe779702409c6b778d79aaed76f
           Name: Shawn McKee
-      Miscellaneous Contact:
-        Primary:
-          ID: c605a5cc0041b50a01473a4195ff6cbbe1743886
-          Name: Bob Ball
-      Resource Report Contact:
-        Primary:
-          ID: c605a5cc0041b50a01473a4195ff6cbbe1743886
-          Name: Bob Ball
-        Secondary:
-          ID: a833f94ad3840fe779702409c6b778d79aaed76f
-          Name: Shawn McKee
       Security Contact:
         Primary:
           ID: c605a5cc0041b50a01473a4195ff6cbbe1743886
@@ -65,13 +54,6 @@ Resources:
         Secondary:
           ID: a833f94ad3840fe779702409c6b778d79aaed76f
           Name: Shawn McKee
-      Resource Report Contact:
-        Primary:
-          ID: fe2ecaf4ad4a0923d1be605ad55a8ca71f67eb66
-          Name: Philippe Laurens
-        Secondary:
-          ID: a833f94ad3840fe779702409c6b778d79aaed76f
-          Name: Shawn McKee
       Security Contact:
         Primary:
           ID: fe2ecaf4ad4a0923d1be605ad55a8ca71f67eb66
@@ -95,13 +77,6 @@ Resources:
     Active: true
     ContactLists:
       Administrative Contact:
-        Primary:
-          ID: fe2ecaf4ad4a0923d1be605ad55a8ca71f67eb66
-          Name: Philippe Laurens
-        Secondary:
-          ID: a833f94ad3840fe779702409c6b778d79aaed76f
-          Name: Shawn McKee
-      Resource Report Contact:
         Primary:
           ID: fe2ecaf4ad4a0923d1be605ad55a8ca71f67eb66
           Name: Philippe Laurens
@@ -134,10 +109,6 @@ Resources:
         Primary:
           ID: a833f94ad3840fe779702409c6b778d79aaed76f
           Name: Shawn McKee
-      Resource Report Contact:
-        Primary:
-          ID: a833f94ad3840fe779702409c6b778d79aaed76f
-          Name: Shawn McKee
       Security Contact:
         Primary:
           ID: a833f94ad3840fe779702409c6b778d79aaed76f
@@ -157,10 +128,6 @@ Resources:
     Active: true
     ContactLists:
       Administrative Contact:
-        Primary:
-          ID: a833f94ad3840fe779702409c6b778d79aaed76f
-          Name: Shawn McKee
-      Resource Report Contact:
         Primary:
           ID: a833f94ad3840fe779702409c6b778d79aaed76f
           Name: Shawn McKee


### PR DESCRIPTION
I plan on asking Wenjing Wu to add her contact info to the relevant resources at AGLT2 so I wanted to clean up the unnecessary contact types first.