### PR TITLE
show resource name in error message, not full resource object (SOFTWARE-3287)

### DIFF
--- a/src/tests/verify_resources.py
+++ b/src/tests/verify_resources.py
@@ -313,7 +313,8 @@ def test_8_res_ids(rgs, rgfns):
         for resname,res in sorted(rg['Resources'].items()):
             if not isinstance(res.get('ID'), int):
                 print_emsg_once('ResID')
-                print("Resource '%s' missing numeric ID in '%s'" % (res,rgfn))
+                print("Resource '%s' missing numeric ID in '%s'"
+                      % (resname, rgfn))
                 errors += 1
 
     return errors


### PR DESCRIPTION
the error message was dumping the full resource object, as it turns out:

https://travis-ci.org/opensciencegrid/topology/builds/496679440#L651

but it should just print the resource name, similar to other error messages