### PR TITLE
Autogenerate IDs for some things that don't have them

### DIFF
--- a/src/tests/verify_resources.py
+++ b/src/tests/verify_resources.py
@@ -121,7 +121,6 @@ _emsgs = {
     'RGUnique'      : "Resource Group names must be unique across all Sites",
     'ResUnique'     : "Resource names must be unique across the OSG topology",
     'ResID'         : "Resources must contain a numeric ID",
-    'ResGrpID'      : "Resource Groups must contain a numeric ID",
     'SiteUnique'    : "Site names must be unique across Facilities",
     'FQDNUnique'    : "FQDNs must be unique across the OSG topology",
     'VOOwnership100': "Total VOOwnership must not exceed 100%",
@@ -300,21 +299,15 @@ def test_7_fqdn_unique(rgs, rgfns):
     return errors
 
 def test_8_res_ids(rgs, rgfns):
-    # Check that resources/resource groups have a numeric ID/GroupID
+    # Check that resources have a numeric ID
 
     errors = 0
 
     for rg,rgfn in zip(rgs,rgfns):
-        if not isinstance(rg.get('GroupID'), int):
-            print_emsg_once('ResGrpID')
-            print("Resource Group missing numeric GroupID: '%s'" % rgfn)
-            errors += 1
-
         for resname,res in sorted(rg['Resources'].items()):
             if not isinstance(res.get('ID'), int):
                 print_emsg_once('ResID')
-                print("Resource '%s' missing numeric ID in '%s'"
-                      % (resname, rgfn))
+                print("Resource '%s' missing numeric ID in '%s'" % (resname,rgfn))
                 errors += 1
 
     return errors

--- a/src/webapp/project_reader.py
+++ b/src/webapp/project_reader.py
@@ -11,7 +11,7 @@ import yaml
 if __name__ == "__main__" and __package__ is None:
     sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from webapp.common import load_yaml_file, to_xml
+from webapp.common import load_yaml_file, to_xml, gen_id
 
 
 log = logging.getLogger(__name__)
@@ -36,6 +36,10 @@ def get_projects(indir="../projects", strict=False):
                 log.error("skipping (non-strict mode)")
                 continue
         project.update(data)
+        if not project["Name"]:
+            project["Name"] = os.path.basename(file)[:-5]
+        if not project["ID"]:
+            project["ID"] = gen_id(project["Name"], digits=9, minimum=1000)
         projects.append(project)
 
     to_output["Projects"]["Project"] = projects

--- a/src/webapp/rg_reader.py
+++ b/src/webapp/rg_reader.py
@@ -72,7 +72,12 @@ def get_topology(indir="../topology", contacts_data=None, strict=False):
 
     for facility_path in root.glob("*/FACILITY.yaml"):
         name = facility_path.parts[-2]
-        id_ = load_yaml_file(facility_path)["ID"]
+        id_ = None
+        if os.path.exists(facility_path):
+            try:
+                id_ = load_yaml_file(facility_path).get("ID")
+            except AttributeError:
+                pass
         topology.add_facility(name, id_)
     for site_path in root.glob("*/*/SITE.yaml"):
         facility, name = site_path.parts[-3:-1]
@@ -85,7 +90,7 @@ def get_topology(indir="../topology", contacts_data=None, strict=False):
                 log.error(skip_msg)
                 continue
         site_info = load_yaml_file(site_path)
-        id_ = site_info["ID"]
+        id_ = site_info.get("ID", None)
         topology.add_site(facility, name, id_, site_info)
     for yaml_path in root.glob("*/*/*.yaml"):
         facility, site, name = yaml_path.parts[-3:]

--- a/src/webapp/topology.py
+++ b/src/webapp/topology.py
@@ -81,7 +81,7 @@ class Resource(object):
         if is_null(yaml_data, "FQDN"):
             raise ValueError(f"Resource {name} does not have an FQDN")
         self.fqdn = self.data["FQDN"]
-        self.id = yaml_data.get("ID") or self.gen_id(name)
+        self.id = yaml_data.get("ID") or self.gen_id(self.data["FQDN"])
 
     @staticmethod
     def gen_id(name):

--- a/src/webapp/topology.py
+++ b/src/webapp/topology.py
@@ -81,7 +81,8 @@ class Resource(object):
         if is_null(yaml_data, "FQDN"):
             raise ValueError(f"Resource {name} does not have an FQDN")
         self.fqdn = self.data["FQDN"]
-        self.id = yaml_data.get("ID") or self.gen_id(self.data["FQDN"])
+        self.id = yaml_data["ID"]  # can't use gen_id until FQDNs are unique SOFTWARE-3373
+        #self.id = yaml_data.get("ID") or self.gen_id(yaml_data["FQDN"])
 
     @staticmethod
     def gen_id(name):

--- a/src/webapp/vos_data.py
+++ b/src/webapp/vos_data.py
@@ -5,7 +5,7 @@ from logging import getLogger
 from typing import Dict, List
 
 
-from .common import Filters, MaybeOrderedDict, VOSUMMARY_SCHEMA_URL, is_null, expand_attr_list
+from .common import Filters, MaybeOrderedDict, VOSUMMARY_SCHEMA_URL, is_null, expand_attr_list, gen_id
 from .contacts_reader import ContactsData
 
 
@@ -18,10 +18,16 @@ class VOsData(object):
         self.vos = {}
         self.reporting_groups_data = reporting_groups_data
 
+    @staticmethod
+    def gen_id(name):
+        return gen_id(name, digits=7, minimum=200)
+
     def get_vo_id_to_name(self) -> Dict:
         return {self.vos[name]["ID"]: name for name in self.vos}
 
     def add_vo(self, vo_name, vo_data):
+        if not vo_data.get("ID"):
+            vo_data["ID"] = self.gen_id(vo_name)
         self.vos[vo_name] = vo_data
 
     def get_tree(self, authorized=False, filters: Filters = None) -> Dict:


### PR DESCRIPTION
If some entry is missing an ID, one will be generated by running the Name through a hash. This works for:
- facilities (a FACILITY.yaml file still needs to exist but can be empty)
- sites
- rgs
- NOT resources (we want to use the FQDN, not the Name, but it's not unique yet -- see SOFTWARE-3373)
- VOs
- projects
