### PR TITLE
improve handling of out-of-date PRs (SOFTWARE-3325)

### DIFF
--- a/src/tests/automerge_downtime_ok.py
+++ b/src/tests/automerge_downtime_ok.py
@@ -46,19 +46,20 @@ def get_base_head_shas(BASE_SHA, HEAD_SHA, MERGE_SHA, errors):
     base = BASE_SHA
     head = HEAD_SHA
     if not commit_is_merged(base, head):
-        emsg = "Base commit %s is not merged into PR head %s" % (base, head)
+        errors += ["PR head %s is out-of-date: %s is not merged" % (head, base)]
         if MERGE_SHA and commit_is_merged(base, MERGE_SHA) \
                      and commit_is_merged(head, MERGE_SHA):
+            print("Using merge commit %s to list changes instead of "
+                  "out-of-date PR head %s" % (MERGE_SHA, HEAD_SHA))
             head = MERGE_SHA
-            emsg += "; using merge commit %s instead as head" % head
         else:
             merge_base = get_merge_base(base, head)
             if merge_base:
+                print("Falling back to merge-base %s to list changes instead "
+                      "of unmerged PR base %s" % (merge_base, BASE_SHA))
                 base = merge_base
-                emsg += "; falling back to merge-base %s" % base
             else:
-                emsg += "; commit histories are unrelated"
-        errors += [emsg]
+                print("PR base and head commit histories are unrelated")
     return base, head
 
 def main(args):

--- a/src/tests/automerge_downtime_ok.py
+++ b/src/tests/automerge_downtime_ok.py
@@ -107,7 +107,7 @@ def main(args):
 
         if resources_affected and contact:
             rg_fname = re.sub(br'_downtime.yaml$', b'.yaml', fname)
-            errors += check_resource_contacts(base, rg_fname,
+            errors += check_resource_contacts(BASE_SHA, rg_fname,
                                               resources_affected, contact)
 
     print_errors(errors)

--- a/src/tests/automerge_downtime_ok.py
+++ b/src/tests/automerge_downtime_ok.py
@@ -21,16 +21,30 @@ import xml.etree.ElementTree as et
 
 
 def usage():
-    print("Usage: %s BASE_SHA MERGE_COMMIT_SHA [GitHubUser]"
+    print("Usage: %s BASE_SHA HEAD_SHA[:MERGE_COMMIT_SHA] [GitHubUser]"
                    % os.path.basename(__file__))
     sys.exit(1)
 
-def main(args):
+def parseargs(args):
     insist(len(args) in (2,3))
-    insist(looks_like_sha(args[0]))
-    insist(looks_like_sha(args[1]))
 
-    BASE_SHA, MERGE_COMMIT_SHA = args[:2]
+    GH_USER = None
+    MERGE_COMMIT_SHA = None
+    BASE_SHA, HEAD_SHA = args[:2]
+    if ':' in HEAD_SHA:
+        HEAD_SHA, MERGE_COMMIT_SHA = HEAD_SHA.split(':',2)
+        insist(looks_like_sha(MERGE_COMMIT_SHA))
+    insist(looks_like_sha(BASE_SHA))
+    insist(looks_like_sha(HEAD_SHA))
+
+    if len(args) == 3:
+        GH_USER = args[2]
+
+    return BASE_SHA, HEAD_SHA, MERGE_COMMIT_SHA, GH_USER
+
+def main(args):
+    BASE_SHA, HEAD_SHA, MERGE_COMMIT_SHA, GH_USER = parseargs(args)
+
     errors = []
     if not commit_is_merged(BASE_SHA, MERGE_COMMIT_SHA):
         emsg = "Commit %s is not merged into %s" % (BASE_SHA, MERGE_COMMIT_SHA)
@@ -51,10 +65,10 @@ def main(args):
     if len(modified) == 0:
         errors += ["Will not automerge PR without any file changes."]
 
-    if len(args) == 3:
-        contact = get_gh_contact(args[2])
+    if GH_USER is not None:
+        contact = get_gh_contact(GH_USER)
         if contact is None:
-            errors += ["No contact found for GitHub user '%s'" % args[2]]
+            errors += ["No contact found for GitHub user '%s'" % GH_USER]
     else:
         contact = None
 

--- a/src/webhook_app.py
+++ b/src/webhook_app.py
@@ -256,7 +256,8 @@ def pull_request_hook():
     global_data._update_webhook_repo()
 
     script = src_dir + "/tests/automerge_downtime_ok.py"
-    cmd = [script, base_sha, head_sha, sender]
+    headmerge_sha = "%s:%s" % (head_sha, merge_sha) if mergeable else head_sha
+    cmd = [script, base_sha, headmerge_sha, sender]
     stdout, stderr, ret = runcmd(cmd, cwd=global_data.webhook_data_dir)
 
     webhook_state = (ret, base_sha, head_label, title)


### PR DESCRIPTION
Currently we create a list of files changed between the PR `base` (eg, `opensciencegrid:master`) and the PR `head` (whatever branch the submitter wants to merge).  If the `head` is not up-to-date (that is, if `base` is not merged into `head`), the diff can contain files changed that have nothing to do with the PR in question.

Either way, the PR is not eligible to be merged when it is out of date, but the report emails with the diff could be improved by showing what the PR submitter intended to change.

Two things we can use for improving the diffs when the PR `head` is out of date are:

1. the automatic test merge commit that github generates to test mergeability when the PR is submitted.  If present, we can use this instead of the PR `head`.  (If it's not present, that means there were merge conflicts.)

2. otherwise, fall back to the git-merge-base of `base` and `head`, and use this merge-base instead of the PR `base`.  This will work unless the user has submitted a PR for a completely unrelated commit history, in which case we just use the original `base` and `head` for the PR.

Option 1) is preferred if available as it contains all unmerged changes in the PR `base`, but option 2) is still useful when there are merge conflicts for showing what was intended to change.

In both options, the script still reports that the PR is \*not\* eligible for auto-merge, since it's out of date - these fallback commits are just to make it possible to report the intended file changes.