### PR TITLE
Add downtime for GLOW due to cooling work

### DIFF
--- a/topology/University of Wisconsin/GLOW/GLOW_downtime.yaml
+++ b/topology/University of Wisconsin/GLOW/GLOW_downtime.yaml
@@ -278,7 +278,7 @@
   - Squid
 # ---------------------------------------------------------
 - Class: SCHEDULED
-  ID: 206221185
+  ID: 206221187
   Description: Down due to cooling system maintenance
   Severity: Outage
   StartTime: Apr 22, 2019 12:00 +0000

--- a/topology/University of Wisconsin/GLOW/GLOW_downtime.yaml
+++ b/topology/University of Wisconsin/GLOW/GLOW_downtime.yaml
@@ -289,7 +289,7 @@
   - Squid
 # ---------------------------------------------------------
 - Class: SCHEDULED
-  ID: 206221185
+  ID: 206221188
   Description: Down due to cooling system maintenance
   Severity: Outage
   StartTime: Apr 22, 2019 12:00 +0000

--- a/topology/University of Wisconsin/GLOW/GLOW_downtime.yaml
+++ b/topology/University of Wisconsin/GLOW/GLOW_downtime.yaml
@@ -200,3 +200,102 @@
     - SRMv2
     - CE
 # ----------------------------------------------------------
+- Class: SCHEDULED
+  ID: 206217406
+  Description: Down due to cooling system maintenance
+  Severity: Outage
+  StartTime: Apr 22, 2019 12:00 +0000
+  EndTime: Apr 22, 2019 18:00 +0000
+  CreatedTime: Apr 18, 2019 16:09 +0000
+  ResourceName: GLOW
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 206219835
+  Description: Down due to cooling system maintenance
+  Severity: Outage
+  StartTime: Apr 22, 2019 12:00 +0000
+  EndTime: Apr 22, 2019 18:00 +0000
+  CreatedTime: Apr 18, 2019 16:13 +0000
+  ResourceName: GLOW-CMS
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 206220451
+  Description: Down due to cooling system maintenance
+  Severity: Outage
+  StartTime: Apr 22, 2019 12:00 +0000
+  EndTime: Apr 22, 2019 18:00 +0000
+  CreatedTime: Apr 18, 2019 16:14 +0000
+  ResourceName: GLOW-CONDOR-CE
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 206220727
+  Description: Down due to cooling system maintenance
+  Severity: Outage
+  StartTime: Apr 22, 2019 12:00 +0000
+  EndTime: Apr 22, 2019 18:00 +0000
+  CreatedTime: Apr 18, 2019 16:14 +0000
+  ResourceName: GLOW-OSG
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 206220907
+  Description: Down due to cooling system maintenance
+  Severity: Outage
+  StartTime: Apr 22, 2019 12:00 +0000
+  EndTime: Apr 22, 2019 18:00 +0000
+  CreatedTime: Apr 18, 2019 16:14 +0000
+  ResourceName: GLOW_SQUID
+  Services:
+  - Squid
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 206221185
+  Description: Down due to cooling system maintenance
+  Severity: Outage
+  StartTime: Apr 22, 2019 12:00 +0000
+  EndTime: Apr 22, 2019 18:00 +0000
+  CreatedTime: Apr 18, 2019 16:15 +0000
+  ResourceName: GLOW_SQUID1
+  Services:
+  - Squid
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 206221185
+  Description: Down due to cooling system maintenance
+  Severity: Outage
+  StartTime: Apr 22, 2019 12:00 +0000
+  EndTime: Apr 22, 2019 18:00 +0000
+  CreatedTime: Apr 18, 2019 16:15 +0000
+  ResourceName: GLOW_SQUID2
+  Services:
+  - Squid
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 206221185
+  Description: Down due to cooling system maintenance
+  Severity: Outage
+  StartTime: Apr 22, 2019 12:00 +0000
+  EndTime: Apr 22, 2019 18:00 +0000
+  CreatedTime: Apr 18, 2019 16:15 +0000
+  ResourceName: GLOW_SQUID3
+  Services:
+  - Squid
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 206221185
+  Description: Down due to cooling system maintenance
+  Severity: Outage
+  StartTime: Apr 22, 2019 12:00 +0000
+  EndTime: Apr 22, 2019 18:00 +0000
+  CreatedTime: Apr 18, 2019 16:15 +0000
+  ResourceName: GLOW_SQUID4
+  Services:
+  - Squid
+# ---------------------------------------------------------

--- a/topology/University of Wisconsin/GLOW/GLOW_downtime.yaml
+++ b/topology/University of Wisconsin/GLOW/GLOW_downtime.yaml
@@ -267,7 +267,7 @@
   - Squid
 # ---------------------------------------------------------
 - Class: SCHEDULED
-  ID: 206221185
+  ID: 206221186
   Description: Down due to cooling system maintenance
   Severity: Outage
   StartTime: Apr 22, 2019 12:00 +0000


### PR DESCRIPTION
Down due to cooling system maintenance on Monday, April 22, from 12:00-18:00 UTC. The following will be down: GLOW, GLOW-CMS, GLOW-CONDOR-CE, GLOW-OSG, GLOW_SQUID, GLOW_SQUID1, GLOW_SQUID2, GLOW_SQUID3, and GLOW_SQUID4.