### PR TITLE
SciTokens config support

### DIFF
--- a/bin/osg-scitokens-config
+++ b/bin/osg-scitokens-config
@@ -29,4 +29,4 @@ cache_scitokens = stashcache.generate_cache_scitokens(vodata,
                                                       resource_groups,
                                                       fqdn=args.fqdn,
                                                       suppress_errors=False)
-print(cache_scitokens)
+print(cache_scitokens, end="")  # config already has trailing newline

--- a/bin/osg-scitokens-config
+++ b/bin/osg-scitokens-config
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+A script to generate a SciTokens config for a StashCache cache in the OSG
+"""
+import argparse
+import os
+import sys
+
+if __name__ == "__main__" and __package__ is None:
+    _parent = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path.append(_parent + "/src")
+
+import webapp.models
+import stashcache
+
+parser = argparse.ArgumentParser(description="Generate a SciTokens config for a StashCache cache server.")
+parser.add_argument("fqdn", metavar="Cache_FQDN", help="FQDN of the cache for config generation.")
+
+args = parser.parse_args()
+
+global_data = webapp.models.GlobalData()
+
+vodata = global_data.get_vos_data()
+resource_groups = global_data.get_topology().get_resource_group_list()
+
+cache_scitokens = stashcache.generate_cache_scitokens(vodata,
+                                                      resource_groups,
+                                                      fqdn=args.fqdn,
+                                                      suppress_errors=False)
+print(cache_scitokens)

--- a/src/stashcache.py
+++ b/src/stashcache.py
@@ -168,7 +168,7 @@ def generate_cache_authfile(vo_data: VOsData, resource_groups: List[ResourceGrou
             else:
                 raise DataError("VO {} in StashCache does not provide a Namespaces list.".format(vo_name))
 
-        has_non_public = False
+        needs_authz = False
         for namespace, authz_list in namespaces.items():
             if not authz_list:
                 if suppress_errors:
@@ -176,9 +176,9 @@ def generate_cache_authfile(vo_data: VOsData, resource_groups: List[ResourceGrou
                 else:
                     raise DataError("Namespace {} (VO {}) does not provide any authorizations.".format(namespace, vo_name))
             if authz_list != ["PUBLIC"]:
-                has_non_public = True
+                needs_authz = True
                 break
-        if not has_non_public:
+        if not needs_authz:
             continue
 
         if resource and not _cache_is_allowed(resource, vo_name, stashcache_data, False, suppress_errors):
@@ -292,13 +292,13 @@ audience = {resource.name}, https://{fqdn}
         if not namespaces:
             continue
 
-        has_non_public = False
+        needs_authz = False
         for authz_list in namespaces.values():
             for authz in authz_list:
                 if authz != "PUBLIC":
-                    has_non_public = True
+                    needs_authz = True
                     break
-        if not has_non_public:
+        if not needs_authz:
             continue
 
         if not _cache_is_allowed(resource, vo_name, stashcache_data,

--- a/src/stashcache.py
+++ b/src/stashcache.py
@@ -314,7 +314,7 @@ audience = {resource.name}, https://{fqdn}
 
     issuer_blocks_str = "\n".join(issuer_blocks)
 
-    return template.format(**locals())
+    return template.format(**locals()).rstrip() + "\n"
 
 
 def _get_scitokens_issuer_block(vo_name: str, scitokens: Dict, dirname: str, suppress_errors: bool) -> str:
@@ -323,7 +323,6 @@ def _get_scitokens_issuer_block(vo_name: str, scitokens: Dict, dirname: str, sup
 issuer = {issuer}
 base_path = {base_path}
 {restricted_path_line}
-
 """
     issuer_block = ""
     if not scitokens.get("Issuer"):

