### PR TITLE
PR webhook state, status webhook & automerge (SOFTWARE-3325)

### DIFF
--- a/src/webapp/common.py
+++ b/src/webapp/common.py
@@ -214,11 +214,11 @@ def git_clone_or_pull(repo, dir, branch, ssh_key=None) -> bool:
         ok = ok and run_git_cmd(["checkout", branch], dir=dir)
     return ok
 
-def git_clone_or_fetch_mirror(repo, dir, ssh_key=None) -> bool:
+def git_clone_or_fetch_mirror(repo, git_dir, ssh_key=None) -> bool:
     if os.path.exists(dir):
-        ok = run_git_cmd(["fetch", "origin"], dir=dir, ssh_key=ssh_key)
+        ok = run_git_cmd(["fetch", "origin"], git_dir=git_dir, ssh_key=ssh_key)
     else:
-        ok = run_git_cmd(["clone", "--mirror", repo, dir], ssh_key=ssh_key)
+        ok = run_git_cmd(["clone", "--mirror", repo, git_dir], ssh_key=ssh_key)
     return ok
 
 

--- a/src/webapp/common.py
+++ b/src/webapp/common.py
@@ -219,6 +219,9 @@ def git_clone_or_fetch_mirror(repo, git_dir, ssh_key=None) -> bool:
         ok = run_git_cmd(["fetch", "origin"], git_dir=git_dir, ssh_key=ssh_key)
     else:
         ok = run_git_cmd(["clone", "--mirror", repo, git_dir], ssh_key=ssh_key)
+        # disable mirror push
+        ok = ok and run_git_cmd(["config", "--unset", "remote.origin.mirror"],
+                                                              git_dir=git_dir)
     return ok
 
 

--- a/src/webapp/common.py
+++ b/src/webapp/common.py
@@ -215,7 +215,7 @@ def git_clone_or_pull(repo, dir, branch, ssh_key=None) -> bool:
     return ok
 
 def git_clone_or_fetch_mirror(repo, git_dir, ssh_key=None) -> bool:
-    if os.path.exists(dir):
+    if os.path.exists(git_dir):
         ok = run_git_cmd(["fetch", "origin"], git_dir=git_dir, ssh_key=ssh_key)
     else:
         ok = run_git_cmd(["clone", "--mirror", repo, git_dir], ssh_key=ssh_key)

--- a/src/webapp/default_config.py
+++ b/src/webapp/default_config.py
@@ -7,6 +7,7 @@ TOPOLOGY_CACHE_LIFETIME = 60 * 15
 
 WEBHOOK_DATA_DIR = "/tmp/topology-webhook/topology.git"
 WEBHOOK_DATA_REPO = "https://github.com/opensciencegrid/topology"
+WEBHOOK_STATE_DIR = "/tmp/topology-webhook/state"
 
 CONTACT_DATA_DIR = "/tmp/topology/contact"
 CONTACT_DATA_REPO = "git@bitbucket.org:opensciencegrid/contact.git"

--- a/src/webapp/default_config.py
+++ b/src/webapp/default_config.py
@@ -7,6 +7,7 @@ TOPOLOGY_CACHE_LIFETIME = 60 * 15
 
 WEBHOOK_DATA_DIR = "/tmp/topology-webhook/topology.git"
 WEBHOOK_DATA_REPO = "https://github.com/opensciencegrid/topology"
+WEBHOOK_DATA_BRANCH = "master"
 WEBHOOK_STATE_DIR = "/tmp/topology-webhook/state"
 
 CONTACT_DATA_DIR = "/tmp/topology/contact"

--- a/src/webapp/models.py
+++ b/src/webapp/models.py
@@ -205,6 +205,8 @@ class GlobalData:
         prdir = "%s/%s" % (self.webhook_state_dir, num)
         statefile = "%s/%s" % (prdir, sha)
         os.makedirs(prdir, mode=0o755, exist_ok=True)
+        if isinstance(state, (tuple,list)):
+            state = "\n".join( x.replace("\n"," ") for x in map(str,state) )
         with open(statefile, "w") as f:
             print(state, file=f)
 

--- a/src/webapp/models.py
+++ b/src/webapp/models.py
@@ -59,6 +59,7 @@ class GlobalData:
         self.topology_data_branch = config.get("TOPOLOGY_DATA_BRANCH", "")
         self.webhook_data_dir = config.get("WEBHOOK_DATA_DIR", "")
         self.webhook_data_repo = config.get("WEBHOOK_DATA_REPO", "")
