### PR TITLE
Adjust structure of OASIS Managers in VOs (SOFTWARE-3947)

### DIFF
--- a/src/webapp/common.py
+++ b/src/webapp/common.py
@@ -144,6 +144,19 @@ def expand_attr_list(data: Dict, namekey: str, ordering: Union[List, None]=None,
     return newdata
 
 
+def order_dict(value: Dict, ordering: List, ignore_missing=False) -> OrderedDict:
+    """
+    Convert a dict to an OrderedDict with key order provided by ``ordering``.
+    """
+    new_value = OrderedDict()
+    for elem in ordering:
+        if elem in value:
+            new_value[elem] = value[elem]
+        elif not ignore_missing:
+            new_value[elem] = None
+    return new_value
+
+
 def to_xml(data) -> str:
     return xmltodict.unparse(data, pretty=True, encoding="utf-8")
 

--- a/src/webapp/vos_data.py
+++ b/src/webapp/vos_data.py
@@ -140,7 +140,6 @@ class VOsData(object):
         """
         new_managers = copy.deepcopy(managers)
         for i, data in enumerate(managers):
-            name = data["Name"]
             if not is_null(data, "DNs"):
                 new_managers[i]["DNs"] = {"DN": data["DNs"]}
             else:

--- a/template-virtual-organization.yaml
+++ b/template-virtual-organization.yaml
@@ -72,7 +72,7 @@ SupportURL: http://www.usatlas.bnl.gov/index.shtml
 #
 ####### Managers (optional) are one or more people with manager access to this VO's OASIS space
 #   # Managers:
-#   #   <MANAGER NAME>:
+#   #   - Name: <MANAGER NAME>
 #   #     # DNs are one or more DNs for this manager's cert(s)
 #   #     DNs:
 #   #     - <DN>

--- a/virtual-organizations/ACCRE.yaml
+++ b/virtual-organizations/ACCRE.yaml
@@ -43,9 +43,9 @@ OASIS:
     UseOASIS: true
 ####### Managers (optional) are one or more people with manager access to this VO's OASIS space
     Managers:
-      Andrew Malone Melo:
+      - Name: Andrew Malone Melo
         DNs:  /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=meloam/CN=692113/CN=Andrew Malone Melo
         ID:  11107327543306be8c340cfa2281444a2d428318
-      Kevin Buterbaugh:
+      - Name: Kevin Buterbaugh
         DNs: /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=klb/CN=670967/CN=Kevin Buterbaugh
         ID: f8b4ca01236536e55faee256011d9c70d8eaff67

--- a/virtual-organizations/ATLAS.yaml
+++ b/virtual-organizations/ATLAS.yaml
@@ -39,7 +39,7 @@ LongName: United States ATLAS Collaboration
 MembershipServicesURL: https://lcg-voms2.cern.ch:8443/vo/atlas/vomrs
 OASIS:
   Managers:
-    Dave Dykstra:
+    - Name: Dave Dykstra
       DNs:
       - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Dave Dykstra 508
       - /DC=org/DC=cilogon/C=US/O=Fermi National Accelerator Laboratory/OU=People/CN=Dave

--- a/virtual-organizations/Argoneut.yaml
+++ b/virtual-organizations/Argoneut.yaml
@@ -25,7 +25,7 @@ LongName: Fermilab/Argoneut
 MembershipServicesURL: https://voms.fnal.gov:8443/voms/fermilab
 OASIS:
   Managers:
-    Gabriele Garzoglio:
+    - Name: Gabriele Garzoglio
       DNs:
       - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Gabriele Garzoglio
         203

--- a/virtual-organizations/BNL.yaml
+++ b/virtual-organizations/BNL.yaml
@@ -30,7 +30,7 @@ ID: 114
 LongName: Brookhaven National Laboratory
 OASIS:
   Managers:
-    John S. De Stefano Jr.:
+    - Name: John S. De Stefano Jr.
       DNs:
       -  /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=destefan/CN=665120/CN=John Steven De Stefano Jr
       ID: 8a7d75ea65a2962520279197c72df6a16e1533a1

--- a/virtual-organizations/Belle.yaml
+++ b/virtual-organizations/Belle.yaml
@@ -48,15 +48,15 @@ LongName: The Belle Experiment at KEK
 MembershipServicesURL: https://voms.cc.kek.jp:8443/voms/belle
 OASIS:
   Managers:
-    Hideki Miyake:
+    - Name: Hideki Miyake
       DNs: /C=JP/O=KEK/OU=CRC/CN=Hideki Miyake
       ID: 6329edd750ea546a7b519d29a50902e3515bab0b
-    I Ueda:
+    - Name: I Ueda
       DNs:
       - /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=ueda/CN=482702/CN=I Ueda
       - /C=JP/O=KEK/OU=CRC/CN=UEDA Ikuo
       ID: 912a123a80b973b4abdfe9a116387294cc6c1da2
-    Kiyoshi Hayasaka:
+    - Name: Kiyoshi Hayasaka
       DNs: /C=JP/O=KEK/OU=CRC/CN=HAYASAKA Kiyoshi
       ID: a576382ce7f50940632597dbf12b34eaa718bae2
   UseOASIS: true

--- a/virtual-organizations/CDF.yaml
+++ b/virtual-organizations/CDF.yaml
@@ -27,7 +27,7 @@ LongName: Collider Detector at Fermilab
 MembershipServicesURL: https://voms.fnal.gov:8443/voms/cdf/
 OASIS:
   Managers:
-    Joe Boyd:
+    - Name: Joe Boyd
       DNs:
       - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Joe Boyd 579
       - /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Joe Boyd 3582

--- a/virtual-organizations/CMS.yaml
+++ b/virtual-organizations/CMS.yaml
@@ -92,11 +92,11 @@ LongName: Compact Muon Solenoid
 MembershipServicesURL: https://lcg-voms.cern.ch:8443/voms/cms
 OASIS:
   Managers:
-    David Alexander Mason:
+    - Name: David Alexander Mason
       DNs: /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=dmason/CN=664436/CN=David Alexander
         Mason
       ID: fbc689042bf0b68df85561edb1a1fb33e1c799a3
-    HYUNWOO KIM:
+    - Name: HYUNWOO KIM
       DNs:
       - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=HYUNWOO KIM 882
       - /DC=gov/DC=fnal/O=Fermilab/OU=People/CN=Hyun woo Kim/CN=UID:hyunwoo

--- a/virtual-organizations/COUPP.yaml
+++ b/virtual-organizations/COUPP.yaml
@@ -24,11 +24,11 @@ LongName: Chicagoland Observatory for Underground Particle Physics
 MembershipServicesURL: https://voms.fnal.gov:8443/voms/fermilab
 OASIS:
   Managers:
-    Christophe Bonnaud:
+    - Name: Christophe Bonnaud
       DNs: /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Christophe
         Bonnaud 3139
       ID: 8cc594d4724bec67b459ff043a26b389a5286382
-    Gabriele Garzoglio:
+    - Name: Gabriele Garzoglio
       DNs:
       - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Gabriele Garzoglio
         203

--- a/virtual-organizations/CSIU.yaml
+++ b/virtual-organizations/CSIU.yaml
@@ -42,7 +42,7 @@ ID: 72
 LongName: Computational Sciences at Indiana University
 OASIS:
   Managers:
-    Scott Teige:
+    - Name: Scott Teige
       DNs:
       - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Scott Teige 652
       - /DC=org/DC=cilogon/C=US/O=Indiana University/CN=Scott Teige A7052

--- a/virtual-organizations/Captmnv.yaml
+++ b/virtual-organizations/Captmnv.yaml
@@ -21,7 +21,7 @@ LongName: CAPTAIN-MINERvA
 MembershipServicesURL: https://voms2.fnal.gov:8443/voms/fermilab
 OASIS:
   Managers:
-    Joe Boyd:
+    - Name: Joe Boyd
       DNs:
       - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Joe Boyd 579
       - /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Joe Boyd 3582

--- a/virtual-organizations/Cdms.yaml
+++ b/virtual-organizations/Cdms.yaml
@@ -18,7 +18,7 @@ LongName: Fermilab/Cdms
 MembershipServicesURL: https://voms.fnal.gov:8443/voms/fermilab
 OASIS:
   Managers:
-    Joe Boyd:
+    - Name: Joe Boyd
       DNs:
       - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Joe Boyd 579
       - /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Joe Boyd 3582

--- a/virtual-organizations/DES.yaml
+++ b/virtual-organizations/DES.yaml
@@ -35,7 +35,7 @@ LongName: Dark Energy Survey
 MembershipServicesURL: https://voms.fnal.gov:8443/voms/des/admin/home.action
 OASIS:
   Managers:
-    Joe Boyd:
+    - Name: Joe Boyd
       DNs:
       - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Joe Boyd 579
       - /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Joe Boyd 3582

--- a/virtual-organizations/DUNE.yaml
+++ b/virtual-organizations/DUNE.yaml
@@ -37,7 +37,7 @@ LongName: Deep Underground Neutrino Experiment
 MembershipServicesURL: https://voms.fnal.gov:8443/voms/dune
 OASIS:
   Managers:
-    Joe Boyd:
+    - Name: Joe Boyd
       DNs:
       - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Joe Boyd 579
       - /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Joe Boyd 3582

--- a/virtual-organizations/DZero.yaml
+++ b/virtual-organizations/DZero.yaml
@@ -45,7 +45,7 @@ LongName: D0 Experiment at Fermilab
 MembershipServicesURL: https://voms.fnal.gov:8443/voms/dzero
 OASIS:
   Managers:
-    Joe Boyd:
+    - Name: Joe Boyd
       DNs:
       - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Joe Boyd 579
       - /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Joe Boyd 3582

--- a/virtual-organizations/EIC.yaml
+++ b/virtual-organizations/EIC.yaml
@@ -27,7 +27,7 @@ LongName: The Electron-Ion Collider eXperiment at RHIC
 MembershipServicesURL: https://www.sdcc.bnl.gov/#accounts
 OASIS:
   Managers:
-    John S. De Stefano Jr.:
+    - Name: John S. De Stefano Jr.
       DNs:
       - /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=destefan/CN=665120/CN=John Steven De Stefano Jr
       ID: 8a7d75ea65a2962520279197c72df6a16e1533a1

--- a/virtual-organizations/ENMR.yaml
+++ b/virtual-organizations/ENMR.yaml
@@ -49,7 +49,7 @@ LongName: A worldwide e-Infrastructure for NMR and structural biology
 MembershipServicesURL: https://voms2.cnaf.infn.it:8443/voms/enmr.eu/
 OASIS:
   Managers:
-    Marco Verlato:
+    - Name: Marco Verlato
       DNs: /DC=org/DC=terena/DC=tcs/C=IT/O=Istituto Nazionale di Fisica Nucleare/CN=Marco Verlato verlato@infn.it
       ID: 0966df4f0f20720c3fbc4bf5f9fbd434148a8506
   UseOASIS: true

--- a/virtual-organizations/Fermilab.yaml
+++ b/virtual-organizations/Fermilab.yaml
@@ -45,14 +45,14 @@ LongName: Fermi National Accelerator Laboratory
 MembershipServicesURL: https://voms2.fnal.gov:8443/voms/fermilab
 OASIS:
   Managers:
-    Dave Dykstra:
+    - Name: Dave Dykstra
       DNs:
       - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Dave Dykstra 508
       - /DC=org/DC=cilogon/C=US/O=Fermi National Accelerator Laboratory/OU=People/CN=Dave
         Dykstra/CN=UID:dwd
       - /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Dave Dykstra 508
       ID: 85fe79f7c8a447834460b6852f46d3eef32fb714
-    Lynn Garren:
+    - Name: Lynn Garren
       DNs:
       - /DC=gov/DC=fnal/O=Fermilab/OU=People/CN=Lynn A. Garren/CN=UID:garren
       - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Lynn Garren 217

--- a/virtual-organizations/GLOW.yaml
+++ b/virtual-organizations/GLOW.yaml
@@ -38,7 +38,7 @@ ID: 13
 LongName: Grid Laboratory of Wisconsin
 OASIS:
   Managers:
-    Aaron Moate:
+    - Name: Aaron Moate
       DNs: /DC=org/DC=doegrids/OU=People/CN=Aaron Moate 717557
       ID: 46a55ac4815b2b8c00ff283549f413113b45d628
   UseOASIS: true

--- a/virtual-organizations/Gluex.yaml
+++ b/virtual-organizations/Gluex.yaml
@@ -26,12 +26,12 @@ LongName: Gluex experiment at Jefferson Lab
 MembershipServicesURL: https://gryphn.phys.uconn.edu:8443/voms/Gluex
 OASIS:
   Managers:
-    Mark Ito:
+    - Name: Mark Ito
       DNs:
       - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Mark Ito 1104
       - /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Mark Ito 1104
       ID: 192356e8dfe991026cc11fc5a7250a1504034bee
-    Richard T. Jones:
+    - Name: Richard T. Jones
       DNs:
       - /DC=org/DC=cilogon/C=US/O=University of Connecticut/CN=Richard Jones A159431
       ID: 650bf84a5cf49caf504fed22ce07b98580c6fa12

--- a/virtual-organizations/HCC.yaml
+++ b/virtual-organizations/HCC.yaml
@@ -50,11 +50,11 @@ LongName: Holland Computing Center at the University of Nebraska.
 MembershipServicesURL: https://hcc-voms.unl.edu:8443/voms/hcc/Login.do
 OASIS:
   Managers:
-    Brian Bockelman:
+    - Name: Brian Bockelman
       DNs: /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=bbockelm/CN=659869/CN=Brian
         Paul Bockelman
       ID: 66ee5cfb622a7343dac85dee42815d1f4fbc2d85
-    Derek Weitzel:
+    - Name: Derek Weitzel
       DNs: /DC=org/DC=cilogon/C=US/O=University of Nebraska-Lincoln/CN=Derek Weitzel A215526
       ID: 5d324b2a0011c48462f5c6d981b307e3733cb8b6
   UseOASIS: true

--- a/virtual-organizations/ILC.yaml
+++ b/virtual-organizations/ILC.yaml
@@ -22,14 +22,14 @@ LongName: International Linear Collider
 MembershipServicesURL: https://grid-voms.desy.de:8443/voms/ilc
 OASIS:
   Managers:
-    Andre Philippe Sailer:
+    - Name: Andre Philippe Sailer
       DNs: /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=sailer/CN=683529/CN=Andre Sailer
       ID: ee4849a97f735597bed71dff0b7866d90065a5f3
-    Dorian Kcira:
+    - Name: Dorian Kcira
       DNs: /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=dkcira/CN=655958/CN=Dorian
         Kcira
       ID: 1fd41017c89ee21ca274634207ddb71cf35518af
-    Scott Teige:
+    - Name: Scott Teige
       DNs:
       - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Scott Teige 652
       - /DC=org/DC=cilogon/C=US/O=Indiana University/CN=Scott Teige A7052

--- a/virtual-organizations/LIGO.yaml
+++ b/virtual-organizations/LIGO.yaml
@@ -40,29 +40,29 @@ ID: 23
 LongName: Laser Interferometer Gravitational-Wave Observatory
 OASIS:
   Managers:
-    Brian Bockelman:
+    - Name: Brian Bockelman
       DNs: /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=bbockelm/CN=659869/CN=Brian
         Paul Bockelman
       ID: 66ee5cfb622a7343dac85dee42815d1f4fbc2d85
-    James Alexander Clark:
+    - Name: James Alexander Clark
       DNs: /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=James Alexander
         Clark 4038
       ID: 504894b714071a10a647aaaa4e1fe7ee3186430b
-    Lazzaro Claudia:
+    - Name: Lazzaro Claudia
       DNs: /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Lazzaro Claudia
         4036
       ID: 267375b4ce27186eaa7648a2cfb6212f0a10ecf8
-    Matyas Selmeci:
+    - Name: Matyas Selmeci
       DNs: /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Matyas Selmeci
       ID: ec1013224934d6a11a2a46a5234b3337095f5ec4
-    Peter Couvares:
+    - Name: Peter Couvares
       DNs: /DC=org/DC=cilogon/C=US/O=LIGO/CN=Peter Couvares peter.couvares@ligo.org
       ID: 547c65a6ed5e9e755c023418a47b8b92e88f0523
-    Sharon Brunett:
+    - Name: Sharon Brunett
       DNs: /DC=org/DC=cilogon/C=US/O=California Institute of Technology/CN=Sharon
         Brunett A20751
       ID: e817cc79849447cc8c98f376e2d0052dda7c675b
-    Duncan MacLeod:
+    - Name: Duncan MacLeod
       DNs: /DC=org/DC=cilogon/C=US/O=LIGO/CN=Duncan Macleod duncan.macleod@ligo.org
       ID: 1e153a63463094d82c7b2786bd2f57f996974984
   OASISRepoURLs:

--- a/virtual-organizations/LSST.yaml
+++ b/virtual-organizations/LSST.yaml
@@ -39,7 +39,7 @@ LongName: Large Synoptic Survey Telescope
 MembershipServicesURL: https://voms.fnal.gov:8443/voms/lsst/
 OASIS:
   Managers:
-    Joe Boyd:
+    - Name: Joe Boyd
       DNs:
       - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Joe Boyd 579
       - /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Joe Boyd 3582

--- a/virtual-organizations/LZ.yaml
+++ b/virtual-organizations/LZ.yaml
@@ -47,11 +47,11 @@ LongName: LUX-ZEPLIN
 MembershipServicesURL: https://voms.hep.wisc.edu:8443/voms/lz
 OASIS:
   Managers:
-    Daniel Bradley:
+    - Name: Daniel Bradley
       DNs: /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=dbradley/CN=614788/CN=Daniel
         Charles Bradley
       ID: 210d07bf782db9938049eaf11820ec908fdda3b5
-    Sridhara Dasu:
+    - Name: Sridhara Dasu
       DNs: /DC=org/DC=doegrids/OU=People/CN=Sridhara Rao Dasu 610586
       ID: 529b7136c6572fde3a9b138ba80acc94136df454
   OASISRepoURLs:

--- a/virtual-organizations/Lariat.yaml
+++ b/virtual-organizations/Lariat.yaml
@@ -27,7 +27,7 @@ LongName: Fermilab/Lariat
 MembershipServicesURL: https://voms.fnal.gov:8443/voms/fermilab
 OASIS:
   Managers:
-    Joe Boyd:
+    - Name: Joe Boyd
       DNs:
       - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Joe Boyd 579
       - /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Joe Boyd 3582

--- a/virtual-organizations/MIS.yaml
+++ b/virtual-organizations/MIS.yaml
@@ -27,34 +27,34 @@ ID: 25
 LongName: OSG Monitoring Information System
 OASIS:
   Managers:
-    Brian Bockelman:
+    - Name: Brian Bockelman
       DNs: /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=bbockelm/CN=659869/CN=Brian
         Paul Bockelman
       ID: 66ee5cfb622a7343dac85dee42815d1f4fbc2d85
-    Brian Lin:
+    - Name: Brian Lin
       DNs:
       - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Brian Lin 1047
       - /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Brian Lin 1047
       ID: 026718919cb6a13e64c8df3b53398c7214ceeaf1
-    Dave Dykstra:
+    - Name: Dave Dykstra
       DNs:
       - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Dave Dykstra 508
       - /DC=org/DC=cilogon/C=US/O=Fermi National Accelerator Laboratory/OU=People/CN=Dave
         Dykstra/CN=UID:dwd
       - /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Dave Dykstra 508
       ID: 85fe79f7c8a447834460b6852f46d3eef32fb714
-    Matyas Selmeci:
+    - Name: Matyas Selmeci
       DNs:
         - /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Matyas Selmeci
         - /DC=org/DC=cilogon/C=US/O=University of Wisconsin-Madison/CN=Matyas Selmeci A148276
       ID: ec1013224934d6a11a2a46a5234b3337095f5ec4
-    Tim Cartwright:
+    - Name: Tim Cartwright
       DNs:
       - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Tim Cartwright 192
       - /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Tim Cartwright
         192
       ID: 19511ac08de9fbb51709a05a707decfe36de286f
-    Tim Theisen:
+    - Name: Tim Theisen
       DNs:
       - /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Tim Theisen 1349
       - /DC=org/DC=cilogon/C=US/O=University of Wisconsin-Madison/CN=Tim Theisen A148211

--- a/virtual-organizations/MicroBooNE.yaml
+++ b/virtual-organizations/MicroBooNE.yaml
@@ -33,14 +33,14 @@ LongName: Fermilab/MicroBooNE
 MembershipServicesURL: https://voms.fnal.gov:8443/voms/fermilab
 OASIS:
   Managers:
-    Brian Bockelman:
+    - Name: Brian Bockelman
       DNs: /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=bbockelm/CN=659869/CN=Brian
         Paul Bockelman
       ID: 66ee5cfb622a7343dac85dee42815d1f4fbc2d85
-    Derek Weitzel:
+    - Name: Derek Weitzel
       DNs: /DC=org/DC=cilogon/C=US/O=University of Nebraska-Lincoln/CN=Derek Weitzel A215526
       ID: 5d324b2a0011c48462f5c6d981b307e3733cb8b6
-    Joe Boyd:
+    - Name: Joe Boyd
       DNs:
       - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Joe Boyd 579
       - /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Joe Boyd 3582

--- a/virtual-organizations/Minerva.yaml
+++ b/virtual-organizations/Minerva.yaml
@@ -19,7 +19,7 @@ LongName: Fermilab/Minerva
 MembershipServicesURL: https://voms.fnal.gov:8443/voms/fermilab
 OASIS:
   Managers:
-    Joe Boyd:
+    - Name: Joe Boyd
       DNs:
       - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Joe Boyd 579
       - /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Joe Boyd 3582

--- a/virtual-organizations/Minos.yaml
+++ b/virtual-organizations/Minos.yaml
@@ -19,7 +19,7 @@ LongName: Fermilab/Minos
 MembershipServicesURL: https://voms.fnal.gov:8443/voms/fermilab
 OASIS:
   Managers:
-    Joe Boyd:
+    - Name: Joe Boyd
       DNs:
       - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Joe Boyd 579
       - /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Joe Boyd 3582

--- a/virtual-organizations/Mu2e.yaml
+++ b/virtual-organizations/Mu2e.yaml
@@ -19,14 +19,14 @@ LongName: Fermilab/Mu2e
 MembershipServicesURL: https://voms.fnal.gov:8443/voms/fermilab
 OASIS:
   Managers:
-    Brian Bockelman:
+    - Name: Brian Bockelman
       DNs: /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=bbockelm/CN=659869/CN=Brian
         Paul Bockelman
       ID: 66ee5cfb622a7343dac85dee42815d1f4fbc2d85
-    Derek Weitzel:
+    - Name: Derek Weitzel
       DNs: /DC=org/DC=cilogon/C=US/O=University of Nebraska-Lincoln/CN=Derek Weitzel A215526
       ID: 5d324b2a0011c48462f5c6d981b307e3733cb8b6
-    Raymond Lloyd Culbertson:
+    - Name: Raymond Lloyd Culbertson
       DNs: /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Raymond Lloyd
         Culbertson 1119
       ID: d2c84720987c5e6a0d6290f84a9677c044147808

--- a/virtual-organizations/Nova.yaml
+++ b/virtual-organizations/Nova.yaml
@@ -25,17 +25,17 @@ LongName: Fermilab/Nova
 MembershipServicesURL: https://voms.fnal.gov:8443/voms/fermilab
 OASIS:
   Managers:
-    Alexander I. Himmel:
+    - Name: Alexander I. Himmel
       DNs: /DC=gov/DC=fnal/O=Fermilab/OU=People/CN=Alex I. Himmel/CN=UID:ahimmel
       ID: 512449466954b8e2d2df17f25173d273e431e1c6
-    Brian Bockelman:
+    - Name: Brian Bockelman
       DNs: /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=bbockelm/CN=659869/CN=Brian
         Paul Bockelman
       ID: 66ee5cfb622a7343dac85dee42815d1f4fbc2d85
-    Derek Weitzel:
+    - Name: Derek Weitzel
       DNs: /DC=org/DC=cilogon/C=US/O=University of Nebraska-Lincoln/CN=Derek Weitzel A215526
       ID: 5d324b2a0011c48462f5c6d981b307e3733cb8b6
-    Robert Illingworth:
+    - Name: Robert Illingworth
       DNs:
       - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Robert Illingworth
         1724

--- a/virtual-organizations/OSG.yaml
+++ b/virtual-organizations/OSG.yaml
@@ -38,14 +38,14 @@ LongName: Open Science Grid
 MembershipServicesURL: https://voms.opensciencegrid.org:8443/voms/osg
 OASIS:
   Managers:
-    Derek Weitzel:
+    - Name: Derek Weitzel
       DNs: /DC=org/DC=cilogon/C=US/O=University of Nebraska-Lincoln/CN=Derek Weitzel A215526
       ID: 5d324b2a0011c48462f5c6d981b307e3733cb8b6
-    Lincoln Bryant:
+    - Name: Lincoln Bryant
       DNs:
       - /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=lbryant/CN=738076/CN=Lincoln Bryant
       ID: 0a22bab3de2d83d723811e3fb1ebca904e924a97
-    Mats Rynge:
+    - Name: Mats Rynge
       DNs:
       - /DC=org/DC=cilogon/C=US/O=University of Southern California/CN=Mats Rynge A91316
       ID: 38cd7e4efcb45e2aff808b98f5f928c96b3a8608

--- a/virtual-organizations/SBGrid.yaml
+++ b/virtual-organizations/SBGrid.yaml
@@ -48,7 +48,7 @@ ID: 32
 LongName: Structural Biology Grid
 OASIS:
   Managers:
-    Peter Meyer (primary):
+    - Name: Peter Meyer (primary)
       DNs: /DC=org/DC=cilogon/C=US/O=Harvard University/CN=Peter Meyer A9331936
       ID: d5ebc623588d1696614076faf0257d83806891a2
 

--- a/virtual-organizations/SBN.yaml
+++ b/virtual-organizations/SBN.yaml
@@ -19,7 +19,7 @@ LongName: Short-Baseline Neutrino Program
 MembershipServicesURL: https://voms2.fnal.gov:8443/voms/fermilab
 OASIS:
   Managers:
-    Joe Boyd:
+    - Name: Joe Boyd
       DNs:
       - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Joe Boyd 579
       - /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Joe Boyd 3582

--- a/virtual-organizations/SBND.yaml
+++ b/virtual-organizations/SBND.yaml
@@ -19,7 +19,7 @@ LongName: Short-Baseline Near Detector
 MembershipServicesURL: https://voms2.fnal.gov:8443/voms/fermilab
 OASIS:
   Managers:
-    Joe Boyd:
+    - Name: Joe Boyd
       DNs:
       - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Joe Boyd 579
       - /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Joe Boyd 3582

--- a/virtual-organizations/SPT.yaml
+++ b/virtual-organizations/SPT.yaml
@@ -47,7 +47,7 @@ LongName: South Pole Telescope
 MembershipServicesURL: https://spt-mgt.grid.uchicago.edu:8443/voms/SPT
 OASIS:
   Managers:
-    Nathan Whitehorn:
+    - Name: Nathan Whitehorn
       DNs: /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Nathan Whitehorn
         3937
       ID: d7ebadcbca04bf37b33f6183bea3245431eedf38

--- a/virtual-organizations/SeaQuest.yaml
+++ b/virtual-organizations/SeaQuest.yaml
@@ -37,7 +37,7 @@ LongName: Fermilab Experiment 906 (SeaQuest)
 MembershipServicesURL: https://voms.fnal.gov:8443/voms/fermilab
 OASIS:
   Managers:
-    Joe Boyd:
+    - Name: Joe Boyd
       DNs:
       - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Joe Boyd 579
       - /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Joe Boyd 3582

--- a/virtual-organizations/Stash.yaml
+++ b/virtual-organizations/Stash.yaml
@@ -21,7 +21,7 @@ LongName: Stash Cache
 MembershipServicesURL: https://voms.opensciencegrid.org:8443/voms/osg
 OASIS:
   Managers:
-    Brian Bockelman:
+    - Name: Brian Bockelman
       DNs: /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=bbockelm/CN=659869/CN=Brian
         Paul Bockelman
       ID: 66ee5cfb622a7343dac85dee42815d1f4fbc2d85

--- a/virtual-organizations/XENON.yaml
+++ b/virtual-organizations/XENON.yaml
@@ -40,7 +40,7 @@ LongName: XENON Collaboration
 MembershipServicesURL: https://voms.grid.sara.nl:8443/voms/xenon.biggrid.nl
 OASIS:
   Managers:
-    Luca Scotto Lavina:
+    - Name: Luca Scotto Lavina
       DNs: /O=GRID-FR/C=FR/O=CNRS/OU=LPNHE/CN=Luca Scotto Lavina
       ID: 34d0a2a03bbffad439ae7c732042d7ad6a609da8
   OASISRepoURLs:

--- a/virtual-organizations/annie.yaml
+++ b/virtual-organizations/annie.yaml
@@ -18,7 +18,7 @@ LongName: Accelerator Neutrino Neutron Interaction Experiment
 MembershipServicesURL: https://voms.fnal.gov:8443/voms/fermilab
 OASIS:
   Managers:
-    Arthur Kreymer:
+    - Name: Arthur Kreymer
       DNs:
       - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Arthur Kreymer 965
       ID: fa14f7cbd84a8b048e6ebd192a72a14bf298c354

--- a/virtual-organizations/auger.yaml
+++ b/virtual-organizations/auger.yaml
@@ -21,7 +21,7 @@ LongName: Pierre Auger Observatory
 MembershipServicesURL: https://voms1.egee.cesnet.cz:8443/voms/auger
 OASIS:
   Managers:
-    Jiri Chudoba:
+    - Name: Jiri Chudoba
       DNs: /DC=cz/DC=cesnet-ca/O=Institute of Physics of the Academy of Sciences of
         the CR/CN=Jiri Chudoba
       ID: 3e40fb9b1d433ca8af3aff19a62d68d8809c3d06

--- a/virtual-organizations/geant4.yaml
+++ b/virtual-organizations/geant4.yaml
@@ -26,7 +26,7 @@ LongName: Geant4 Software Toolkit
 MembershipServicesURL: https://lcg-voms.cern.ch:8443/voms/geant4
 OASIS:
   Managers:
-    Hans Wenzel:
+    - Name: Hans Wenzel
       DNs:
       - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Hans Wenzel 959
       - /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Hans Wenzel 959

--- a/virtual-organizations/icarus.yaml
+++ b/virtual-organizations/icarus.yaml
@@ -19,7 +19,7 @@ LongName: Imaging Cosmic And Rare Underground Signals
 MembershipServicesURL: https://voms2.fnal.gov:8443/voms/fermilab
 OASIS:
   Managers:
-    HYUNWOO KIM:
+    - Name: HYUNWOO KIM
       DNs:
       - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=HYUNWOO KIM 882
       - /DC=gov/DC=fnal/O=Fermilab/OU=People/CN=Hyun woo Kim/CN=UID:hyunwoo

--- a/virtual-organizations/nanoHUB.yaml
+++ b/virtual-organizations/nanoHUB.yaml
@@ -26,13 +26,13 @@ ID: 26
 LongName: nanoHUB Network for Computational Nanotechnology (NCN)
 OASIS:
   Managers:
-    Scott Teige:
+    - Name: Scott Teige
       DNs:
       - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Scott Teige 652
       - /DC=org/DC=cilogon/C=US/O=Indiana University/CN=Scott Teige A7052
       - /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Scott Teige 1
       ID: 238d6d2794a7aa5391ae3d13297561a015026bb2
-    Steven Clark:
+    - Name: Steven Clark
       DNs:
       - /CN=Steven M Clark/OU=Purdue TeraGrid/O=Purdue University/ST=Indiana/C=US
       - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Steven Clark 174

--- a/virtual-organizations/next.yaml
+++ b/virtual-organizations/next.yaml
@@ -19,7 +19,7 @@ LongName: Neutrino Experiment with a Xenon TPC
 MembershipServicesURL: https://voms2.fnal.gov:8443/voms/fermilab
 OASIS:
   Managers:
-    Michael Diesburg:
+    - Name: Michael Diesburg
       DNs: /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Michael Diesburg
         47
       ID: ffc9ff0f27ebd113597fa3404c4b2de4a1e5d845

--- a/virtual-organizations/sPHENIX.yaml
+++ b/virtual-organizations/sPHENIX.yaml
@@ -27,7 +27,7 @@ LongName: Successor to the Pioneering High Energy Nuclear Interaction eXperiment
 MembershipServicesURL: https://www.racf.bnl.gov/docs/getstart
 OASIS:
   Managers:
-    John S. De Stefano Jr.:
+    - Name: John S. De Stefano Jr.
       DNs:
       - /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=destefan/CN=665120/CN=John Steven De Stefano Jr
       ID: 8a7d75ea65a2962520279197c72df6a16e1533a1

--- a/virtual-organizations/snoplus.snolab.ca.yaml
+++ b/virtual-organizations/snoplus.snolab.ca.yaml
@@ -31,11 +31,11 @@ LongName: SNO+ at SNOLAB
 MembershipServicesURL: https://voms.gridpp.ac.uk:8443/voms/snoplus.snolab.ca/
 OASIS:
   Managers:
-    Freija Descamps:
+    - Name: Freija Descamps
       DNs: /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Freija Descamps
         1236
       ID: 5950a48f5d2a46e3aeb4f57252ec700073556ad8
-    Kevin Labe:
+    - Name: Kevin Labe
       DNs:
       - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Kevin Labe 1781
       - /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Kevin Labe 1781


### PR DESCRIPTION
So for SOFTWARE-3947, we want to change the OASIS Managers section from a dict of dicts (keyed off of the Manager Name) to a list of dicts, with a new Name attribute instead of the key from the original dict.

Adjusting the yaml data itself isn't too bad, but we have to modify the webapp code that processes this section.  I ended up replacing the call to `expand_attr_list` (which took the old dict) with a new `order_dict` function that provides the same ordering without moving the key to a Name attribute.

@matyasselmeci, you wrote the original code that i'm modifying here, so if you could sanity check it that'd be great.