### PR TITLE
In CHTC.yaml changed submit-3 to submit3

### DIFF
--- a/topology/University of Wisconsin/CHTC/CHTC.yaml
+++ b/topology/University of Wisconsin/CHTC/CHTC.yaml
@@ -153,7 +153,7 @@ Resources:
     VOOwnership:
       GLOW: 100
 
-  CHTC-submit-3:
+  CHTC-submit3:
     Active: true
     ContactLists:
       Administrative Contact:
@@ -178,7 +178,7 @@ Resources:
           ID: 3f306d87236d84ef770ddf0c34844908e2d94dfa
           Name: Timothy Slauson
     Description: CHTC Submit Node
-    FQDN: submit-3.chtc.wisc.edu
+    FQDN: submit3.chtc.wisc.edu
     ID: 1028
     Services:
       Submit Node:


### PR DESCRIPTION
To make it consistent with submit2.chtc.wisc.edu, which is the
first CHTC submit node to have the hyphen removed from naming
convention.