### PR TITLE
SBGrid: Update DN's for Timony & Meyer

### DIFF
--- a/virtual-organizations/SBGrid.yaml
+++ b/virtual-organizations/SBGrid.yaml
@@ -51,17 +51,11 @@ LongName: Structural Biology Grid
 OASIS:
   Managers:
     Peter Meyer (primary):
-      DNs: /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Peter Meyer 2982
+      DNs: /DC=org/DC=cilogon/C=US/O=GitHub/CN=Pete Meyer A9298046
       ID: d5ebc623588d1696614076faf0257d83806891a2
     Michael (Mick) Timony (secondary):
       DNs:
-      - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Michael Timony 888
-      - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Michael Timony (Portal)
-        888
-      - /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Michael (Mick)
-        Timony 888
-      - /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Michael Timony
-        (Portal) 888
+      - /DC=org/DC=cilogon/C=US/O=GitHub/CN=Mick T. A9297176
       ID: 41c964bb180f52a5be0ffe708fac051a5114d74a
 
   UseOASIS: true


### PR DESCRIPTION
New DN's for Mick Timony & Peter Meyer of the SBGrid VO.