### PR TITLE
Add dns check bypass (SOFTWARE-3676)

### DIFF
--- a/bin/osg-notify
+++ b/bin/osg-notify
@@ -113,7 +113,8 @@ def parseargs():
                          choices=["all", "administrative", "miscellaneous", "security", "submitter"],
                          help="Filter on contact type e.g. administrative, miscellaneous, security, or submitter "
                          "(default: all)", )
-
+    oparser.add_argument("--bypass-dns-check", default=False, dest="bypass_dns_check",
+                         help="Bypass the check of one of our IPs to match with the hostanme resolution")
     args = oparser.parse_args()
 
     if args.oim_recipients == 'vos' and args.owner_vo:
@@ -130,7 +131,7 @@ def parseargs():
 
 def network_ok():
     info = net_name_addr_utils.get_host_network_info()
-    net_ok = net_name_addr_utils.hostnetinfo_good(info)
+    net_ok = net_name_addr_utils.hostnetinfo_good(info, args.bypass_dns_check)
 
     if net_ok:
         return True

--- a/bin/osg-notify
+++ b/bin/osg-notify
@@ -113,8 +113,8 @@ def parseargs():
                          choices=["all", "administrative", "miscellaneous", "security", "submitter"],
                          help="Filter on contact type e.g. administrative, miscellaneous, security, or submitter "
                          "(default: all)", )
-    oparser.add_argument("--bypass-dns-check", default=False, dest="bypass_dns_check",
-                         help="Bypass the check of one of our IPs to match with the hostanme resolution")
+    oparser.add_argument("--bypass-dns-check", action="store_true", dest="bypass_dns_check",
+                         help="Bypass checking that one of the host's IP addresses matches with the hostanme resolution")
     args = oparser.parse_args()
 
     if args.oim_recipients == 'vos' and args.owner_vo:
@@ -129,9 +129,9 @@ def parseargs():
 
     return args
 
-def network_ok():
+def network_ok(bypass_dns_check):
     info = net_name_addr_utils.get_host_network_info()
-    net_ok = net_name_addr_utils.hostnetinfo_good(info, args.bypass_dns_check)
+    net_ok = net_name_addr_utils.hostnetinfo_good(info, bypass_dns_check)
 
     if net_ok:
         return True
@@ -190,7 +190,7 @@ def main():
 
     if args.dryrun:
         print(msg)
-    elif network_ok():
+    elif network_ok(args.bypass_dns_check):
         for _ in range(1, 4):
             try:
                 verify_send = raw_input("Really send mail to {0} recipients? (y/N)".format(len(recipients)))

--- a/src/net_name_addr_utils.py
+++ b/src/net_name_addr_utils.py
@@ -45,11 +45,9 @@ HostNetInfo = collections.namedtuple('HostNetInfo',
 )
 
 def hostnetinfo_good(info, bypass_dns_check=False):
-    return info.addr_is_public \
-       # If the arg --bypass_dns_check is set to True we will not care about
-       # the outcome of info.addr_is_ours
-       and (info.addr_is_ours or bypass_dns_check) \
-       and info.fqdn == info.fqdn_reverse
+    # If the arg --bypass_dns_check is set to True we will not care about
+    # the outcome of info.addr_is_ours
+    return info.addr_is_public and (info.addr_is_ours or bypass_dns_check) and info.fqdn == info.fqdn_reverse
 
 def get_host_network_info():
     port = 25
@@ -84,9 +82,9 @@ def print_net_info(info):
     print("IPv4 is public? %s" % info.addr_is_public)
     print("IPv4 is ours? %s"   % info.addr_is_ours)
     if info.addr_is_ours == False:
-        print("The IP address to wich the hostname resolvs is not and assigned \
-                to any of the interfaces listed in this host. To skip this \
-                check pass the argument --bypass-dns-check to this script"
+        print("The IP address to wich the hostname resolves is not and assigned")
+        print("to any of the interfaces listed in this host. To skip this")
+        print("check pass the argument --bypass-dns-check to this script")
     matchstr = "match" if info.fqdn == info.fqdn_reverse else "mismatch"
     print("Reverse FQDN: %s (%s)" % (info.fqdn_reverse, matchstr))
 

--- a/src/net_name_addr_utils.py
+++ b/src/net_name_addr_utils.py
@@ -44,8 +44,11 @@ HostNetInfo = collections.namedtuple('HostNetInfo',
      'addr_is_ours', 'fqdn_reverse', 'iface_addrs')
 )
 
-def hostnetinfo_good(info):
-    return info.addr_is_public and info.addr_is_ours \
+def hostnetinfo_good(info, bypass_dns_check=False):
+    return info.addr_is_public \
+       # If the arg --bypass_dns_check is set to True we will not care about
+       # the outcome of info.addr_is_ours
+       and (info.addr_is_ours or bypass_dns_check) \
        and info.fqdn == info.fqdn_reverse
 
 def get_host_network_info():
@@ -80,6 +83,10 @@ def print_net_info(info):
     print("IPv4: %s" % info.addr)
     print("IPv4 is public? %s" % info.addr_is_public)
     print("IPv4 is ours? %s"   % info.addr_is_ours)
+    if info.addr_is_ours == False:
+        print("The IP address to wich the hostname resolvs is not and assigned \
+                to any of the interfaces listed in this host. To skip this \
+                check pass the argument --bypass-dns-check to this script"
     matchstr = "match" if info.fqdn == info.fqdn_reverse else "mismatch"
     print("Reverse FQDN: %s (%s)" % (info.fqdn_reverse, matchstr))
 


### PR DESCRIPTION
Adds the argument option '--bypass-dns-check' that tells the script to ignore the result of checking if the ip obtained from the hostname resolution is listed in any of the interfaces of the host.

The tests I did are:

1) real hostname no bypass
real hostname: fermicloud178
set hostname: fermicloud178
bypass-dns-check: no

Result:  OK

2) real hostname + bypass
real hostname: fermicloud178
set hostname: fermicloud178
bypass-dns-check: yes

Result:  OK


3) Use a fake hostanme no bypass
real hostname: fermicloud177
set hostname: fermicloud178
bypass-dns-check: no

Result:  It complains

4) Fake name + bypass option
real hostname: fermicloud177
set hostname: fermicloud178
bypass-dns-check: yes

Result: OK

