### PR TITLE
Add downtime for BU_ATLAS_Tier2 due to Annual Power Maintenance

### DIFF
--- a/topology/Boston University/Boston University ATLAS Tier2/BU_ATLAS_Tier2_downtime.yaml
+++ b/topology/Boston University/Boston University ATLAS Tier2/BU_ATLAS_Tier2_downtime.yaml
@@ -72,3 +72,15 @@
   Severity: Outage
   StartTime: May 21, 2018 14:00 +0000
 # ----------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 251480023
+  Description: 'Annual MGHPCC power maintenance day '
+  Severity: Outage
+  StartTime: Jun 10, 2019 17:00 +0000
+  EndTime: Jun 12, 2019 04:00 +0000
+  CreatedTime: Jun 10, 2019 01:26 +0000
+  ResourceName: NET2
+  Services:
+  - CE
+  - SRMv2
+# ---------------------------------------------------------


### PR DESCRIPTION
Annual site-wide MGHPCC power maintenance day

Greeting OSG.  This is my first use of the new downtime scheduling procedure.  Please approve as we want to be down starting 12:00 noon tomorrow... - Saul Youssef