### PR TITLE
secure webhook using github secret (SOFTWARE-3325)

### DIFF
--- a/src/webapp/default_config.py
+++ b/src/webapp/default_config.py
@@ -9,6 +9,7 @@ WEBHOOK_DATA_DIR = "/tmp/topology-webhook/topology.git"
 WEBHOOK_DATA_REPO = "https://github.com/opensciencegrid/topology"
 WEBHOOK_DATA_BRANCH = "master"
 WEBHOOK_STATE_DIR = "/tmp/topology-webhook/state"
+WEBHOOK_SECRET_KEY = None
 
 CONTACT_DATA_DIR = "/tmp/topology/contact"
 CONTACT_DATA_REPO = "git@bitbucket.org:opensciencegrid/contact.git"

--- a/src/webapp/models.py
+++ b/src/webapp/models.py
@@ -1,6 +1,6 @@
 import datetime
 import glob
-import hashlib
+import hmac
 import logging
 import os
 import re
@@ -243,11 +243,12 @@ class GlobalData:
         else:
             return None, None
 
-    def validate_webhook_signature(self, payload_body, x_hub_signature):
+    def validate_webhook_signature(self, data, x_hub_signature):
         if self.webhook_secret_key:
-            sha1 = hashlib.sha1(self.webhook_secret_key + payload_body)
+            secret = self.webhook_secret_key
+            sha1 = hmac.new(secret, msg=data, digestmod='sha1').hexdigest()
             our_signature = "sha1=" + sha1
-            return our_signature == x_hub_signature
+            return hmac.compare_digest(our_signature, x_hub_signature)
 
 
 def _dtid(created_datetime: datetime.datetime):

--- a/src/webapp/models.py
+++ b/src/webapp/models.py
@@ -1,5 +1,6 @@
 import datetime
 import glob
+import hashlib
 import logging
 import os
 import re
@@ -39,6 +40,16 @@ class CachedData:
         self.next_update = self.timestamp + self.cache_lifetime
         self.force_update = False
 
+def _readfile(path):
+    """ return stripped file contents, or None on errors """
+    if path:
+        try:
+            with open(path, mode="rb") as f:
+                return f.read().strip()
+        except IOError as e:
+            log.error("Failed to read file '%s': %s" % (path, e))
+            return None
+
 
 class GlobalData:
     def __init__(self, config=None, strict=False):
@@ -61,6 +72,7 @@ class GlobalData:
         self.webhook_data_repo = config.get("WEBHOOK_DATA_REPO", "")
         self.webhook_data_branch = config.get("WEBHOOK_DATA_BRANCH", "")
         self.webhook_state_dir = config.get("WEBHOOK_STATE_DIR", "")
+        self.webhook_secret_key = _readfile(config.get("WEBHOOK_SECRET_KEY"))
         if config["CONTACT_DATA_DIR"]:
             self.contacts_file = os.path.join(config["CONTACT_DATA_DIR"], "contacts.yaml")
         else:
@@ -230,6 +242,12 @@ class GlobalData:
                 return f.read().strip().split('\n'), pr_num(statefile)
         else:
             return None, None
+
+    def validate_webhook_signature(self, payload_body, x_hub_signature):
+        if self.webhook_secret_key:
+            sha1 = hashlib.sha1(self.webhook_secret_key + payload_body)
+            our_signature = "sha1=" + sha1
+            return our_signature == x_hub_signature
 
 
 def _dtid(created_datetime: datetime.datetime):


### PR DESCRIPTION
This implements the method discussed in [SOFTWARE-3325](https://opensciencegrid.atlassian.net/browse/SOFTWARE-3325) to verify that webhooks are actually sent by github.

I've verified that this is working properly on topology-itb by sending `ping` hooks.