### PR TITLE
fix net2.rc.fas.harvard.edu set inactive, was incomplete in PR #708

### DIFF
--- a/topology/Harvard University/Harvard University/HU_ATLAS_Tier2.yaml
+++ b/topology/Harvard University/Harvard University/HU_ATLAS_Tier2.yaml
@@ -95,7 +95,7 @@ Resources:
     VOOwnership:
       ATLAS: 100
   NET2_HU:
-    Active: true
+    Active: false
     ContactLists:
       Administrative Contact:
         Primary:
@@ -144,7 +144,7 @@ Resources:
       StorageCapacityMax: 1
       StorageCapacityMin: 1
   net2.rc.fas.harvard.edu-squid:
-    Active: true
+    Active: false
     ContactLists:
       Administrative Contact:
         Primary:


### PR DESCRIPTION
Now should be completely disabled.