### PR TITLE
Add U. Chicago SLATE test stashcaches

### DIFF
--- a/topology/University of Chicago/UChicago/UChicagoCachingInfrastructure.yaml
+++ b/topology/University of Chicago/UChicago/UChicagoCachingInfrastructure.yaml
@@ -28,7 +28,7 @@ Resources:
         Description: StashCache cache server
     AllowedVOs:
       - ANY
-  UCHICAGO_TEST_STASHCACHE_CACHE
+  UCHICAGO_TEST_STASHCACHE_CACHE:
     FQDN: stashcache.uchicago.slateci.net
     Active: false
     ContactLists:
@@ -46,7 +46,7 @@ Resources:
         Secondary:
           ID: 0a22bab3de2d83d723811e3fb1ebca904e924a97
           Name: Lincoln Bryant
-    Service: 
+    Services: 
       XRootD cache server:
         Description: StashCache cache server
     AllowedVOs:

--- a/topology/University of Chicago/UChicago/UChicagoCachingInfrastructure.yaml
+++ b/topology/University of Chicago/UChicago/UChicagoCachingInfrastructure.yaml
@@ -43,7 +43,7 @@ Resources:
           ID: a418fbc5dd33637bba264c01d84d52dd317f2813
           Name: Judith Stephen
       Security Contact:
-        Secondary:
+        Primary:
           ID: 0a22bab3de2d83d723811e3fb1ebca904e924a97
           Name: Lincoln Bryant
     Services: 

--- a/topology/University of Chicago/UChicago/UChicagoCachingInfrastructure.yaml
+++ b/topology/University of Chicago/UChicago/UChicagoCachingInfrastructure.yaml
@@ -31,6 +31,7 @@ Resources:
   UCHICAGO_TEST_STASHCACHE_CACHE:
     FQDN: stashcache.uchicago.slateci.net
     Active: false
+    ID: 999
     ContactLists:
       Administrative Contact:
         Primary:

--- a/topology/University of Chicago/UChicago/UChicagoCachingInfrastructure.yaml
+++ b/topology/University of Chicago/UChicago/UChicagoCachingInfrastructure.yaml
@@ -28,3 +28,50 @@ Resources:
         Description: StashCache cache server
     AllowedVOs:
       - ANY
+  UCHICAGO_TEST_STASHCACHE_CACHE:
+    FQDN: stashcache.uchicago.slateci.net
+    Active: false
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          ID: 0a22bab3de2d83d723811e3fb1ebca904e924a97
+          Name: Lincoln Bryant
+        Secondary:
+          ID: 2d78d115b8b035ba841646faceb9ad0c3413f605
+          Name: Chris Weaver
+        Tertiary:
+          ID: a418fbc5dd33637bba264c01d84d52dd317f2813
+          Name: Judith Stephen
+      Security Contact:
+        Secondary:
+          ID: 0a22bab3de2d83d723811e3fb1ebca904e924a97
+          Name: Lincoln Bryant
+    Services: 
+      XRootD cache server
+        Description: StashCache cache test server
+    AllowedVOs:
+      - ANY_PUBLIC
+  UCHICAGO_AUTH_TEST_STASHCACHE_CACHE:
+    FQDN: stashcache.uchicago.slateci.net
+    Active: false
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          ID: 0a22bab3de2d83d723811e3fb1ebca904e924a97
+          Name: Lincoln Bryant
+        Secondary:
+          ID: 2d78d115b8b035ba841646faceb9ad0c3413f605
+          Name: Chris Weaver
+        Tertiary:
+          ID: a418fbc5dd33637bba264c01d84d52dd317f2813
+          Name: Judith Stephen
+      Security Contact:
+        Secondary:
+          ID: 0a22bab3de2d83d723811e3fb1ebca904e924a97
+          Name: Lincoln Bryant
+    Service: 
+      XRootD cache server
+        Description: StashCache cache server
+    AllowedVOs:
+      - LIGO
+    DN: /DC=org/DC=incommon/C=US/ST=IL/L=Chicago/O=University of Chicago/OU=IT Services - Self Enrollment/CN=stashcache.uchicago.slateci.net

