### PR TITLE
Update UFlorida-HPC_downtime.yaml

### DIFF
--- a/topology/University of Florida/UF HPC/UFlorida-HPC_downtime.yaml
+++ b/topology/University of Florida/UF HPC/UFlorida-HPC_downtime.yaml
@@ -277,3 +277,14 @@
   Services:
   - GridFtp
 # ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 95610993
+  Description: lustre hardware issue
+  Severity: Outage
+  StartTime: Dec 12, 2018 15:00 +0000
+  EndTime: Dec 12, 2018 21:00 +0000
+  CreatedTime: Dec 11, 2018 14:44 +0000
+  ResourceName: UFlorida-SLB-GridFTP
+  Services:
+  - GridFtp
+# ---------------------------------------------------------


### PR DESCRIPTION
Add downtime for cmsio.rc.ufl.edu due to a motherboard replacement of one of the OSSes.