### PR TITLE
Update UFlorida-HPC_downtime.yaml

### DIFF
--- a/topology/University of Florida/UF HPC/UFlorida-HPC_downtime.yaml
+++ b/topology/University of Florida/UF HPC/UFlorida-HPC_downtime.yaml
@@ -299,3 +299,67 @@
   Services:
   - GridFtp
 # ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 200132800
+  Description: "UFRC will carry out a major maintenance on 5/6 \u2013 5/9. As a result,\
+    \ HiPerGator cluster, home area, /ufrc, /orange as well as /apps will be out of\
+    \ service during this maintenance. User login servers will be down as well.    \
+    \ Though CMS servers including /cms will not be touched in this maintenance, other\
+    \ resources that CMS jobs may rely on will be unavailable therefore CMS jobs will\
+    \ not be able to run at the time. "
+  Severity: Outage
+  StartTime: May 06, 2019 13:00 +0000
+  EndTime: May 09, 2019 21:00 +0000
+  CreatedTime: Apr 11, 2019 15:08 +0000
+  ResourceName: UFlorida-CMS
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 200133866
+  Description: "UFRC will carry out a major maintenance on 5/6 \u2013 5/9. As a result,\
+    \ HiPerGator cluster, home area, /ufrc, /orange as well as /apps will be out of\
+    \ service during this maintenance. User login servers will be down as well.    \
+    \ Though CMS servers including /cms will not be touched in this maintenance, other\
+    \ resources that CMS jobs may rely on will be unavailable therefore CMS jobs will\
+    \ not be able to run at the time. "
+  Severity: Outage
+  StartTime: May 06, 2019 13:00 +0000
+  EndTime: May 09, 2019 21:00 +0000
+  CreatedTime: Apr 11, 2019 15:09 +0000
+  ResourceName: UFlorida-HPC
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 200134214
+  Description: "UFRC will carry out a major maintenance on 5/6 \u2013 5/9. As a result,\
+    \ HiPerGator cluster, home area, /ufrc, /orange as well as /apps will be out of\
+    \ service during this maintenance. User login servers will be down as well.    \
+    \ Though CMS servers including /cms will not be touched in this maintenance, other\
+    \ resources that CMS jobs may rely on will be unavailable therefore CMS jobs will\
+    \ not be able to run at the time. "
+  Severity: Outage
+  StartTime: May 06, 2019 13:00 +0000
+  EndTime: May 09, 2019 21:00 +0000
+  CreatedTime: Apr 11, 2019 15:10 +0000
+  ResourceName: UFlorida-HPG2
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 200134564
+  Description: "UFRC will carry out a major maintenance on 5/6 \u2013 5/9. As a result,\
+    \ HiPerGator cluster, home area, /ufrc, /orange as well as /apps will be out of\
+    \ service during this maintenance. User login servers will be down as well.    \
+    \ Though CMS servers including /cms will not be touched in this maintenance, other\
+    \ resources that CMS jobs may rely on will be unavailable therefore CMS jobs will\
+    \ not be able to run at the time. "
+  Severity: Outage
+  StartTime: May 06, 2019 13:00 +0000
+  EndTime: May 09, 2019 21:00 +0000
+  CreatedTime: Apr 11, 2019 15:10 +0000
+  ResourceName: UFlorida-SLB-GridFTP
+  Services:
+  - GridFtp
+# ---------------------------------------------------------


### PR DESCRIPTION
UFRC will carry out a major maintenance on 5/6 – 5/9. As a result, HiPerGator cluster, home area, /ufrc, /orange as well as /apps will be out of service during this maintenance. User login servers will be down as well. Though CMS servers including /cms will not be touched in this maintenance, other resources that CMS jobs may rely on will be unavailable therefore CMS jobs will not be able to run at the time. 