### PR TITLE
Don't crash the webapp

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -64,7 +64,7 @@ if not app.config.get("SECRET_KEY"):
 if "LOGLEVEL" in app.config:
     app.logger.setLevel(app.config["LOGLEVEL"])
 
-global_data = GlobalData(app.config)
+global_data = GlobalData(app.config, strict=app.config.get("STRICT", app.debug))
 
 
 def _fix_unicode(text):

--- a/src/webapp/models.py
+++ b/src/webapp/models.py
@@ -99,7 +99,11 @@ class GlobalData:
         if self.contacts_data.should_update():
             ok = self._update_contacts_repo()
             if ok:
-                self.contacts_data.update(contacts_reader.get_contacts_data(self.contacts_file))
+                try:
+                    self.contacts_data.update(contacts_reader.get_contacts_data(self.contacts_file))
+                except Exception:
+                    log.exception("Failed to update contacts data")
+                    self.contacts_data.try_again()
             else:
                 self.contacts_data.try_again()
 
@@ -111,14 +115,21 @@ class GlobalData:
         """
         if self.dn_set.should_update():
             contacts_data = self.get_contacts_data()
-            self.dn_set.update(set(contacts_data.get_dns()))
+            try:
+                self.dn_set.update(set(contacts_data.get_dns()))
+            except Exception:
+                log.exception("Failed to update DNs")
         return self.dn_set.data
 
     def get_topology(self) -> Topology:
         if self.topology.should_update():
             ok = self._update_topology_repo()
             if ok:
-                self.topology.update(rg_reader.get_topology(self.topology_dir, self.get_contacts_data()))
+                try:
+                    self.topology.update(rg_reader.get_topology(self.topology_dir, self.get_contacts_data()))
+                except Exception:
+                    log.exception("Failed to update topology")
+                    self.topology.try_again()
             else:
                 self.topology.try_again()
 
@@ -128,7 +139,11 @@ class GlobalData:
         if self.vos_data.should_update():
             ok = self._update_topology_repo()
             if ok:
-                self.vos_data.update(vo_reader.get_vos_data(self.vos_dir, self.get_contacts_data()))
+                try:
+                    self.vos_data.update(vo_reader.get_vos_data(self.vos_dir, self.get_contacts_data()))
+                except Exception:
+                    log.exception("Failed to update VOs")
+                    self.vos_data.try_again()
             else:
                 self.vos_data.try_again()
 
@@ -138,7 +153,11 @@ class GlobalData:
         if self.projects.should_update():
             ok = self._update_topology_repo()
             if ok:
-                self.projects.update(project_reader.get_projects(self.projects_dir))
+                try:
+                    self.projects.update(project_reader.get_projects(self.projects_dir))
+                except Exception:
+                    log.exception("Failed to update projects")
+                    self.projects.try_again()
             else:
                 self.projects.try_again()
 

--- a/src/webapp/models.py
+++ b/src/webapp/models.py
@@ -126,6 +126,7 @@ class GlobalData:
                 if self.strict:
                     raise
                 log.exception("Failed to update DNs")
+                self.contacts_data.try_again()
         return self.dn_set.data
 
     def get_topology(self) -> Topology:

--- a/src/webapp/project_reader.py
+++ b/src/webapp/project_reader.py
@@ -32,7 +32,8 @@ def get_projects(indir="../projects", strict=False):
             if strict:
                 raise
             else:
-                log.error("skipping")
+                # load_yaml_file() already logs the specific error
+                log.error("skipping (non-strict mode)")
                 continue
         project.update(data)
         projects.append(project)

--- a/src/webapp/project_reader.py
+++ b/src/webapp/project_reader.py
@@ -2,8 +2,11 @@
 from argparse import ArgumentParser
 from collections import OrderedDict
 
+import logging
 import os
 import sys
+
+import yaml
 
 if __name__ == "__main__" and __package__ is None:
     sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -11,7 +14,10 @@ if __name__ == "__main__" and __package__ is None:
 from webapp.common import load_yaml_file, to_xml
 
 
-def get_projects(indir="../projects"):
+log = logging.getLogger(__name__)
+
+
+def get_projects(indir="../projects", strict=False):
     to_output = {"Projects":{"Project": []}}
     projects = []
 
@@ -20,7 +26,15 @@ def get_projects(indir="../projects"):
             continue
         project = OrderedDict.fromkeys(["ID", "Name", "Description", "PIName", "Organization", "Department",
                                         "FieldOfScience", "Sponsor"])
-        project.update(load_yaml_file(os.path.join(indir, file)))
+        try:
+            data = load_yaml_file(os.path.join(indir, file))
+        except yaml.YAMLError:
+            if strict:
+                raise
+            else:
+                log.error("skipping")
+                continue
+        project.update(data)
         projects.append(project)
 
     to_output["Projects"]["Project"] = projects
@@ -28,19 +42,20 @@ def get_projects(indir="../projects"):
     return to_output
 
 
-def get_projects_xml(indir="../projects"):
+def get_projects_xml(indir="../projects", strict=False):
     """Returns the serialized XML as a string"""
-    return to_xml(get_projects(indir))
+    return to_xml(get_projects(indir, strict=strict))
 
 
 if __name__ == "__main__":
-    # We are running as the main script
+    logging.basicConfig()
     parser = ArgumentParser()
     parser.add_argument("indir", help="input dir for projects data")
-    parser.add_argument("outfile", nargs='?', default=None, help="output file for vosummary")
+    parser.add_argument("outfile", nargs='?', default=None, help="output file for miscproject")
+    parser.add_argument("--nostrict", action='store_false', dest='strict', help="Skip files with parse errors (instead of exiting)")
     args = parser.parse_args()
 
-    xml = get_projects_xml(args.indir)
+    xml = get_projects_xml(args.indir, strict=args.strict)
     if args.outfile:
         with open(args.outfile, "w") as fh:
             fh.write(xml)

--- a/src/webapp/rg_reader.py
+++ b/src/webapp/rg_reader.py
@@ -19,9 +19,12 @@ where the return value `xml` is a string.
 from argparse import ArgumentParser
 
 import os
+import logging
 import pprint
 import sys
 from pathlib import Path
+import yaml
+
 
 # thanks stackoverflow
 if __name__ == "__main__" and __package__ is None:
@@ -30,6 +33,10 @@ if __name__ == "__main__" and __package__ is None:
 from webapp.common import ensure_list, to_xml, Filters, load_yaml_file
 from webapp.contacts_reader import get_contacts_data
 from webapp.topology import CommonData, Topology
+
+
+log = logging.getLogger(__name__)
+
 
 class RGError(Exception):
     """An error with converting a specific RG"""
@@ -46,18 +53,18 @@ class DowntimeError(Exception):
         self.rg = rg
 
 
-def get_rgsummary_rgdowntime(indir, contacts_file=None, authorized=False):
+def get_rgsummary_rgdowntime(indir, contacts_file=None, authorized=False, strict=False):
     contacts_data = None
     if contacts_file:
         contacts_data = get_contacts_data(contacts_file)
-    topology = get_topology(indir, contacts_data)
+    topology = get_topology(indir, contacts_data, strict=strict)
     filters = Filters()
     filters.past_days = -1
     return topology.get_resource_summary(authorized=authorized, filters=filters), \
            topology.get_downtimes(authorized=authorized, filters=filters)
 
 
-def get_topology(indir="../topology", contacts_data=None):
+def get_topology(indir="../topology", contacts_data=None, strict=False):
     root = Path(indir)
     support_centers = load_yaml_file(root / "support-centers.yaml")
     service_types = load_yaml_file(root / "services.yaml")
@@ -79,11 +86,24 @@ def get_topology(indir="../topology", contacts_data=None):
         if name.endswith("_downtime.yaml"): continue
 
         name = name.replace(".yaml", "")
-        rg = load_yaml_file(yaml_path)
+        try:
+            rg = load_yaml_file(yaml_path)
+        except yaml.YAMLError:
+            if strict:
+                raise
+            else:
+                log.error("skipping")
+                continue
         downtime_yaml_path = yaml_path.with_name(name + "_downtime.yaml")
         downtimes = None
         if downtime_yaml_path.exists():
-            downtimes = ensure_list(load_yaml_file(downtime_yaml_path))
+            try:
+                downtimes = ensure_list(load_yaml_file(downtime_yaml_path))
+            except yaml.YAMLError:
+                if strict:
+                    raise
+                log.error("skipping")
+                # keep going with downtimes=None
 
         topology.add_rg(facility, site, name, rg)
         if downtimes:
@@ -99,34 +119,25 @@ def main(argv):
     parser.add_argument("outfile", nargs='?', default=None, help="output file for rgsummary")
     parser.add_argument("downtimefile", nargs='?', default=None, help="output file for rgdowntime")
     parser.add_argument("--contacts", help="contacts yaml file")
+    parser.add_argument("--nostrict", action='store_false', dest='strict', help="Skip files with parse errors (instead of exiting)")
     args = parser.parse_args(argv[1:])
 
-    try:
-        rgsummary, rgdowntime = get_rgsummary_rgdowntime(args.indir, args.contacts,
-                                                         authorized=True)
-        if args.outfile:
-            with open(args.outfile, "w") as fh:
-                fh.write(to_xml(rgsummary))
-        else:
-            print(to_xml(rgsummary))
-        if args.downtimefile:
-            with open(args.downtimefile, "w") as fh:
-                fh.write(to_xml(rgdowntime))
-        else:
-            print(to_xml(rgdowntime))
-    except RGError as e:
-        print("Error happened while processing RG:", file=sys.stderr)
-        pprint.pprint(e.rg, stream=sys.stderr)
-        raise
-    except DowntimeError as e:
-        print("Error happened while processing downtime:", file=sys.stderr)
-        pprint.pprint(e.downtime, stream=sys.stderr)
-        print("RG:", file=sys.stderr)
-        pprint.pprint(e.rg, stream=sys.stderr)
-        raise
+    rgsummary, rgdowntime = get_rgsummary_rgdowntime(args.indir, args.contacts,
+                                                     authorized=True, strict=args.strict)
+    if args.outfile:
+        with open(args.outfile, "w") as fh:
+            fh.write(to_xml(rgsummary))
+    else:
+        print(to_xml(rgsummary))
+    if args.downtimefile:
+        with open(args.downtimefile, "w") as fh:
+            fh.write(to_xml(rgdowntime))
+    else:
+        print(to_xml(rgdowntime))
 
     return 0
 
 
 if __name__ == '__main__':
+    logging.basicConfig()
     sys.exit(main(sys.argv))

--- a/src/webapp/rg_reader.py
+++ b/src/webapp/rg_reader.py
@@ -92,7 +92,8 @@ def get_topology(indir="../topology", contacts_data=None, strict=False):
             if strict:
                 raise
             else:
-                log.error("skipping")
+                # load_yaml_file() already logs the specific error
+                log.error("skipping (non-strict mode)")
                 continue
         downtime_yaml_path = yaml_path.with_name(name + "_downtime.yaml")
         downtimes = None
@@ -102,7 +103,8 @@ def get_topology(indir="../topology", contacts_data=None, strict=False):
             except yaml.YAMLError:
                 if strict:
                     raise
-                log.error("skipping")
+                # load_yaml_file() already logs the specific error
+                log.error("skipping (non-strict mode)")
                 # keep going with downtimes=None
 
         topology.add_rg(facility, site, name, rg)

--- a/src/webapp/vo_reader.py
+++ b/src/webapp/vo_reader.py
@@ -34,14 +34,15 @@ def get_vos_data(indir, contacts_data, strict=False) -> VOsData:
             if strict:
                 raise
             else:
-                log.error("skipping")
+                # load_yaml_file() already logs the specific error
+                log.error("skipping (non-strict mode)")
                 continue
         except Exception as e:
             log.error("%s adding VO %s", e, name)
             log.error("Data:\n%s", pprint.pformat(data))
             if strict:
                 raise
-            log.exception("Skipping; exception info follows")
+            log.exception("Skipping (non-strict mode); exception info follows")
             continue
 
     return vos_data

--- a/src/webapp/vo_reader.py
+++ b/src/webapp/vo_reader.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
 from argparse import ArgumentParser
+import logging
 import os
 import pprint
 import sys
+
+import yaml
 
 # thanks stackoverflow
 if __name__ == "__main__" and __package__ is None:
@@ -13,19 +16,34 @@ from webapp.contacts_reader import get_contacts_data
 from webapp.vos_data import VOsData
 
 
-def get_vos_data(indir, contacts_data) -> VOsData:
+log = logging.getLogger(__name__)
+
+
+def get_vos_data(indir, contacts_data, strict=False) -> VOsData:
     reporting_groups_data = load_yaml_file(os.path.join(indir, "REPORTING_GROUPS.yaml"))
     vos_data = VOsData(contacts_data=contacts_data, reporting_groups_data=reporting_groups_data)
     for file in os.listdir(indir):
         if file == "REPORTING_GROUPS.yaml": continue
         if not file.endswith(".yaml"): continue
         name = file[:-5]
-        data = load_yaml_file(os.path.join(indir, file))
+        data = None
         try:
+            data = load_yaml_file(os.path.join(indir, file))
             vos_data.add_vo(name, data)
-        except Exception:
-            pprint.pprint(name, data)
-            raise
+        except yaml.YAMLError:
+            if strict:
+                raise
+            else:
+                log.error("skipping")
+                continue
+        except Exception as e:
+            log.error("%s adding VO %s", e, name)
+            log.error("Data:\n%s", pprint.pformat(data))
+            if strict:
+                raise
+            log.exception("Skipping; exception info follows")
+            continue
+
     return vos_data
 
 
@@ -34,13 +52,14 @@ def main(argv):
     parser.add_argument("indir", help="input dir for virtual-organizations data")
     parser.add_argument("outfile", nargs='?', default=None, help="output file for vosummary")
     parser.add_argument("--contacts", help="contacts yaml file")
+    parser.add_argument("--nostrict", action='store_false', dest='strict', help="Skip files with parse errors (instead of exiting)")
     args = parser.parse_args(argv[1:])
 
     contacts_data = None
     if args.contacts:
         contacts_data = get_contacts_data(args.contacts)
     xml = to_xml(
-        get_vos_data(args.indir, contacts_data=contacts_data).get_tree(authorized=True))
+        get_vos_data(args.indir, contacts_data=contacts_data, strict=args.strict).get_tree(authorized=True))
     if args.outfile:
         with open(args.outfile, "w") as fh:
             fh.write(xml)
@@ -48,4 +67,5 @@ def main(argv):
         print(xml)
 
 if __name__ == '__main__':
+    logging.basicConfig()
     sys.exit(main(sys.argv))


### PR DESCRIPTION
- The rg, vo, and project readers log and skip files with errors when run from the webapp
- The webapp itself also catches and logs exceptions

This should avoid 503 errors in production. When running the readers from the command line (as we do in the CI), they still die to exceptions. The webapp can also die to exceptions if running in devel mode or `STRICT=True` in the config.