### PR TITLE
ITB test double downtime (2/2) for VDT-ITB-MADISON

### DIFF
--- a/topology/University of Wisconsin/GLOW EDU/VDT-ITB_downtime.yaml
+++ b/topology/University of Wisconsin/GLOW EDU/VDT-ITB_downtime.yaml
@@ -1,0 +1,11 @@
+- Class: SCHEDULED
+  ID: 127910179
+  Description: Test Downtime
+  Severity: No Significant Outage Expected
+  StartTime: Jan 31, 2019 00:00 +0000
+  EndTime: Jan 31, 2019 00:01 +0000
+  CreatedTime: Jan 17, 2019 23:56 +0000
+  ResourceName: VDT-ITB-MADISON
+  Services:
+  - CE
+# ---------------------------------------------------------


### PR DESCRIPTION
this time with branch protection enabled for `itb`