### PR TITLE
Update UFlorida-HPC_downtime.yaml

### DIFF
--- a/topology/University of Florida/UF HPC/UFlorida-HPC_downtime.yaml
+++ b/topology/University of Florida/UF HPC/UFlorida-HPC_downtime.yaml
@@ -383,8 +383,8 @@
   ID: 279906262
   Description: Rack Rearrangement
   Severity: Outage
-  StartTime: Jul 17, 2019 13:00 +0000
-  EndTime: Jul 17, 2019 21:00 +0000
+  StartTime: Jul 19, 2019 13:00 +0000
+  EndTime: Jul 19, 2019 21:00 +0000
   CreatedTime: Jul 12, 2019 23:03 +0000
   ResourceName: UFlorida-SLB-GridFTP
   Services:
@@ -394,8 +394,8 @@
   ID: 279906848
   Description: Rack Rearrangement
   Severity: Outage
-  StartTime: Jul 17, 2019 13:00 +0000
-  EndTime: Jul 17, 2019 21:00 +0000
+  StartTime: Jul 19, 2019 13:00 +0000
+  EndTime: Jul 19, 2019 21:00 +0000
   CreatedTime: Jul 12, 2019 23:04 +0000
   ResourceName: UFlorida-XRD
   Services:


### PR DESCRIPTION
Downtime date change from Jul 17 to Jul 19 due to lack of staffs.