### PR TITLE
Cluster in Ottawa Canada is being decommissioned

### DIFF
--- a/topology/CancerComputer/CCHDV/CancerComputer_Hotel.yaml
+++ b/topology/CancerComputer/CCHDV/CancerComputer_Hotel.yaml
@@ -4,7 +4,7 @@ GroupID: 448
 Production: true
 Resources:
   CancerComputer_Hotel_CE:
-    Active: true
+    Active: false
     ContactLists:
       Administrative Contact:
         Secondary:


### PR DESCRIPTION
There is not likely to be another compute datacenter in Ottawa from CancerComputer, so setting the site to inactive while moving the systems to another cluster elsewhere.