### PR TITLE
We are upgrading hadoop to OSG 3.4

### DIFF
--- a/topology/Purdue University/Purdue CMS/Purdue-Hammer_downtime.yaml
+++ b/topology/Purdue University/Purdue CMS/Purdue-Hammer_downtime.yaml
@@ -133,3 +133,14 @@
   Services:
     - CE
 # ----------------------------------------------------------
+- Class: SCHEDULED
+  ID: 67251937
+  Description: We are upgrading hadoop to OSG 3.4
+  Severity: Outage
+  StartTime: Nov 14, 2018 13:00 +0000
+  EndTime: Nov 15, 2018 03:00 +0000
+  CreatedTime: Nov 08, 2018 18:59 +0000
+  ResourceName: Purdue-Hammer-CE
+  Services:
+  - CE
+# ---------------------------------------------------------


### PR DESCRIPTION
The CMS storage cluster and the Hammer community cluster will be unavailable to do some maintenance work as well as the OSG 3.4 upgrade.