+        self.webhook_data_branch = config.get("WEBHOOK_DATA_BRANCH", "")
         self.webhook_state_dir = config.get("WEBHOOK_STATE_DIR", "")
         if config["CONTACT_DATA_DIR"]:
             self.contacts_file = os.path.join(config["CONTACT_DATA_DIR"], "contacts.yaml")

--- a/src/webapp/models.py
+++ b/src/webapp/models.py
@@ -1,4 +1,5 @@
 import datetime
+import glob
 import logging
 import os
 import time
@@ -206,9 +207,15 @@ class GlobalData:
         with open(statefile, "w") as f:
             print(state, file=f)
 
-    def get_webhook_pr_state(self, num, sha):
+    def get_webhook_pr_state(self, sha, num='[1-9]*'):
         prdir = "%s/%s" % (self.webhook_state_dir, num)
         statefile = "%s/%s" % (prdir, sha)
+        if '*' in num:
+            filelist = glob.glob(statefile)
+            if len(filelist) == 0:
+                return None
+            # if there are multiple PRs with this sha, take the newest
+            statefile = max(filelist, key=lambda fn: int(fn.split('/')[0]))
         if os.path.exists(statefile):
             with open(statefile) as f:
                 return f.read().split()

--- a/src/webapp/models.py
+++ b/src/webapp/models.py
@@ -57,6 +57,7 @@ class GlobalData:
         self.topology_data_branch = config.get("TOPOLOGY_DATA_BRANCH", "")
         self.webhook_data_dir = config.get("WEBHOOK_DATA_DIR", "")
         self.webhook_data_repo = config.get("WEBHOOK_DATA_REPO", "")
+        self.webhook_state_dir = config.get("WEBHOOK_STATE_DIR", "")
         if config["CONTACT_DATA_DIR"]:
             self.contacts_file = os.path.join(config["CONTACT_DATA_DIR"], "contacts.yaml")
         else:
@@ -197,6 +198,22 @@ class GlobalData:
                 self.projects.try_again()
 
         return self.projects.data
+
+    def set_webhook_pr_state(self, num, sha, state):
+        prdir = "%s/%s" % (self.webhook_state_dir, num)
+        statefile = "%s/%s" % (prdir, sha)
+        os.makedirs(prdir, mode=0o755, exist_ok=True)
+        with open(statefile, "w") as f:
+            print(state, file=f)
+
+    def get_webhook_pr_state(self, num, sha):
+        prdir = "%s/%s" % (self.webhook_state_dir, num)
+        statefile = "%s/%s" % (prdir, sha)
+        if os.path.exists(statefile):
+            with open(statefile) as f:
+                return f.read().split()
+        else:
+            return None
 
 
 def _dtid(created_datetime: datetime.datetime):

--- a/src/webapp/models.py
+++ b/src/webapp/models.py
@@ -74,8 +74,10 @@ class GlobalData:
         if not self.config["NO_GIT"]:
             parent = os.path.dirname(self.webhook_data_dir)
             os.makedirs(parent, mode=0o755, exist_ok=True)
-            ok = common.git_clone_or_fetch_mirror(self.webhook_data_repo,
-                                                  self.webhook_data_dir)
+            ssh_key = self.config["GIT_SSH_KEY"]
+            ok = common.git_clone_or_fetch_mirror(repo=self.webhook_data_repo,
+                                               git_dir=self.webhook_data_dir,
+                                               ssh_key=ssh_key)
             if ok:
                 log.debug("webhook repo update ok")
             else:

--- a/src/webhook_app.py
+++ b/src/webhook_app.py
@@ -226,10 +226,9 @@ def pull_request_hook():
 
     global_data._update_webhook_repo()
 
-    if ret == 0:
-        script = src_dir + "/tests/automerge_downtime_ok.py"
-        cmd = [script, base_sha, head_sha, sender]
-        stdout, stderr, ret = runcmd(cmd, cwd=global_data.webhook_data_dir)
+    script = src_dir + "/tests/automerge_downtime_ok.py"
+    cmd = [script, base_sha, head_sha, sender]
+    stdout, stderr, ret = runcmd(cmd, cwd=global_data.webhook_data_dir)
 
     webhook_state = (ret, base_sha, head_label, title)
     global_data.set_webhook_pr_state(pull_num, head_sha, webhook_state)

