### PR TITLE
add new VO for ARA experiment

### DIFF
--- a/virtual-organizations/ARA.yaml
+++ b/virtual-organizations/ARA.yaml
@@ -1,0 +1,34 @@
+AppDescription: ARA Production and Analysis
+CertificateOnly: false
+Community: The ARA astrophysics community.
+Contacts:
+  Administrative Contact:
+  - ID: b512ff43d2e9239b62fb63bf3b30202fa30731e9
+    Name: David Schultz
+  - ID: 67523ec91c983a4c0c1c576beeac1037aa863da3
+    Name: Steve Barnet
+  - ID: bc87af94d3512f536e417f1e45808b975fb2874f
+    Name: Vladimir Brik
+  Security Contact:
+  - ID: 67523ec91c983a4c0c1c576beeac1037aa863da3
+    Name: Steve Barnet
+Disable: false
+FieldsOfScience:
+  PrimaryFields:
+  - Astrophysics
+  SecondaryFields:
+  - Physics and astronomy
+ID: 138
+LongName: Askaryan Radio Array
+Name: ARA
+OASIS:
+  OASISRepoURLs:
+  - http://cvmfs-stratum0.wipac.wisc.edu/cvmfs/ara.opensciencegrid.org
+  - http://hcc-cvmfs-repo.unl.edu:8000/cvmfs/ara.osgstorage.org
+  UseOASIS: true
+ParentVO:
+  ID: 38
+  Name: IceCube
+PrimaryURL: https://ara.wipac.wisc.edu
+PurposeURL: https://ara.wipac.wisc.edu
+SupportURL: https://ara.wipac.wisc.edu


### PR DESCRIPTION
The primary purpose of the VO is to host an OASIS repository for ARA.

@efajardo said to create the VO here.