### PR TITLE
We are upgrading hadoop to OSG 3.4

### DIFF
--- a/topology/Purdue University/Purdue CMS/Purdue-Hadoop_downtime.yaml
+++ b/topology/Purdue University/Purdue CMS/Purdue-Hadoop_downtime.yaml
@@ -517,3 +517,14 @@
   Services:
     - GridFtp
 # ----------------------------------------------------------
+- Class: SCHEDULED
+  ID: 67255438
+  Description: We are upgrading hadoop to OSG 3.4
+  Severity: Outage
+  StartTime: Nov 14, 2018 13:00 +0000
+  EndTime: Nov 15, 2018 03:00 +0000
+  CreatedTime: Nov 08, 2018 19:05 +0000
+  ResourceName: Purdue-Hadoop-CE
+  Services:
+  - CE
+#


### PR DESCRIPTION
the CMS storage cluster and the Hammer community cluster will be unavailable to do some maintenance work as well as the OSG 3.4 upgrade.