### PR TITLE
Add AllowedOrigins and AllowedCaches entries for all VOs in StashCache

### DIFF
--- a/virtual-organizations/CMS.yaml
+++ b/virtual-organizations/CMS.yaml
@@ -117,5 +117,5 @@ DataFederations:
     Namespaces:
       /store:
         - FQAN:/cms
-    AllowedOrigins: []    # FIXME
-    AllowedCaches: []    # FIXME
+    AllowedOrigins: []    # FIXME - Contact StashCache operations to find the resource(s) that should be allowed to serve data under /cms
+    AllowedCaches: []    # FIXME - Contact StashCache operations to find the resource(s) that should be allowed to serve data under /cms

--- a/virtual-organizations/CMS.yaml
+++ b/virtual-organizations/CMS.yaml
@@ -117,4 +117,5 @@ DataFederations:
     Namespaces:
       /store:
         - FQAN:/cms
-    AllowedCaches: []
+    AllowedOrigins: []    # FIXME
+    AllowedCaches: []    # FIXME

--- a/virtual-organizations/Fermilab.yaml
+++ b/virtual-organizations/Fermilab.yaml
@@ -90,3 +90,6 @@ DataFederations:
     Namespaces:
       /pnfs/fnal.gov:
         - PUBLIC
+    AllowedOrigins: []     # <- FIXME
+    AllowedCaches:
+      - ANY

--- a/virtual-organizations/Fermilab.yaml
+++ b/virtual-organizations/Fermilab.yaml
@@ -90,6 +90,6 @@ DataFederations:
     Namespaces:
       /pnfs/fnal.gov:
         - PUBLIC
-    AllowedOrigins: []     # <- FIXME
+    AllowedOrigins: []    # FIXME - Contact StashCache operations to find the resource(s) that should be allowed to serve data under /pnfs/fnal.gov
     AllowedCaches:
       - ANY

--- a/virtual-organizations/OSG.yaml
+++ b/virtual-organizations/OSG.yaml
@@ -102,3 +102,7 @@ DataFederations:
     Namespaces:
       /user:
         - PUBLIC
+    AllowedOrigins: []       # FIXME
+    AllowedCaches:
+      - ANY
+

--- a/virtual-organizations/OSG.yaml
+++ b/virtual-organizations/OSG.yaml
@@ -102,7 +102,7 @@ DataFederations:
     Namespaces:
       /user:
         - PUBLIC
-    AllowedOrigins: []       # FIXME
+    AllowedOrigins: []    # FIXME - Contact StashCache operations to find the resource(s) that should be allowed to serve data under /user
     AllowedCaches:
       - ANY
 


### PR DESCRIPTION
There need to be _some_ values, even if they're empty, for authfile
generation to work.  Some of the values will need to be replaced once we
know what the origin servers are.