--- a/src/webhook_app.py
+++ b/src/webhook_app.py
@@ -217,8 +217,6 @@ def pull_request_hook():
                      " at {head_sha} on {head_label} onto {base_label}"
                      .format(**locals()))
 
-    global_data._update_webhook_repo()
-
     pull_ref   = "pull/{pull_num}/head".format(**locals())
 
     if base_label != _required_base_label:
@@ -227,9 +225,6 @@ def pull_request_hook():
         return Response("Not Interested")
 
     global_data._update_webhook_repo()
-
-    # make sure data repo contains relevant commits
-    stdout, stderr, ret = fetch_data_ref(base_ref, pull_ref)
 
     if ret == 0:
         script = src_dir + "/tests/automerge_downtime_ok.py"
@@ -277,10 +272,6 @@ def runcmd(cmd, input=None, **kw):
                          encoding='utf-8', **kw)
     stdout, stderr = p.communicate(input)
     return stdout, stderr, p.returncode
-
-def fetch_data_ref(*refs):
-    return runcmd(['git', 'fetch', 'origin'] + list(refs),
-                  cwd=global_data.webhook_data_dir)
 
 def send_mailx_email(subject, body):
     recipients = [

--- a/src/webhook_app.py
+++ b/src/webhook_app.py
@@ -98,13 +98,19 @@ def push_ref(sha, remote_ref):
     cmd = ['git', 'push', 'origin', refspec]
     return runcmd(cmd, cwd=global_data.webhook_data_dir)
 
+def _status_msg(msg, out, err, ret):
+    return "%s:\n%s\n---\n%s\n---\n" % (msg, out, err), ret
+
 def do_automerge(base_sha, head_sha, message, base_ref):
     out, err, ret = gen_merge_commit(base_sha, head_sha, message)
     if ret != 0:
-        # TODO: error message
-        return None
+        return _status_msg("Failed to generate merge commit", out, err, ret)
     new_merge_commit = out.strip()
     out, err, ret = push_ref(new_merge_commit, base_ref)
+    if ret != 0:
+        return _status_msg("Failed to push merge commit", out, err, ret)
+    else:
+        return _status_msg("Successfully pushed merge commit", out, err, ret)
 
 @app.route("/status", methods=["GET", "POST"])
 def status_hook():

--- a/src/webhook_app.py
+++ b/src/webhook_app.py
@@ -110,13 +110,18 @@ def status_hook():
         return Response("Wrong event type", status=400)
 
     payload = request.get_json()
-    head_sha = payload['sha']       # '02d565300874d691bfebada6929cbb7c9c1d8018'
-    repo = payload['repository']    # { ... }
-    owner = repo['owner']['login']  # 'opensciencegrid'
-    reponame = repo['name']         # 'topology'
-    context = payload['context']    # 'continuous-integration/travis-ci/push'
-    ci_state = payload['state']     # 'success' ...
-    target_url = payload.get('target_url')  # travis build url
+    try:
+        head_sha = payload['sha']
+        repo = payload['repository']
+        owner = repo['owner']['login'] # 'opensciencegrid'
+        reponame = repo['name']        # 'topology'
+        context = payload['context']   # 'continuous-integration/travis-ci/push'
+        ci_state = payload['state']    # 'success' ...
+        target_url = payload.get('target_url')  # travis build url
+    except (TypeError, KeyError) as e:
+        emsg = "Malformed payload for status hook: %s" % e
+        app.logger.error(emsg)
+        return Response(emsg, status=400)
 
     if (context != 'continuous-integration/travis-ci/push' or
             owner != _required_repo_owner or reponame != _required_repo_name):

--- a/src/webhook_app.py
+++ b/src/webhook_app.py
@@ -110,9 +110,7 @@ def do_automerge(base_sha, head_sha, message, base_ref):
     body = ("Downtime PR eligible for automerge and Status check passed:"
             "\n\n%s" % message)
     send_mailx_email(subject, body)
-    return True
-
-#   return push_ref(new_merge_commit, base_ref)
+    return push_ref(new_merge_commit, base_ref)
 
 @app.route("/status", methods=["GET", "POST"])
 def status_hook():

--- a/src/webhook_app.py
+++ b/src/webhook_app.py
@@ -63,7 +63,7 @@ global_data = GlobalData(app.config)
 src_dir = os.path.abspath(os.path.dirname(__file__))
 
 ( _required_repo_owner, _required_repo_name
-) = global_data.webhook_data_repo.split('/')[-2:]
+) = global_data.webhook_data_repo.split(':')[-1].split('/')[-2:]
 
 _required_base_ref = 'master'
 _required_base_label = "%s:%s" % (_required_repo_owner, _required_base_ref)

