### PR TITLE
Add HCC as a LIGO-recognized origin

### DIFF
--- a/virtual-organizations/LIGO.yaml
+++ b/virtual-organizations/LIGO.yaml
@@ -80,5 +80,6 @@ DataFederations:
         - PUBLIC
     AllowedOrigins:
       - CIT_LIGO_ORIGIN
+      - HCC-StashCache-Origin
     AllowedCaches:
       - HCC-Stash


### PR DESCRIPTION
@efajardo said that the HCC origin is responsible for hosting LIGO's private data so I think it should be registered as such. Are there any reason that we shouldn't?