### PR TITLE
Inactivate cms-squid.sdfarm.kr frontier squid

### DIFF
--- a/topology/Korea Institute of Science and Technology Information/T3_KR_KISTI/T3_KR_KISTI.yaml
+++ b/topology/Korea Institute of Science and Technology Information/T3_KR_KISTI/T3_KR_KISTI.yaml
@@ -5,7 +5,7 @@ GroupID: 394
 Production: true
 Resources:
   KISTI_CMS_SQUID:
-    Active: true
+    Active: false
     ContactLists:
       Administrative Contact:
         Primary:


### PR DESCRIPTION
For a request from CMS facility staff, we move this squid server to T2_KR_KISTI.