### PR TITLE
Set a single APEL normalization factor for Purdue CMS

### DIFF
--- a/topology/Purdue University/Purdue CMS/Purdue.yaml
+++ b/topology/Purdue University/Purdue CMS/Purdue.yaml
@@ -46,7 +46,7 @@ Resources:
     VOOwnership:
       CMS: 100
     WLCGInformation:
-      APELNormalFactor: 16.37
+      APELNormalFactor: 15.07
       AccountingName: T2_US_Purdue
       HEPSPEC: 3929
       InteropAccounting: true
@@ -101,7 +101,7 @@ Resources:
     VOOwnership:
       CMS: 100
     WLCGInformation:
-      APELNormalFactor: 15.03
+      APELNormalFactor: 15.07
       AccountingName: T2_US_Purdue
       HEPSPEC: 123284
       InteropAccounting: true
@@ -156,7 +156,7 @@ Resources:
     VOOwnership:
       CMS: 0
     WLCGInformation:
-      APELNormalFactor: 17.95
+      APELNormalFactor: 15.07
       AccountingName: T2_US_Purdue
       HEPSPEC: 85
       InteropAccounting: true
@@ -212,7 +212,7 @@ Resources:
     VOOwnership:
       CMS: 0
     WLCGInformation:
-      APELNormalFactor: 17.95
+      APELNormalFactor: 15.07
       AccountingName: T2_US_Purdue
       HEPSPEC: 85
       InteropAccounting: true
@@ -268,7 +268,7 @@ Resources:
     VOOwnership:
       CMS: 0
     WLCGInformation:
-      APELNormalFactor: 22.5
+      APELNormalFactor: 15.07
       AccountingName: T2_US_Purdue
       HEPSPEC: 85
       InteropAccounting: true


### PR DESCRIPTION
As discussed in #932, we will set a single APEL normalization factor for all Purdue CMS resources.