### PR TITLE
Add DNs as comments for origin authfiles

### DIFF
--- a/src/stashcache.py
+++ b/src/stashcache.py
@@ -151,7 +151,6 @@ def generate_cache_authfile(vo_data: VOsData, resource_groups: List[ResourceGrou
     """
     authfile = ""
     id_to_dir = defaultdict(set)
-    id_to_dn = {}
 
     resource = _get_cache_resource(fqdn, resource_groups, suppress_errors)
     if fqdn and not resource:
@@ -194,18 +193,14 @@ def generate_cache_authfile(vo_data: VOsData, resource_groups: List[ResourceGrou
                 elif authz.startswith("DN:"):
                     hash = _generate_dn_hash(authz[3:])
                     id_to_dir["u {}".format(hash)].add(namespace)
-                    id_to_dn["u {}".format(hash)] = authz[3:]
 
     if legacy:
         for dn in _generate_ligo_dns():
             hash = _generate_dn_hash(dn)
             id_to_dir["u {}".format(hash)].add("/user/ligo")
-            id_to_dn["u {}".format(hash)] = dn
 
     for id, dir_list in id_to_dir.items():
         if dir_list:
-            if id.startswith("u "):
-                authfile += "# {}\n".format(id_to_dn[id])
             authfile += "{} {}\n".format(id,
                 " ".join([i + " rl" for i in sorted(dir_list)]))
 


### PR DESCRIPTION
Example output for sc-origin.chtc.wisc.edu:
```
# WARNING: Resource SU_STASHCACHE_CACHE was skipped for VO GLOW because the resource does not provide a DN.
# WARNING: Resource MWT2_STASHCACHE_CACHE was skipped for VO GLOW because the resource does not provide a DN.
# WARNING: Resource UCHICAGO_STASHCACHE_CACHE was skipped for VO GLOW because the resource does not provide a DN.
# WARNING: Resource UCSD_STASHCACHE_CACHE was skipped for VO GLOW because the resource does not provide a DN.

# /DC=org/DC=incommon/C=US/postalCode=53706/ST=WI/L=Madison/street=1210 West Dayton Street/O=University of Wisconsin-Madison/OU=OCIS/CN=sc-cache.chtc.wisc.edu
u bc9a1f9c.0 /chtc/PROTECTED lr
# /DC=org/DC=terena/DC=tcs/C=NL/L=Amsterdam/O=Universiteit van Amsterdam/CN=fiona-r-uva.vlan7.uvalight.net
u 571da07e.0 /chtc/PROTECTED lr
# /DC=org/DC=incommon/C=US/postalCode=68588/ST=NE/L=Lincoln/street=14th And R St./O=University of Nebraska-Lincoln/OU=Holland Computing Center/CN=hcc-stash.unl.edu
u 06b434e5.0 /chtc/PROTECTED lr
# /DC=org/DC=incommon/C=US/postalCode=92093/ST=CA/L=La Jolla/street=9500 Gilman Drive/O=University of California, San Diego/OU=UCSD/CN=stashcache.t2.ucsd.edu
u ae8f875c.0 /chtc/PROTECTED lr

u * /chtc/PUBLIC lr
```