### PR TITLE
Update host info for squid service.

### DIFF
--- a/topology/Boston University/Boston University ATLAS Tier2/BU_ATLAS_Tier2.yaml
+++ b/topology/Boston University/Boston University ATLAS Tier2/BU_ATLAS_Tier2.yaml
@@ -96,7 +96,7 @@ Resources:
           ID: 82375e645bdcae71e863c8a7aa7eb7f8cf553768
           Name: Saul Youssef
     Description: squid service for frontier and cvmfs
-    FQDN: atlas-net2.bu.edu
+    FQDN: at8.bu.edu
     ID: 923
     Services:
       Squid:


### PR DESCRIPTION
atlas-net2.bu.edu is being decomissioned, new squid service runs on at8.bu.edu.