### PR TITLE
Initial osg-topology Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:2.7-alpine as base
+
+FROM base as builder
+
+RUN mkdir /install
+WORKDIR /install
+
+COPY requirements-rootless.txt /
+
+RUN pip install --install-option="--prefix=/install" -r /requirements-rootless.txt
+
+FROM base
+
+LABEL maintainer OSG Software <help@opensciencegrid.org>
+
+COPY --from=builder /install /usr/local
+COPY . /app
+
+ENV X509_USER_PROXY /user.proxy
+
+WORKDIR /app/bin
+
+CMD ["--help"]
+ENTRYPOINT ["python", "osg-topology"]


### PR DESCRIPTION
Just something I was playing around with yesterday. Currently requires mounting a user proxy to /user.proxy to view emails. I'd like to also support the case where users mount their cert/key so they don't have to have `{voms,grid}-proxy-init` installed locally. I think the main hurdle there is getting certs installed but I haven't gotten that far.

I learned a bunch about docker image development practices and niceties of multi-stage builds from here: https://blog.realkinetic.com/building-minimal-docker-containers-for-python-applications-37d0272c52f3?gi=fc1cb2613305