### PR TITLE
Revert "Use a wrapper around yaml.safe_load instead of anymarkup so I get file name info for parse errors"

### DIFF
--- a/src/webapp/common.py
+++ b/src/webapp/common.py
@@ -9,7 +9,6 @@ import sys
 from typing import Dict, List, Union, AnyStr
 
 import xmltodict
-import yaml
 
 MaybeOrderedDict = Union[None, OrderedDict]
 
@@ -200,16 +199,3 @@ def gen_id(instr: AnyStr, digits, minimum=1, hashfn=hashlib.md5) -> int:
     instr_b = instr if isinstance(instr, bytes) else instr.encode("utf-8", "surrogateescape")
     mod = (10 ** digits) - minimum
     return minimum + (int(hashfn(instr_b).hexdigest(), 16) % mod)
-
-
-def load_yaml_file(filename) -> Dict:
-    """Load a yaml file (wrapper around yaml.safe_load() because it does not
-    report the filename in which an error occurred.
-
-    """
-    try:
-        with open(filename) as stream:
-            return yaml.safe_load(stream)
-    except yaml.YAMLError as e:
-        log.error("YAML error in %s: %s", filename, e)
-        raise

--- a/src/webapp/contacts_reader.py
+++ b/src/webapp/contacts_reader.py
@@ -6,11 +6,13 @@ import os
 import sys
 from typing import Dict
 
+import anymarkup
+
 # thanks stackoverflow
 if __name__ == "__main__" and __package__ is None:
     sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from webapp.common import MaybeOrderedDict, to_xml, MISCUSER_SCHEMA_URL, load_yaml_file
+from webapp.common import MaybeOrderedDict, to_xml, MISCUSER_SCHEMA_URL
 
 
 log = getLogger(__name__)
@@ -113,7 +115,7 @@ class ContactsData(object):
 
 
 def get_contacts_data(infile) -> ContactsData:
-    return ContactsData(load_yaml_file(infile))
+    return ContactsData(anymarkup.parse_file(infile))
 
 
 def main(argv):

--- a/src/webapp/project_reader.py
+++ b/src/webapp/project_reader.py
@@ -1,14 +1,10 @@
-#!/usr/bin/env python3
 from argparse import ArgumentParser
 from collections import OrderedDict
 
 import os
-import sys
 
-if __name__ == "__main__" and __package__ is None:
-    sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import anymarkup
 
-from webapp.common import load_yaml_file, to_xml
 
 
 def get_projects(indir="../projects"):
@@ -18,7 +14,7 @@ def get_projects(indir="../projects"):
     for file in os.listdir(indir):
         project = OrderedDict.fromkeys(["ID", "Name", "Description", "PIName", "Organization", "Department",
                                         "FieldOfScience", "Sponsor"])
-        project.update(load_yaml_file(os.path.join(indir, file)))
+        project.update(anymarkup.parse_file(os.path.join(indir, file)))
         projects.append(project)
 
     to_output["Projects"]["Project"] = projects
@@ -28,7 +24,7 @@ def get_projects(indir="../projects"):
 
 def get_projects_xml(indir="../projects"):
     """Returns the serialized XML as a string"""
-    return to_xml(get_projects(indir))
+    return anymarkup.serialize(get_projects(indir), 'xml').decode()
 
 
 if __name__ == "__main__":

--- a/src/webapp/rg_reader.py
+++ b/src/webapp/rg_reader.py
@@ -16,8 +16,10 @@ Usage as a module
 where the return value `xml` is a string.
 
 """
+import argparse
 from argparse import ArgumentParser
 
+import anymarkup
 import os
 import pprint
 import sys
@@ -27,7 +29,7 @@ from pathlib import Path
 if __name__ == "__main__" and __package__ is None:
     sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from webapp.common import ensure_list, to_xml, Filters, load_yaml_file
+from webapp.common import ensure_list, to_xml, Filters
 from webapp.contacts_reader import get_contacts_data
 from webapp.topology import CommonData, Topology
 
@@ -59,18 +61,18 @@ def get_rgsummary_rgdowntime(indir, contacts_file=None, authorized=False):
 
 def get_topology(indir="../topology", contacts_data=None):
     root = Path(indir)
-    support_centers = load_yaml_file(root / "support-centers.yaml")
-    service_types = load_yaml_file(root / "services.yaml")
+    support_centers = anymarkup.parse_file(root / "support-centers.yaml")
+    service_types = anymarkup.parse_file(root / "services.yaml")
     tables = CommonData(contacts=contacts_data, service_types=service_types, support_centers=support_centers)
     topology = Topology(tables)
 
     for facility_path in root.glob("*/FACILITY.yaml"):
         name = facility_path.parts[-2]
-        id_ = load_yaml_file(facility_path)["ID"]
+        id_ = anymarkup.parse_file(facility_path)["ID"]
         topology.add_facility(name, id_)
     for site_path in root.glob("*/*/SITE.yaml"):
         facility, name = site_path.parts[-3:-1]
-        site_info = load_yaml_file(site_path)
+        site_info = anymarkup.parse_file(site_path)
         id_ = site_info["ID"]
         topology.add_site(facility, name, id_, site_info)
     for yaml_path in root.glob("*/*/*.yaml"):
@@ -79,11 +81,11 @@ def get_topology(indir="../topology", contacts_data=None):
         if name.endswith("_downtime.yaml"): continue
 
         name = name.replace(".yaml", "")
-        rg = load_yaml_file(yaml_path)
+        rg = anymarkup.parse_file(yaml_path)
         downtime_yaml_path = yaml_path.with_name(name + "_downtime.yaml")
         downtimes = None
         if downtime_yaml_path.exists():
-            downtimes = ensure_list(load_yaml_file(downtime_yaml_path))
+            downtimes = ensure_list(anymarkup.parse_file(downtime_yaml_path))
 
         topology.add_rg(facility, site, name, rg)
         if downtimes:

--- a/src/webapp/vo_reader.py
+++ b/src/webapp/vo_reader.py
@@ -1,26 +1,27 @@
-#!/usr/bin/env python3
-from argparse import ArgumentParser
+from argparse import ArgumentParser, FileType
 import os
 import pprint
 import sys
+
+import anymarkup
 
 # thanks stackoverflow
 if __name__ == "__main__" and __package__ is None:
     sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from webapp.common import load_yaml_file, to_xml
+from webapp.common import to_xml
 from webapp.contacts_reader import get_contacts_data
 from webapp.vos_data import VOsData
 
 
 def get_vos_data(indir, contacts_data) -> VOsData:
-    reporting_groups_data = load_yaml_file(os.path.join(indir, "REPORTING_GROUPS.yaml"))
+    reporting_groups_data = anymarkup.parse_file(os.path.join(indir, "REPORTING_GROUPS.yaml"))
     vos_data = VOsData(contacts_data=contacts_data, reporting_groups_data=reporting_groups_data)
     for file in os.listdir(indir):
         if file == "REPORTING_GROUPS.yaml": continue
         if not file.endswith(".yaml"): continue
         name = file[:-5]
-        data = load_yaml_file(os.path.join(indir, file))
+        data = anymarkup.parse_file(os.path.join(indir, file))
         try:
             vos_data.add_vo(name, data)
         except Exception:


### PR DESCRIPTION
Reverts opensciencegrid/topology#261