--- a/src/webhook_app.py
+++ b/src/webhook_app.py
@@ -31,7 +31,8 @@ def _verify_config(cfg):
             raise FileNotFoundError(ssh_key)
         else:
             st = os.stat(ssh_key)
-            if st.st_uid != os.getuid() or (st.st_mode & 0o7777) not in (0o700, 0o600, 0o400):
+            perm_ok = st.st_mode & 0o400 and not st.st_mode & 0o7077
+            if st.st_uid != os.getuid() or not perm_ok:
                 raise PermissionError(ssh_key)
 
 default_authorized = False

--- a/src/webhook_app.py
+++ b/src/webhook_app.py
@@ -247,6 +247,7 @@ automerge_downtime script output:
 ---
 """.format(**locals())
 
+    # only send email if DT files modified or contact unknown
     if ret <= 2:
         _,_,_ = send_mailx_email(subject, out)
 

--- a/src/webhook_app.py
+++ b/src/webhook_app.py
@@ -131,6 +131,7 @@ def status_hook():
         emsg = "Malformed payload for status hook: %s" % e
         app.logger.error(emsg)
         return Response(emsg, status=400)
+    app.logger.debug("Got status hook '%s' for '%s'" % (ci_state, head_sha))
 
     if (context != 'continuous-integration/travis-ci/push' or
             owner != _required_repo_owner or reponame != _required_repo_name):
@@ -151,6 +152,8 @@ def status_hook():
     base_ref = _required_base_ref
 
     if pr_dt_automerge_ret == 0 and not app.config['NO_GIT']:
+        app.logger.info("Got travis success status hook for commit %s;\n"
+                "eligible for DT automerge" % head_sha)
         message = "Auto-merge Downtime PR #{pull_num} from {head_label}" \
                   "\n\n{pr_title}".format(**locals())
         ok = do_automerge(base_sha, head_sha, message, base_ref)
@@ -203,6 +206,9 @@ def pull_request_hook():
         emsg = "Malformed payload for pull_request hook: %s" % e
         app.logger.error(emsg)
         return Response(emsg, status=400)
+    app.logger.debug("Got pull_request hook for PR #{pull_num}"
+                     " at {head_sha} on {head_label} onto {base_label}"
+                     .format(**locals()))
 
     global_data._update_webhook_repo()
 

--- a/src/webhook_app.py
+++ b/src/webhook_app.py
@@ -147,14 +147,14 @@ def pull_request_hook():
         pull_num   = payload['pull_request']['number']
         pull_url   = payload['pull_request']['html_url']
         title      = payload['pull_request']['title']
+
+        mergeable  = payload['pull_request']['mergeable']
+        if mergeable:
+            merge_sha = payload['pull_request']['merge_commit_sha']
     except (TypeError, KeyError) as e:
         return Response("Malformed payload: {0}".format(e), status=400)
 
     global_data._update_webhook_repo()
-
-    mergeable  = payload['pull_request']['mergeable']
-    if mergeable:
-        merge_sha = payload['pull_request']['merge_commit_sha']
 
     pull_ref   = "pull/{pull_num}/head".format(**locals())
 

--- a/src/webhook_app.py
+++ b/src/webhook_app.py
@@ -138,10 +138,14 @@ def status_hook():
 
     valid_contexts = ( 'continuous-integration/travis-ci/pr',
                        'continuous-integration/travis-ci/push' )
-    if (context not in valid_contexts or
-            owner != _required_repo_owner or reponame != _required_repo_name):
+    if context not in valid_contexts:
         app.logger.info("Ignoring non-travis status hook for '%s'" % context)
         return Response("Not Interested; context was '%s'" % context)
+
+    if owner != _required_repo_owner or reponame != _required_repo_name:
+        app.logger.info("Ignoring status hook repo '%s/%s'"
+                        % (owner, reponame))
+        return Response("Not Interested; repo was '%s/%s'" % (owner, reponame))
 
     if ci_state != 'success':
         app.logger.info("Ignoring travis '%s' status hook" % ci_state)

--- a/src/webhook_app.py
+++ b/src/webhook_app.py
@@ -109,12 +109,15 @@ def status_hook():
     owner = repo['owner']['login']  # 'opensciencegrid'
     reponame = repo['name']         # 'topology'
     context = payload['context']    # 'continuous-integration/travis-ci/push'
+    ci_state = payload['state']     # 'success' ...
     target_url = payload.get('target_url')  # travis build url
 
     if (context != 'continuous-integration/travis-ci/push' or
             owner != _required_repo_owner or reponame != _required_repo_name):
         return Response("Not Interested")
 
+    if ci_state != 'success':
+        return Response("Not interested; CI state was '%s'" % ci_state)
 
     pr_webhook_state, pull_num = global_data.get_webhook_pr_state(sha)
     if pr_webhook_state is None or len(pr_webhook_state) != 3:

--- a/src/webhook_app.py
+++ b/src/webhook_app.py
@@ -103,7 +103,7 @@ def do_automerge(base_sha, head_sha, message, base_ref):
     new_merge_commit = out.strip()
 
     # for now, send all-clear email rather than actually pushing upstream
-    subject = "Downtime Automerge Approved"
+    subject = "[DT-AM] Downtime Automerge Approved"
     body = ("Downtime PR eligible for automerge and Status check passed:"
             "\n\n%s" % message)
     send_mailx_email(subject, body)
@@ -239,8 +239,9 @@ def pull_request_hook():
     global_data.set_webhook_pr_state(pull_num, head_sha, webhook_state)
 
     OK = "Yes" if ret == 0 else "No"
+    Eligible = "Eligible!" if ret == 0 else "Not Eligible."
 
-    subject = "Pull Request {pull_url} {action}".format(**locals())
+    subject = "[DT-AM] PR #{pull_num} {action}: {Eligible}".format(**locals())
 
     out = """\
 In Pull Request: {pull_url}

