### PR TITLE
be safer about getting payload action

### DIFF
--- a/src/webhook_app.py
+++ b/src/webhook_app.py
@@ -249,7 +249,7 @@ def pull_request_hook():
         return Response("Wrong event type", status=400)
 
     payload = request.get_json()
-    action = payload['action']
+    action = payload and payload.get('action')
     if action not in ("opened",):
         app.logger.info("Ignoring pull_request hook action '%s'" % action)
         return Response("Not Interested")


### PR DESCRIPTION
`payload['action']` _should_ always exist, but if somebody forgot to set content type to application/json when setting up the webhook on github, then `payload` will be `None`.