### PR TITLE
allow passing git_dir explicitly to run_git_cmd (SOFTWARE-3325)

### DIFF
--- a/src/webapp/common.py
+++ b/src/webapp/common.py
@@ -157,6 +157,17 @@ def trim_space(s: str) -> str:
 
 
 def run_git_cmd(cmd: List, dir=None, git_dir=None, ssh_key=None) -> bool:
+    """
+    Run git command, optionally specifying ssh key and/or git dirs
+
+    Options:
+
+        dir       path to git work-tree, if not current directory
+        git_dir   path to git-dir, if not .git subdir of work-tree
+        ssh_key   path to ssh public key identity file, if any
+
+    For a bare git repo, specify `git_dir` but not `dir`.
+    """
     if ssh_key and not os.path.exists(ssh_key):
         log.critical("ssh key not found at %s: unable to update secure repo",
                      ssh_key)


### PR DESCRIPTION
previously, passing a `dir` parameter to `run_git_cmd` would be interpreted as a working-tree, and it would assume that the git-dir was also in a `.git` subdir.

in the case of the webhook app, the webhook data dir is a bare repo; that is, a git-dir without a working-tree.

by accepting an explicit `git_dir` parameter, this `run_git_cmd` can now be run on a bare git repo, as well as non-bare repos with a git-dir and working-tree in separate locations.