--- a/src/webhook_app.py
+++ b/src/webhook_app.py
@@ -104,7 +104,7 @@ def status_hook():
         return Response("Wrong event type", status=400)
 
     payload = request.get_json()
-    sha = payload['sha']            # '02d565300874d691bfebada6929cbb7c9c1d8018'
+    head_sha = payload['sha']       # '02d565300874d691bfebada6929cbb7c9c1d8018'
     repo = payload['repository']    # { ... }
     owner = repo['owner']['login']  # 'opensciencegrid'
     reponame = repo['name']         # 'topology'
@@ -119,9 +119,9 @@ def status_hook():
     if ci_state != 'success':
         return Response("Not interested; CI state was '%s'" % ci_state)
 
-    pr_webhook_state, pull_num = global_data.get_webhook_pr_state(sha)
+    pr_webhook_state, pull_num = global_data.get_webhook_pr_state(head_sha)
     if pr_webhook_state is None or len(pr_webhook_state) != 3:
-        return Response("No PR automerge info available for %s" % sha)
+        return Response("No PR automerge info available for %s" % head_sha)
 
     pr_dt_automerge_ret, head_label, pr_title = pr_webhook_state
 

--- a/src/webhook_app.py
+++ b/src/webhook_app.py
@@ -120,10 +120,10 @@ def status_hook():
         return Response("Not interested; CI state was '%s'" % ci_state)
 
     pr_webhook_state, pull_num = global_data.get_webhook_pr_state(head_sha)
-    if pr_webhook_state is None or len(pr_webhook_state) != 3:
+    if pr_webhook_state is None or len(pr_webhook_state) != 4:
         return Response("No PR automerge info available for %s" % head_sha)
 
-    pr_dt_automerge_ret, head_label, pr_title = pr_webhook_state
+    pr_dt_automerge_ret, base_sha, head_label, pr_title = pr_webhook_state
     base_ref = _required_base_ref
 
     if pr_dt_automerge_ret == 0:
@@ -186,7 +186,7 @@ def pull_request_hook():
         cmd = [script, base_sha, head_sha, sender]
         stdout, stderr, ret = runcmd(cmd, cwd=global_data.webhook_data_dir)
 
-    webhook_state = "{ret}\n{head_label}\n{title}".format(**locals())
+    webhook_state = (ret, base_sha, head_label, title)
     global_data.set_webhook_pr_state(pull_num, head_sha, webhook_state)
 
     OK = "Yes" if ret == 0 else "No"

--- a/src/webhook_app.py
+++ b/src/webhook_app.py
@@ -133,10 +133,12 @@ def status_hook():
         return Response(emsg, status=400)
     app.logger.debug("Got status hook '%s' for '%s'" % (ci_state, head_sha))
 
