### PR TITLE
set inactive NET2_HU resource

### DIFF
--- a/topology/Harvard University/Harvard University/HU_ATLAS_Tier2.yaml
+++ b/topology/Harvard University/Harvard University/HU_ATLAS_Tier2.yaml
@@ -3,7 +3,7 @@ GroupID: 182
 Production: true
 Resources:
   HU_ATLAS_Tier2:
-    Active: true
+    Active: false
     ContactLists:
       Administrative Contact:
         Primary:


### PR DESCRIPTION
This resource is no more active. Per discussion and agreement with @dancaunt and @SaulYoussef I'm disabling it.