--- a/topology/University of Chicago/UChicago/UChicagoCachingInfrastructure.yaml
+++ b/topology/University of Chicago/UChicago/UChicagoCachingInfrastructure.yaml
@@ -38,7 +38,7 @@ Resources:
           Name: Lincoln Bryant
         Secondary:
           ID: 2d78d115b8b035ba841646faceb9ad0c3413f605
-          Name: Chris Weaver
+          Name: Christopher Weaver
         Tertiary:
           ID: a418fbc5dd33637bba264c01d84d52dd317f2813
           Name: Judith Stephen
@@ -61,7 +61,7 @@ Resources:
           Name: Lincoln Bryant
         Secondary:
           ID: 2d78d115b8b035ba841646faceb9ad0c3413f605
-          Name: Chris Weaver
+          Name: Christopher Weaver
         Tertiary:
           ID: a418fbc5dd33637bba264c01d84d52dd317f2813
           Name: Judith Stephen

--- a/topology/University of Chicago/UChicago/UChicagoCachingInfrastructure.yaml
+++ b/topology/University of Chicago/UChicago/UChicagoCachingInfrastructure.yaml
@@ -47,7 +47,7 @@ Resources:
           ID: 0a22bab3de2d83d723811e3fb1ebca904e924a97
           Name: Lincoln Bryant
     Services: 
-      XRootD cache server
+      XRootD cache server:
         Description: StashCache cache test server
     AllowedVOs:
       - ANY_PUBLIC
@@ -70,7 +70,7 @@ Resources:
           ID: 0a22bab3de2d83d723811e3fb1ebca904e924a97
           Name: Lincoln Bryant
     Service: 
-      XRootD cache server
+      XRootD cache server:
         Description: StashCache cache server
     AllowedVOs:
       - LIGO

--- a/topology/University of Chicago/UChicago/UChicagoCachingInfrastructure.yaml
+++ b/topology/University of Chicago/UChicago/UChicagoCachingInfrastructure.yaml
@@ -28,30 +28,7 @@ Resources:
         Description: StashCache cache server
     AllowedVOs:
       - ANY
-  UCHICAGO_TEST_STASHCACHE_CACHE:
-    FQDN: stashcache.uchicago.slateci.net
-    Active: false
-    ContactLists:
-      Administrative Contact:
-        Primary:
-          ID: 0a22bab3de2d83d723811e3fb1ebca904e924a97
-          Name: Lincoln Bryant
-        Secondary:
-          ID: 2d78d115b8b035ba841646faceb9ad0c3413f605
-          Name: Christopher Weaver
-        Tertiary:
-          ID: a418fbc5dd33637bba264c01d84d52dd317f2813
-          Name: Judith Stephen
-      Security Contact:
-        Primary:
-          ID: 0a22bab3de2d83d723811e3fb1ebca904e924a97
-          Name: Lincoln Bryant
-    Services: 
-      XRootD cache server:
-        Description: StashCache cache test server
-    AllowedVOs:
-      - ANY_PUBLIC
-  UCHICAGO_AUTH_TEST_STASHCACHE_CACHE:
+  UCHICAGO_TEST_STASHCACHE_CACHE
     FQDN: stashcache.uchicago.slateci.net
     Active: false
     ContactLists:
@@ -73,5 +50,6 @@ Resources:
       XRootD cache server:
         Description: StashCache cache server
     AllowedVOs:
+      - ANY_PUBLIC
       - LIGO
     DN: /DC=org/DC=incommon/C=US/ST=IL/L=Chicago/O=University of Chicago/OU=IT Services - Self Enrollment/CN=stashcache.uchicago.slateci.net


### PR DESCRIPTION
These caches are intended for testing deployment of the OSG stashcache container image using SLATE.