### PR TITLE
replace Hover with Xhao in updated ATLAS topology.

### DIFF
--- a/virtual-organizations/ATLAS.yaml
+++ b/virtual-organizations/ATLAS.yaml
@@ -3,16 +3,14 @@ CertificateOnly: false
 Community: The ATLAS physics community.
 Contacts:
   Administrative Contact:
-  - ID: fa0ca5484e97c3caa3a2fb59217caa70e8b3d66d
-    Name: John Hover
-  Miscellaneous Contact:
   - ID: a688fe1904cfc91c2c5529eb898a13f9ebfbadbe
     Name: Xin Zhao
+  Miscellaneous Contact:
   - ID: 8a7d75ea65a2962520279197c72df6a16e1533a1
     Name: John S. De Stefano Jr.
   Security Contact:
-  - ID: fa0ca5484e97c3caa3a2fb59217caa70e8b3d66d
-    Name: John Hover
+  - ID: a688fe1904cfc91c2c5529eb898a13f9ebfbadbe
+    Name: Xin Zhao
   Sponsors:
   - ID: 2a7d2665e9aa0e66ab4131e53de14df72a51b74d
     Name: Horst Severini


### PR DESCRIPTION
John Hover is no longer associated with BNL or ATLAS.

I believe Caballero should also be removed from OASIS.