### PR TITLE
Unscheduled CIT downtime

### DIFF
--- a/topology/California Institute of Technology/Caltech CMS Tier2/CIT_CMS_T2_downtime.yaml
+++ b/topology/California Institute of Technology/Caltech CMS Tier2/CIT_CMS_T2_downtime.yaml
@@ -317,3 +317,15 @@
   ResourceName: CIT_HEP_CE
   Services:
     - CE
+
+# ----------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 120032292
+  Description: power issues in one rack and in others several datanodes down.
+  Severity: Severe
+  StartTime: Jan 11, 2019 10:00 +0000
+  EndTime: Jan 12, 2019 10:00 +0000
+  CreatedTime: Jan 11, 2019 10:00 +0000
+  ResourceName: CIT_CMS_SE
+  Services:
+    - GridFtp


### PR DESCRIPTION
There are power issues in one of the racks and also several other datanodes are down and affect all HDFS. Files are not lost, but nodes are not accessible and this affects all SE. 

p.s. There is no xrootd as a service for SE, shouldn't this be implemented in some way, same as xrootd caches? Or this is not something what CMS would look/need?