### PR TITLE
add production topology-webhook.wsgi (SOFTWARE-3548)

### DIFF
--- a/src/topology-webhook.wsgi
+++ b/src/topology-webhook.wsgi
@@ -1,0 +1,4 @@
+import os, sys
+os.environ['TOPOLOGY_CONFIG'] = '/etc/opt/topology/config-production-webhook.py'
+sys.path.insert(0, '/opt/topology-webhook/src')
+from webhook_app import app as application


### PR DESCRIPTION
We have separate `topology-itb.wsgi` and `topology-itb-webhook.wsgi` already, but i never added a `topology-webhook.wsgi` for the production instance.