### PR TITLE
We are upgrading hadoop to OSG 3.4

### DIFF
--- a/topology/Purdue University/Purdue CMS/Purdue-Brown_downtime.yaml
+++ b/topology/Purdue University/Purdue CMS/Purdue-Brown_downtime.yaml
@@ -21,3 +21,14 @@
     - CE
 
 # ----------------------------------------------------------
+- Class: SCHEDULED
+  ID: 67266277
+  Description: We are upgrading hadoop to OSG 3.4
+  Severity: Outage
+  StartTime: Nov 14, 2018 13:00 +0000
+  EndTime: Nov 15, 2018 03:00 +0000
+  CreatedTime: Nov 08, 2018 19:23 +0000
+  ResourceName: Purdue-Brown
+  Services:
+  - CE
+# ---------------------------------------------------------


### PR DESCRIPTION
The CMS storage cluster and the Hammer community cluster will be unavailable to do some maintenance work as well as the OSG 3.4 upgrade.