### PR TITLE
Revising FNAL tape downtime 

### DIFF
--- a/topology/Fermi National Accelerator Laboratory/FNAL USCMS Tier1/USCMS-FNAL-WC1_downtime.yaml
+++ b/topology/Fermi National Accelerator Laboratory/FNAL USCMS Tier1/USCMS-FNAL-WC1_downtime.yaml
@@ -538,7 +538,7 @@
   Description: Tape room humidity control failure
   Severity: Outage
   StartTime: Oct 26, 2019 00:00 +0000
-  EndTime: Nov 01, 2019 23:59 +0000
+  EndTime: Oct 29, 2019 19:00 +0000
   CreatedTime: Oct 28, 2019 16:23 +0000
   ResourceName: USCMS-FNAL-WC1-SE
   Services:


### PR DESCRIPTION
Tapes are back in operation, so adjusting downtime to match