### PR TITLE
Use LibYAML for faster loading of topology data

### DIFF
--- a/src/tests/automerge_downtime_ok.py
+++ b/src/tests/automerge_downtime_ok.py
@@ -125,7 +125,7 @@ def parse_yaml_at_version(sha, fname, default):
     if not txt:
         return default
     try:
-        return yaml.safe_load(txt)
+        return yaml.load(txt, Loader=yaml.CSafeLoader)
     except yaml.error.YAMLError:
         return None
 

--- a/src/tests/automerge_downtime_ok.py
+++ b/src/tests/automerge_downtime_ok.py
@@ -12,6 +12,11 @@ try:
 except ImportError:
     from urllib2 import urlopen
 
+try:
+    from yaml import CSafeLoader as SafeLoader
+except ImportError:
+    from yaml import SafeLoader
+
 import xml.etree.ElementTree as et
 
 
@@ -125,7 +130,7 @@ def parse_yaml_at_version(sha, fname, default):
     if not txt:
         return default
     try:
-        return yaml.load(txt, Loader=yaml.CSafeLoader)
+        return yaml.load(txt, Loader=SafeLoader)
     except yaml.error.YAMLError:
         return None
 

--- a/src/tests/verify_downtimes.py
+++ b/src/tests/verify_downtimes.py
@@ -8,6 +8,11 @@ import sys
 import os
 import re
 
+try:
+    from yaml import CSafeLoader as SafeLoader
+except ImportError:
+    from yaml import SafeLoader
+
 _topdir = os.path.abspath(os.path.dirname(__file__) + "/../..")
 sys.path.append(_topdir + "/src")
 
@@ -15,7 +20,7 @@ from webapp import topology
 
 def load_yaml_file(fname, errors):
     try:
-        yml = yaml.load(open(fname), Loader=yaml.CSafeLoader)
+        yml = yaml.load(open(fname), Loader=SafeLoader)
         if yml is None:
             errors.append("YAML file is empty or invalid: %s", fname)
         return yml
@@ -71,7 +76,7 @@ def main():
 
     downtime_filenames = sorted(glob.glob("*/*/*_downtime.yaml"))
 
-    services = yaml.load(open("services.yaml"), Loader=yaml.CSafeLoader)
+    services = yaml.load(open("services.yaml"), Loader=SafeLoader)
 
     errors = []
     for dt_fname in downtime_filenames:

--- a/src/tests/verify_downtimes.py
+++ b/src/tests/verify_downtimes.py
@@ -15,7 +15,7 @@ from webapp import topology
 
 def load_yaml_file(fname, errors):
     try:
-        yml = yaml.safe_load(open(fname))
+        yml = yaml.load(open(fname), Loader=yaml.CSafeLoader)
         if yml is None:
             errors.append("YAML file is empty or invalid: %s", fname)
         return yml
@@ -71,7 +71,7 @@ def main():
 
     downtime_filenames = sorted(glob.glob("*/*/*_downtime.yaml"))
 
-    services = yaml.safe_load(open("services.yaml"))
+    services = yaml.load(open("services.yaml"), Loader=yaml.CSafeLoader)
 
     errors = []
     for dt_fname in downtime_filenames:

--- a/src/tests/verify_resources.py
+++ b/src/tests/verify_resources.py
@@ -44,7 +44,7 @@ def get_vo_names():
 def load_yamlfile(fn):
     with open(fn) as f:
         try:
-            yml = yaml.safe_load(f)
+            yml = yaml.load(f, Loader=yaml.CSafeLoader)
             if yml is None:
                 print("YAML file is empty or invalid: %s", fn)
             return yml

--- a/src/tests/verify_resources.py
+++ b/src/tests/verify_resources.py
@@ -14,6 +14,11 @@ try:
 except ImportError:
     from urllib2 import urlopen
 
+try:
+    from yaml import CSafeLoader as SafeLoader
+except ImportError:
+    from yaml import SafeLoader
+
 import xml.etree.ElementTree as et
 
 _topdir = os.path.abspath(os.path.dirname(__file__) + "/../..")
@@ -44,7 +49,7 @@ def get_vo_names():
 def load_yamlfile(fn):
     with open(fn) as f:
         try:
-            yml = yaml.load(f, Loader=yaml.CSafeLoader)
+            yml = yaml.load(f, Loader=SafeLoader)
             if yml is None:
                 print("YAML file is empty or invalid: %s", fn)
             return yml

--- a/src/webapp/common.py
+++ b/src/webapp/common.py
@@ -15,7 +15,7 @@ import yaml
 try:
     from yaml import CSafeLoader as SafeLoader
 except ImportError:
-    log.debug("CSafeLoader not available - install libyaml")
+    log.warning("CSafeLoader not available - install libyaml-devel and reinstall PyYAML")
     from yaml import SafeLoader
 
 MaybeOrderedDict = Union[None, OrderedDict]

--- a/src/webapp/common.py
+++ b/src/webapp/common.py
@@ -8,8 +8,15 @@ import subprocess
 import sys
 from typing import Dict, List, Union, AnyStr
 
+log = getLogger(__name__)
+
 import xmltodict
 import yaml
+try:
+    from yaml import CSafeLoader as SafeLoader
+except ImportError:
+    log.debug("CSafeLoader not available - install libyaml")
+    from yaml import SafeLoader
 
 MaybeOrderedDict = Union[None, OrderedDict]
 
@@ -20,7 +27,6 @@ VOSUMMARY_SCHEMA_URL = "https://my.opensciencegrid.org/schema/vosummary.xsd"
 
 SSH_WITH_KEY = os.path.abspath(os.path.dirname(__file__) + "/ssh_with_key.sh")
 
-log = getLogger(__name__)
 
 
 class Filters(object):
@@ -229,7 +235,7 @@ def load_yaml_file(filename) -> Dict:
     """
     try:
         with open(filename, encoding='utf-8', errors='surrogateescape') as stream:
-            return yaml.load(stream, Loader=yaml.CSafeLoader)
+            return yaml.load(stream, Loader=SafeLoader)
     except yaml.YAMLError as e:
         log.error("YAML error in %s: %s", filename, e)
         raise

--- a/src/webapp/common.py
+++ b/src/webapp/common.py
@@ -229,7 +229,7 @@ def load_yaml_file(filename) -> Dict:
     """
     try:
         with open(filename, encoding='utf-8', errors='surrogateescape') as stream:
-            return yaml.safe_load(stream)
+            return yaml.load(stream, Loader=yaml.CSafeLoader)
     except yaml.YAMLError as e:
         log.error("YAML error in %s: %s", filename, e)
         raise


### PR DESCRIPTION
Quick testing with rg_reader.py shows a 4x speed-up after switching to the PyYAML CSafeLoader: 8.8 sec down to 1.9 sec.