### PR TITLE
- moved StashCache origin server from the grinch.phys.uconn.edu

### DIFF
--- a/topology/University of Connecticut/UConn-OSG/UConn-OSG.yaml
+++ b/topology/University of Connecticut/UConn-OSG/UConn-OSG.yaml
@@ -104,11 +104,47 @@ Resources:
         Details:
           hidden: false
           uri_override: grinch.phys.uconn.edu:8443
+    VOOwnership:
+      Gluex: 100
+    WLCGInformation:
+      APELNormalFactor: 0
+      HEPSPEC: 85
+      InteropAccounting: false
+      InteropBDII: true
+      InteropMonitoring: true
+      KSI2KMax: 500
+      KSI2KMin: 100
+      LDAPURL: ldap://is.grid.iu.edu:2180/mds-vo-name=UConn-OSG,o=grid
+      StorageCapacityMax: 50
+      StorageCapacityMin: 25
+      TapeCapacity: 0
+  UConn-OSG_StashCache_origin:
+    Active: true
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          ID: 650bf84a5cf49caf504fed22ce07b98580c6fa12
+          Name: Richard T. Jones
+      Resource Report Contact:
+        Primary:
+          ID: 650bf84a5cf49caf504fed22ce07b98580c6fa12
+          Name: Richard T. Jones
+      Security Contact:
+        Primary:
+          ID: 650bf84a5cf49caf504fed22ce07b98580c6fa12
+          Name: Richard T. Jones
+    Description: UConn-OSG StashCache origin server
+    Disable: false
+    FQDN: gandalf.phys.uconn.edu
+    FQDNAliases:
+    - gandalf.phys.uconn.edu
+    ID: 287
+    Services:
       XRootD origin server:
         Description: StashCache Origin server for UConn-OSG
         Details:
           hidden: false
-          uri_override: grinch.phys.uconn.edu:1094
+          uri_override: gandalf.phys.uconn.edu:1094
         AllowedVOs:
         - GLUEX
     VOOwnership:


### PR DESCRIPTION
  node to a separate server gandalf.phys.uconn.edu.