-    if (context != 'continuous-integration/travis-ci/push' or
+    valid_contexts = ( 'continuous-integration/travis-ci/pr',
+                       'continuous-integration/travis-ci/push' )
+    if (context not in valid_contexts or
             owner != _required_repo_owner or reponame != _required_repo_name):
         app.logger.info("Ignoring non-travis status hook for '%s'" % context)
-        return Response("Not Interested")
+        return Response("Not Interested; context was '%s'" % context)
 
     if ci_state != 'success':
         app.logger.info("Ignoring travis '%s' status hook" % ci_state)

--- a/src/webhook_app.py
+++ b/src/webhook_app.py
@@ -60,23 +60,6 @@ def _fix_unicode(text):
     return text.encode('utf-8', 'surrogateescape').decode('utf-8')
 
 
-'''
-# some bash for ya
-
-base_commit=24603d8a
-head_commit=5021baa7
-
-base_branch=master
-
-new_sha=$(
-  git commit-tree -p $base_commit -p $head_commit \
-                  -m "auto-merge downtime x into $base_branch" \
-                  refs/pull/98/merge^{tree}
-) 
-
-git push origin $new_sha:refs/heads/$base_branch
-'''
-
 # already checked in automerge test script
 # might want to move the check here though, and pass in merge_sha
 def commit_is_merged(ancestor_sha, head_sha):

--- a/src/webhook_app.py
+++ b/src/webhook_app.py
@@ -117,8 +117,13 @@ def status_hook():
 
     pr_dt_automerge_ret = global_data.get_webhook_pr_state(pull_num, head_sha)
 
-    return Response('Thank You')
 
+    if pr_dt_automerge_ret == 0:
+        message = "Auto-merge Downtime PR #{pull_num} from {head_label}" \
+                  "\n\n{pr_title}".format(**locals())
+        do_automerge(base_sha, head_sha, message, base_ref)
+
+    return Response('Thank You')
 
 
 @app.route("/pull_request", methods=["GET", "POST"])
@@ -174,11 +179,6 @@ def pull_request_hook():
         stdout, stderr, ret = runcmd(cmd, cwd=global_data.webhook_data_dir)
 
     global_data.set_webhook_pr_state(pull_num, head_sha, ret)
-
-    if ret == 0 and mergeable:
-        message = "Auto-merge Downtime PR #{pull_num} from {head_label}" \
-                  "\n\n{title}".format(**locals())
-        do_automerge(base_sha, head_sha, message, base_ref)
 
     OK = "Yes" if ret == 0 else "No"
 

--- a/src/webhook_app.py
+++ b/src/webhook_app.py
@@ -154,6 +154,8 @@ def status_hook():
 
     pr_dt_automerge_ret, base_sha, head_label, pr_title = pr_webhook_state
     base_ref = _required_base_ref
+    if re.search(r'^-?\d+$', pr_dt_automerge_ret):
+        pr_dt_automerge_ret = int(pr_dt_automerge_ret)
 
     if pr_dt_automerge_ret == 0 and not app.config['NO_GIT']:
         app.logger.info("Got travis success status hook for commit %s;\n"

--- a/src/webhook_app.py
+++ b/src/webhook_app.py
@@ -49,7 +49,11 @@ global_data = GlobalData(app.config)
 
 src_dir = os.path.abspath(os.path.dirname(__file__))
 
-repo_owner, repo_name = global_data.webhook_data_repo.split('/')[-2:]
+( _required_repo_owner, _required_repo_name
+) = global_data.webhook_data_repo.split('/')[-2:]
+
+_required_base_ref = 'master'
+_required_base_label = "%s:%s" % (_required_repo_owner, _required_base_ref)
 
 def _fix_unicode(text):
     """Convert a partial unicode string to full unicode"""
@@ -119,7 +123,7 @@ def status_hook():
     target_url = payload.get('target_url')  # travis build url
 
     if (context != 'continuous-integration/travis-ci/push' or
-            owner != repo_owner or reponame != repo_name):
+            owner != _required_repo_owner or reponame != _required_repo_name):
         return Response("Not Interested")
 
     pr_dt_automerge_ret = global_data.get_webhook_pr_state(pull_num, head_sha)
@@ -127,7 +131,6 @@ def status_hook():
     return Response('Thank You')
 
 
-_required_base_label = 'opensciencegrid:master'
 
 @app.route("/pull_request", methods=["GET", "POST"])
 def pull_request_hook():

--- a/src/webhook_app.py
+++ b/src/webhook_app.py
@@ -146,6 +146,7 @@ def pull_request_hook():
 
         pull_num   = payload['pull_request']['number']
         pull_url   = payload['pull_request']['html_url']
+        title      = payload['pull_request']['title']
     except (TypeError, KeyError) as e:
         return Response("Malformed payload: {0}".format(e), status=400)
 
@@ -173,6 +174,8 @@ def pull_request_hook():
     global_data.set_webhook_pr_state(pull_num, head_sha, ret)
 
     if ret == 0 and mergeable:
+        message = "Auto-merge Downtime PR #{pull_num} from {head_label}" \
+                  "\n\n{title}".format(**locals())
         new_merge_commit = gen_merge_commit(base_sha, head_sha, message)
         push_ref(new_merge_commit, base_ref)
 

--- a/src/webhook_app.py
+++ b/src/webhook_app.py
@@ -65,7 +65,7 @@ src_dir = os.path.abspath(os.path.dirname(__file__))
 ( _required_repo_owner, _required_repo_name
 ) = global_data.webhook_data_repo.split(':')[-1].split('/')[-2:]
 
-_required_base_ref = 'master'
+_required_base_ref = global_data.webhook_data_branch
 _required_base_label = "%s:%s" % (_required_repo_owner, _required_base_ref)
 
 def _fix_unicode(text):

--- a/src/webhook_app.py
+++ b/src/webhook_app.py
@@ -95,7 +95,8 @@ def push_ref(sha, remote_ref):
 def do_automerge(base_sha, head_sha, message, base_ref):
     out, err, ret = gen_merge_commit(base_sha, head_sha, message)
     if ret != 0:
-        # XXX: log message: Failed to generate merge commit...
+        app.logger.error("Failed to generate merge commit of %s onto %s"
+                         % (head_sha, base_sha))
         return False
     new_merge_commit = out.strip()
     return push_ref(new_merge_commit, base_ref)

--- a/src/webhook_app.py
+++ b/src/webhook_app.py
@@ -99,7 +99,15 @@ def do_automerge(base_sha, head_sha, message, base_ref):
                          % (head_sha, base_sha))
         return False
     new_merge_commit = out.strip()
