### PR TITLE
Retire Utah's initial CE

### DIFF
--- a/topology/University of Utah/CHPC/CHPC Group.yaml
+++ b/topology/University of Utah/CHPC/CHPC Group.yaml
@@ -78,23 +78,4 @@ Resources:
         Description: Compute Element
         Details:
           hidden: false
-  U of U Compute Element:
-    Active: true
-    ContactLists:
-      Administrative Contact:
-        Primary:
-          ID: 443c32443113f2e2dbf7dc77c0e5697d4f27f90a
-          Name: Irvin Allen
-      Security Contact:
-        Primary:
-          ID: 443c32443113f2e2dbf7dc77c0e5697d4f27f90a
-          Name: Irvin Allen
-    Description: This is our main CE for the University of Utah
-    FQDN: osggate.chpc.utah.edu
-    ID: 800
-    Services:
-      CE:
-        Description: Compute Element
-        Details:
-          hidden: false
 SupportCenter: Community Support Center


### PR DESCRIPTION
The admin verified that the resource is no longer active (https://support.opensciencegrid.org/public/tickets/31dd351c0e5212cb76544617d6499f65a8261d00fd14585b91ca9cd48f1956b6) and I verified that it hasn't contributed hours in the past 1 year: https://gracc.opensciencegrid.org/kibana/goto/27df65d72744dc2a1b0497ec58220b84