### PR TITLE
CIT_CMS_T2 downtime due to power maitenance,renovations.

### DIFF
--- a/topology/California Institute of Technology/Caltech CMS Tier2/CIT_CMS_T2_downtime.yaml
+++ b/topology/California Institute of Technology/Caltech CMS Tier2/CIT_CMS_T2_downtime.yaml
@@ -341,3 +341,78 @@
   ResourceName: CIT_CMS_T2
   Services:
     - CE
+
+# ----------------------------------------------------------
+# Caltech Tier2 Power maitenance 23-02-2019
+
+# ----------------------------------------------------------
+- Class: SCHEDULED
+  ID: 149486444
+  Description: Power maitenance at Caltech
+  Severity: Outage
+  StartTime: Feb 22, 2019 18:00 +0000
+  EndTime: Feb 25, 2019 23:00 +0000
+  CreatedTime: Feb 20, 2019 20:00 +0000
+  ResourceName: CIT_CMS_SE
+  Services:
+    - GridFtp
+
+# ----------------------------------------------------------
+- Class: SCHEDULED
+  ID: 149486445
+  Description: Power maitenance at Caltech
+  Severity: Outage
+  StartTime: Feb 22, 2019 18:00 +0000
+  EndTime: Feb 25, 2019 23:00 +0000
+  CreatedTime: Feb 20, 2019 20:00 +0000
+  ResourceName: CIT_CMS_T2
+  Services:
+    - CE
+
+- Class: SCHEDULED
+  ID: 149486446
+  Description: Power maitenance at Caltech
+  Severity: Outage
+  StartTime: Feb 22, 2019 18:00 +0000
+  EndTime: Feb 25, 2019 23:00 +0000
+  CreatedTime: Feb 20, 2019 20:00 +0000
+  ResourceName: CIT_CMS_T2B
+  Services:
+    - CE
+
+- Class: SCHEDULED
+  ID: 149486447
+  Description: Power maitenance at Caltech
+  Severity: Outage
+  StartTime: Feb 22, 2019 18:00 +0000
+  EndTime: Feb 25, 2019 23:00 +0000
+  CreatedTime: Feb 20, 2019 20:00 +0000
+  ResourceName: CIT_CMS_T2C
+  Services:
+    - CE
+
+
+# ----------------------------------------------------------
+- Class: SCHEDULED
+  ID: 149486448
+  Description: Power maitenance at Caltech
+  Severity: Outage
+  StartTime: Feb 22, 2019 18:00 +0000
+  EndTime: Feb 25, 2019 23:00 +0000
+  CreatedTime: Feb 20, 2019 20:00 +0000
+  ResourceName: CIT_CMS_T2_Squid
+  Services:
+    - Squid
+
+# ----------------------------------------------------------
+- Class: SCHEDULED
+  ID: 149486449
+  Description: Power maitenance at Caltech
+  Severity: Outage
+  StartTime: Feb 22, 2019 18:00 +0000
+  EndTime: Feb 25, 2019 23:00 +0000
+  CreatedTime: Feb 20, 2019 20:00 +0000
+  ResourceName: CIT_CMS_T2_2_Squid
+  Services:
+    - Squid
+


### PR DESCRIPTION
Part of the Tier2 cluster will be without electricity on Saturday, February 23rd due to needed maitenance and renovations. As this happens on weekend, I extend this downtime from Friday to Monday. In case all will be back sooner, we will shorten it.