### PR TITLE
Adding downtime for USCMS-FNAL-WC1-CE (cmsosgce.fnal.gov)

### DIFF
--- a/topology/Fermi National Accelerator Laboratory/FNAL USCMS Tier1/USCMS-FNAL-WC1_downtime.yaml
+++ b/topology/Fermi National Accelerator Laboratory/FNAL USCMS Tier1/USCMS-FNAL-WC1_downtime.yaml
@@ -433,3 +433,14 @@
   StartTime: Jun 18, 2019 15:00 +0000
   CreatedTime: Jun 10, 2019 17:12 -0000
 # ----------------------------------------------------------
+- Class: SCHEDULED
+  ID: 294311344
+  Description: The host is out of warranty and needs to be replaced
+  Severity: Outage
+  StartTime: Jul 30, 2019 16:00 +0000
+  EndTime: Aug 07, 2019 15:00 +0000
+  CreatedTime: Jul 29, 2019 15:12 +0000
+  ResourceName: USCMS-FNAL-WC1-CE
+  Services:
+  - CE
+# ---------------------------------------------------------


### PR DESCRIPTION
The host is out of warranty and needs to be replaced