--- a/src/stashcache.py
+++ b/src/stashcache.py
@@ -181,6 +181,8 @@ def generate_cache_authfile(vo_data, resource_groups, fqdn=None, legacy=True, su
 
         for namespace, authz_list in namespaces.items():
             for authz in authz_list:
+                if not isinstance(authz, str):
+                    continue
                 if authz.startswith("FQAN:"):
                     id_to_dir["g {}".format(authz[5:])].add(namespace)
                 elif authz.startswith("DN:"):
@@ -232,6 +234,54 @@ def generate_public_cache_authfile(vo_data, resource_groups, fqdn=None, legacy=T
         authfile = authfile[:-2] + "\n"
 
     return authfile
+
+
+def generate_cache_scitokens(fqdn, vo_data, resource_groups, suppress_errors=True):
+    """
+    Generate the SciTokens needed by a StashCache cache server.
+    """
+    scitokens_cfg = "[Global]\n"
+    id_to_dir = defaultdict(list)
+
+    resource = _get_cache_resource(fqdn, resource_groups, suppress_errors)
+    if fqdn and not resource:
+        return ""
+
+    scitokens_cfg += "audience = {}, https://{}\n\n".format(resource.name, fqdn)
+
+    for vo_name, vo_data in vo_data.vos.items():
+        stashcache_data = vo_data.get('DataFederations', {}).get('StashCache')
+        if not stashcache_data:
+            continue
+
+        has_non_public = False
+        for authz_list in stashcache_data.get("Namespaces", {}).values():
+            for authz in authz_list:
+                if authz != "PUBLIC":
+                    has_non_public = True
+                    break
+        if not has_non_public:
+            continue
+
+        if resource and not _cache_is_allowed(resource, vo_name, stashcache_data, False, suppress_errors):
+            continue
+
+        for dirname, authz_list in stashcache_data.get("Namespaces", {}).items():
+            for authz in authz_list:
+                if not isinstance(authz, dict) or not 'SciTokens' in authz or not isinstance(authz['SciTokens'], dict):
+                    continue
+                if 'Base Path' not in authz['SciTokens']:
+                    raise DataError("'Base Path' missing from the SciTokens config for {}.".format(vo_name))
+                if 'Issuer' not in authz['SciTokens']:
+                    raise DataError("'Issuer' missing from the SciTokens config for {}.".format(vo_name))
+                scitokens_cfg += "[Issuer {}]\n".format(dirname)
+                scitokens_cfg += "issuer = {}\n".format(authz['SciTokens']['Issuer'])
+                scitokens_cfg += "base_path = {}\n".format(authz['SciTokens']['Base Path'])
+                if 'Restricted Path' in authz['SciTokens']:
+                     scitokens_cfg += "restricted_path = {}\n".format(authz['SciTokens']['Restricted Path'])
+                scitokens_cfg += "\n"
+
+    return scitokens_cfg
 
 
 def _origin_is_allowed(origin_hostname, vo_name, stashcache_data, resource_groups, suppress_errors=True):

--- a/virtual-organizations/CMS.yaml
+++ b/virtual-organizations/CMS.yaml
@@ -117,5 +117,9 @@ DataFederations:
     Namespaces:
       /store:
         - FQAN:/cms
+        - SciTokens:
+            Issuer: https://scitokens.org/cms
+            Base Path: /
+            Restricted Path: /store
     AllowedOrigins: []    # FIXME - Contact StashCache operations to find the resource(s) that should be allowed to serve data under /store
     AllowedCaches: []    # Deny by default

--- a/virtual-organizations/GLOW.yaml
+++ b/virtual-organizations/GLOW.yaml
@@ -55,6 +55,9 @@ DataFederations:
       /chtc/PROTECTED:
         - FQAN:/GLOW
         - DN:/DC=org/DC=cilogon/C=US/O=University of Wisconsin-Madison/CN=Matyas Selmeci A148276
+        - SciTokens:
+            Issuer: https://scitokens.org/chtc
+            Base Path: /chtc
     AllowedOrigins:
       - CHTC_STASHCACHE_ORIGIN
     AllowedCaches:

--- a/virtual-organizations/OSG.yaml
+++ b/virtual-organizations/OSG.yaml
@@ -71,4 +71,3 @@ DataFederations:
     AllowedOrigins: []    # FIXME - Contact StashCache operations to find the resource(s) that should be allowed to serve data under /user
     AllowedCaches:
       - ANY
-


### PR DESCRIPTION
#352 rebased on master with some code style changes and the webapp route added.

Added a SciTokens entry for GLOW and tested (locally) with the URL http://127.0.0.1:5000/stashcache/scitokens?cache_fqdn=sc-cache.chtc.wisc.edu to give the result:
```
[Global]
audience = CHTC_STASHCACHE_CACHE, https://sc-cache.chtc.wisc.edu

[Issuer /chtc/PROTECTED]
issuer = https://scitokens.org/chtc
base_path = /chtc
```