### PR TITLE
Add downtime for mwt2-gk.campuscluster.illinois.edu due to filesystem…

### DIFF
--- a/topology/University of Chicago/MWT2 ATLAS UC/MWT2_downtime.yaml
+++ b/topology/University of Chicago/MWT2 ATLAS UC/MWT2_downtime.yaml
@@ -870,4 +870,14 @@
   Services:
   - CE
 # ---------------------------------------------------------
-
+- Class: UNSCHEDULED
+  ID: 308108051
+  Description: Condor-CE/filesystem issues
+  Severity: Outage
+  StartTime: Aug 12, 2019 00:00 +0000
+  EndTime: Aug 15, 2019 14:00 +0000
+  CreatedTime: Aug 14, 2019 14:26 +0000
+  ResourceName: MWT2_CE_UIUC
+  Services:
+  - CE
+# ---------------------------------------------------------


### PR DESCRIPTION
… issues

Troubleshooting and fixing the mwt2-gk for htcondor-ce/filesystem issues to get it back up and running.