### PR TITLE
Update UFlorida-HPC_downtime.yaml

### DIFF
--- a/topology/University of Florida/UF HPC/UFlorida-HPC_downtime.yaml
+++ b/topology/University of Florida/UF HPC/UFlorida-HPC_downtime.yaml
@@ -363,3 +363,19 @@
   Services:
   - GridFtp
 # ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 221825172
+  Description: "UFRC will carry out a major maintenance on 5/6 \u2013 5/9. As a result,\
+    \ HiPerGator cluster, home area, /ufrc, /orange as well as /apps will be out of\
+    \ service during this maintenance. User login servers will be down as well.    \
+    \ Though CMS servers including /cms will not be touched in this maintenance, other\
+    \ resources that CMS jobs may rely on will be unavailable therefore CMS jobs will\
+    \ not be able to run at the time. "
+  Severity: Outage
+  StartTime: May 06, 2019 13:00 +0000
+  EndTime: May 09, 2019 21:00 +0000
+  CreatedTime: May 06, 2019 17:41 +0000
+  ResourceName: UFlorida-XRD
+  Services:
+  - XRootD component
+# ---------------------------------------------------------


### PR DESCRIPTION
Belated Xrootd Redirector Downtime that should have been entered on April 11.