### PR TITLE
Setting downtime for USCMS-FNAL-WC1-CE3

### DIFF
--- a/topology/Fermi National Accelerator Laboratory/FNAL USCMS Tier1/USCMS-FNAL-WC1_downtime.yaml
+++ b/topology/Fermi National Accelerator Laboratory/FNAL USCMS Tier1/USCMS-FNAL-WC1_downtime.yaml
@@ -455,3 +455,14 @@
   Services:
   - CE
 # ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 326243546
+  Description: The host is out of warranty and needs to be replaced
+  Severity: Outage
+  StartTime: Sep 05, 2019 22:00 +0000
+  EndTime: Sep 12, 2019 15:00 +0000
+  CreatedTime: Sep 04, 2019 14:12 +0000
+  ResourceName: USCMS-FNAL-WC1-CE3
+  Services:
+  - CE
+# ---------------------------------------------------------


### PR DESCRIPTION
The underlying hardware is out of warranty and needs to be replaced. The service will be migrated to a new host with the same name.