### PR TITLE
We are upgrading hadoop to OSG 3.4

### DIFF
--- a/topology/Purdue University/Purdue CMS/Purdue-Halstead_downtime.yaml
+++ b/topology/Purdue University/Purdue CMS/Purdue-Halstead_downtime.yaml
@@ -70,3 +70,15 @@
   Services:
     - CE
 # ----------------------------------------------------------
+
+- Class: SCHEDULED
+  ID: 67270319
+  Description: We are upgrading hadoop to OSG 3.4
+  Severity: Outage
+  StartTime: Nov 14, 2018 13:00 +0000
+  EndTime: Nov 15, 2018 03:00 +0000
+  CreatedTime: Nov 08, 2018 19:30 +0000
+  ResourceName: Purdue-Halstead
+  Services:
+  - CE
+# ---------------------------------------------------------


### PR DESCRIPTION
he CMS storage cluster and the Hammer community cluster will be unavailable to do some maintenance work as well as the OSG 3.4 upgrade