### PR TITLE
Sandhills resource at the University of Nebraska marked inactive

### DIFF
--- a/topology/University of Nebraska/Nebraska-Lincoln/Sandhills.yaml
+++ b/topology/University of Nebraska/Nebraska-Lincoln/Sandhills.yaml
@@ -4,7 +4,7 @@ GroupID: 230
 Production: true
 Resources:
   Sandhills:
-    Active: true
+    Active: false
     ContactLists:
       Administrative Contact:
         Primary:


### PR DESCRIPTION
The Sandhills cluster at the University of Nebraska has been retired and is no longer active.