### PR TITLE
Scheduled downtime for site network upgrades

### DIFF
--- a/topology/California Institute of Technology/Caltech CMS Tier2/CIT_CMS_T2_HPC_downtime.yaml
+++ b/topology/California Institute of Technology/Caltech CMS Tier2/CIT_CMS_T2_HPC_downtime.yaml
@@ -1,0 +1,12 @@
+- Class: SCHEDULED
+  ID: 223551490
+  Description: Network upgrade
+  Severity: Outage
+  StartTime: May 13, 2019 15:00 +0000
+  EndTime: May 14, 2019 15:00 +0000
+  CreatedTime: May 08, 2019 17:39 +0000
+  ResourceName: CIT_CMS_T2_HPC_Squid
+  Services:
+  - Squid
+# ---------------------------------------------------------
+

--- a/topology/California Institute of Technology/Caltech CMS Tier2/CIT_CMS_T2_downtime.yaml
+++ b/topology/California Institute of Technology/Caltech CMS Tier2/CIT_CMS_T2_downtime.yaml
@@ -490,3 +490,111 @@
   ResourceName: CIT_HEP_CE
   Services:
     - CE
+
+- Class: SCHEDULED
+  ID: 223551490
+  Description: Network upgrade
+  Severity: Outage
+  StartTime: May 13, 2019 15:00 +0000
+  EndTime: May 14, 2019 15:00 +0000
+  CreatedTime: May 08, 2019 17:39 +0000
+  ResourceName: CIT_CMS_T2_HPC_Squid
+  Services:
+  - Squid
+# ---------------------------------------------------------
+
+- Class: SCHEDULED
+  ID: 223553728
+  Description: Network upgrade
+  Severity: Outage
+  StartTime: May 13, 2019 15:00 +0000
+  EndTime: May 14, 2019 15:00 +0000
+  CreatedTime: May 08, 2019 17:42 +0000
+  ResourceName: CIT_CMS_SE
+  Services:
+  - GridFtp
+# ---------------------------------------------------------
+
+- Class: SCHEDULED
+  ID: 223553816
+  Description: Network upgrade
+  Severity: Outage
+  StartTime: May 13, 2019 15:00 +0000
+  EndTime: May 14, 2019 15:00 +0000
+  CreatedTime: May 08, 2019 17:43 +0000
+  ResourceName: CIT_CMS_T2
+  Services:
+  - CE
+# ---------------------------------------------------------
+
+- Class: SCHEDULED
+  ID: 223553889
+  Description: Network upgrade
+  Severity: Outage
+  StartTime: May 13, 2019 15:00 +0000
+  EndTime: May 14, 2019 15:00 +0000
+  CreatedTime: May 08, 2019 17:43 +0000
+  ResourceName: CIT_CMS_T2B
+  Services:
+  - CE
+# ---------------------------------------------------------
+
+- Class: SCHEDULED
+  ID: 223554238
+  Description: Network upgrade
+  Severity: Outage
+  StartTime: May 13, 2019 15:00 +0000
+  EndTime: May 14, 2019 15:00 +0000
+  CreatedTime: May 08, 2019 17:43 +0000
+  ResourceName: CIT_CMS_T2C
+  Services:
+  - CE
+# ---------------------------------------------------------
+
+- Class: SCHEDULED
+  ID: 223554362
+  Description: Network upgrade
+  Severity: Outage
+  StartTime: May 13, 2019 15:00 +0000
+  EndTime: May 14, 2019 15:00 +0000
+  CreatedTime: May 08, 2019 17:43 +0000
+  ResourceName: CIT_CMS_T2_2_Squid
+  Services:
+  - Squid
+# ---------------------------------------------------------
+
+- Class: SCHEDULED
+  ID: 223554458
+  Description: Network upgrade
+  Severity: Outage
+  StartTime: May 13, 2019 15:00 +0000
+  EndTime: May 14, 2019 15:00 +0000
+  CreatedTime: May 08, 2019 17:44 +0000
+  ResourceName: CIT_CMS_T2_Squid
+  Services:
+  - Squid
+# ---------------------------------------------------------
+
+- Class: SCHEDULED
+  ID: 223554557
+  Description: Network upgrade
+  Severity: Outage
+  StartTime: May 13, 2019 15:00 +0000
+  EndTime: May 14, 2019 15:00 +0000
+  CreatedTime: May 08, 2019 17:44 +0000
+  ResourceName: Caltech PerfSonar Bandwidth
+  Services:
+  - net.perfSONAR.Bandwidth
+# ---------------------------------------------------------
+
+- Class: SCHEDULED
+  ID: 223554632
+  Description: Network upgrade
+  Severity: Outage
+  StartTime: May 13, 2019 15:00 +0000
+  EndTime: May 14, 2019 15:00 +0000
+  CreatedTime: May 08, 2019 17:44 +0000
+  ResourceName: Caltech PerfSonar Latency
+  Services:
+  - net.perfSONAR.Latency
+# ---------------------------------------------------------

--- a/topology/California Institute of Technology/Caltech CMS Tier2/CIT_CMS_T2_downtime.yaml
+++ b/topology/California Institute of Technology/Caltech CMS Tier2/CIT_CMS_T2_downtime.yaml
@@ -491,18 +491,7 @@
   Services:
     - CE
 
-- Class: SCHEDULED
-  ID: 223551490
-  Description: Network upgrade
-  Severity: Outage
-  StartTime: May 13, 2019 15:00 +0000
-  EndTime: May 14, 2019 15:00 +0000
-  CreatedTime: May 08, 2019 17:39 +0000
-  ResourceName: CIT_CMS_T2_HPC_Squid
-  Services:
-  - Squid
-# ---------------------------------------------------------
-
+# ----------------------------------------------------------
 - Class: SCHEDULED
   ID: 223553728
   Description: Network upgrade


### PR DESCRIPTION
We are having a full site 24h downtime as planned for network upgrades. More details here (internal): https://caltech.teamwork.com/#tasks/13978962

@juztas @shashwithap @andres-moya