-    return push_ref(new_merge_commit, base_ref)
+
+    # for now, send all-clear email rather than actually pushing upstream
+    subject = "Downtime Automerge Approved"
+    body = ("Downtime PR eligible for automerge and Status check passed:"
+            "\n\n%s" % message)
+    send_mailx_email(subject, body)
+    return True
+
+#   return push_ref(new_merge_commit, base_ref)
 
 @app.route("/status", methods=["GET", "POST"])
 def status_hook():
@@ -239,14 +247,8 @@ automerge_downtime script output:
 ---
 """.format(**locals())
 
-    recipients = [
-        "edquist@cs.wisc.edu",
-        "matyas@cs.wisc.edu",
-        "blin@cs.wisc.edu",
-    ]
-
     if ret <= 2:
-        _,_,_ = send_mailx_email(subject, out, recipients)
+        _,_,_ = send_mailx_email(subject, out)
 
     return Response(out)
 
@@ -265,7 +267,12 @@ def fetch_data_ref(*refs):
     return runcmd(['git', 'fetch', 'origin'] + list(refs),
                   cwd=global_data.webhook_data_dir)
 
-def send_mailx_email(subject, body, recipients):
+def send_mailx_email(subject, body):
+    recipients = [
+        "edquist@cs.wisc.edu",
+        "matyas@cs.wisc.edu",
+        "blin@cs.wisc.edu",
+    ]
     app.logger.info("Sending email to %s, Re: %s" % (recipients, subject))
     return runcmd(["mailx", "-s", subject] + recipients, input=body)
 

--- a/src/webhook_app.py
+++ b/src/webhook_app.py
@@ -22,7 +22,16 @@ from webapp.topology import GRIDTYPE_1, GRIDTYPE_2
 class InvalidArgumentsError(Exception): pass
 
 def _verify_config(cfg):
-    pass
+    if not cfg["NO_GIT"]:
+        ssh_key = cfg["GIT_SSH_KEY"]
+        if not ssh_key:
+            raise ValueError("GIT_SSH_KEY must be specified if using Git")
+        elif not os.path.exists(ssh_key):
+            raise FileNotFoundError(ssh_key)
+        else:
+            st = os.stat(ssh_key)
+            if st.st_uid != os.getuid() or (st.st_mode & 0o7777) not in (0o700, 0o600, 0o400):
+                raise PermissionError(ssh_key)
 
 default_authorized = False
 

--- a/src/webhook_app.py
+++ b/src/webhook_app.py
@@ -92,6 +92,8 @@ def gen_merge_commit(base_sha, head_sha, message):
 def push_ref(sha, remote_ref):
     refspec = "%s:refs/heads/%s" % (sha, remote_ref)
     gitcmd = ['push', 'origin', refspec]
+    app.logger.info("Pushing downtime automerge commit %s to branch '%s'"
+                    % (sha, remote_ref))
     return run_git_cmd(gitcmd, git_dir=global_data.webhook_data_dir,
                        ssh_key=ssh_key)
 

--- a/src/webhook_app.py
+++ b/src/webhook_app.py
@@ -80,12 +80,16 @@ def commit_is_merged(ancestor_sha, head_sha):
     stdout, stderr, ret = runcmd(cmd, cwd=global_data.webhook_data_dir)
     return ret == 0
 
+_git_user_name = "Topology Automerge"
+_git_user_email = "help@opensciencegrid.org"
 def gen_merge_commit(base_sha, head_sha, message):
     # NOTE: we've already checked this in automerge test script
     if not commit_is_merged(base_sha, head_sha):
         return '', 'commit %s is not merged into %s' % (base_sha, head_sha), 1
     tree_rev = head_sha + "^{tree}"
-    cmd = ['git', 'commit-tree', '-p', base_sha, '-p', head_sha,
+    cmd = ['git', '-c', 'user.name=%s'  % _git_user_name,
+                  '-c', 'user.email=%s' % _git_user_email,
+                  'commit-tree', '-p', base_sha, '-p', head_sha,
                                  '-m', message, tree_rev]
     return runcmd(cmd, cwd=global_data.webhook_data_dir)
 

--- a/src/webhook_app.py
+++ b/src/webhook_app.py
@@ -137,8 +137,8 @@ def pull_request_hook():
         sender     = payload['sender']['login']
 
         head_sha   = payload['pull_request']['head']['sha']
-        head_label = payload['pull_request']['head']['label']
-        head_ref   = payload['pull_request']['head']['ref']
+        head_label = payload['pull_request']['head']['label']  # user:branch
+        head_ref   = payload['pull_request']['head']['ref']    # branch
 
         base_sha   = payload['pull_request']['base']['sha']
         base_label = payload['pull_request']['base']['label']

--- a/src/webhook_app.py
+++ b/src/webhook_app.py
@@ -124,6 +124,7 @@ def status_hook():
         return Response("No PR automerge info available for %s" % head_sha)
 
     pr_dt_automerge_ret, head_label, pr_title = pr_webhook_state
+    base_ref = _required_base_ref
 
     if pr_dt_automerge_ret == 0:
         message = "Auto-merge Downtime PR #{pull_num} from {head_label}" \

--- a/src/webhook_app.py
+++ b/src/webhook_app.py
@@ -54,6 +54,8 @@ if not app.config.get("SECRET_KEY"):
 #         app.config["SECRET_KEY"] = "this is not very secret"
 #     else:
 #         raise Exception("SECRET_KEY required when FLASK_ENV != development")
+if "LOGLEVEL" in app.config:
+    app.logger.setLevel(app.config["LOGLEVEL"])
 
 global_data = GlobalData(app.config)
 


### PR DESCRIPTION
This contains work to complete the 'automerge' feature for downtime pull requests (the second half of [SOFTWARE-3325](https://opensciencegrid.atlassian.net/browse/SOFTWARE-3325)).

The key features here are:

1. add a mechanism for the `pull_request` webhook to write state to disk
  this is needed because the mergeability check script does not know about the travis-ci results
2. add a second webhook to handle `status` check updates
  in particular, this receives the result status of a travis-ci check
3. add the ability to generate our own merge commit, and to push the result to upstream
  this gets done in the `status` webhook if the mergeability and travis checks both succeed

For now I'm marking this `WIP` and `do-not-merge`, as I have more to do in terms of testing and I will most likely clean up the commit history with more rebasing + force pushing before the end.

The changes to `src/webapp/models.py` and `src/webapp/default_config.py` are exactly item 1 above, which could stand as its own PR now if that's preferred.