### PR TITLE
Unicode handling demonstration

### DIFF
--- a/topology/University of Wisconsin/CHTC/CHTC_downtime.yaml
+++ b/topology/University of Wisconsin/CHTC/CHTC_downtime.yaml
@@ -1,0 +1,11 @@
+- Class: UNSCHEDULED
+  ID: 241639931
+  Description: "stuff was broken \xAF\\_(\u30C4)_/\xAF"
+  Severity: Severe
+  StartTime: Apr 29, 2019 00:00 +0000
+  EndTime: Apr 29, 2019 17:00 +0000
+  CreatedTime: May 29, 2019 16:06 +0000
+  ResourceName: CHTC_STASHCACHE_ORIGIN
+  Services:
+  - XRootD origin server
+# ---------------------------------------------------------


### PR DESCRIPTION
This commit is to demonstrate how the topology reader deals with backslashed unicode chars. I will revert this once I am done demonstrating.