### PR TITLE
Update Univ of Utah CHPC to reflect updated CEs

### DIFF
--- a/topology/University of Utah/CHPC/CHPC Group.yaml
+++ b/topology/University of Utah/CHPC/CHPC Group.yaml
@@ -69,7 +69,7 @@ Resources:
           Name: CHPC OSG Support
     Description: Hosted CE for the notchpeak cluster
     FQDN: sl-uu-hce3.slateci.io
-    ID: 936
+    ID: 1042
     Services:
       CE:
         Description: Compute Element

--- a/topology/University of Utah/CHPC/CHPC Group.yaml
+++ b/topology/University of Utah/CHPC/CHPC Group.yaml
@@ -46,7 +46,7 @@ Resources:
           Name: CHPC OSG Support
     Description: SLATE deployed Hosted CE for the lonepeak cluster
     FQDN: sl-uu-hce2.slateci.io
-    ID: 936
+    ID: 1041
     Services:
       CE:
         Description: Compute Element

--- a/topology/University of Utah/CHPC/CHPC Group.yaml
+++ b/topology/University of Utah/CHPC/CHPC Group.yaml
@@ -2,47 +2,28 @@ GroupDescription: Primary CE for the University of Utah
 GroupID: 440
 Production: true
 Resources:
-  OSG_US_UUTAH_KINGSPEAK:
+  SLATE_US_UUTAH_KINGSPEAK:
     Active: true
     ContactLists:
       Administrative Contact:
         Primary:
-          ID:  030408ab932e143859b5f97a2d1c9e30ba2a9f0d
-          Name: Marco Mascheroni
+          ID:  40a181cc3b7a43593188c9607310d35cb079bda9
+          Name: Mitchell Steinman
       Resource Report Contact:
         Primary:
-          ID:  030408ab932e143859b5f97a2d1c9e30ba2a9f0d
-          Name: Marco Mascheroni
+          ID:  40a181cc3b7a43593188c9607310d35cb079bda9
+          Name: Mitchell Steinman
       Security Contact:
         Primary:
-          ID:  030408ab932e143859b5f97a2d1c9e30ba2a9f0d
-          Name: Marco Mascheroni
+          ID:  40a181cc3b7a43593188c9607310d35cb079bda9
+          Name: Mitchell Steinman
       Site Contact:
         Primary:
           ID:  ddfa10c8a8500e5c31818e7c1a063b3ce5ab6a8b
           Name: CHPC OSG Support
     Description: Hosted CE for the Kingspeak cluster at CHPC
-    FQDN: hosted-ce14.grid.uchicago.edu
+    FQDN: sl-uu-hce1.slateci.io
     ID: 937
-    Services:
-      CE:
-        Description: Compute Element
-        Details:
-          hidden: false
-  OSG_US_UUTAH_LONEPEAK:
-    Active: true
-    ContactLists:
-      Resource Report Contact:
-        Primary:
-          ID:  030408ab932e143859b5f97a2d1c9e30ba2a9f0d
-          Name: Marco Mascheroni
-      Site Contact:
-        Primary:
-          ID:  443c32443113f2e2dbf7dc77c0e5697d4f27f90a
-          Name: Irvin Allen
-    Description: Hosted CE for the lonepeak cluster
-    FQDN: hosted-ce12.grid.uchicago.edu
-    ID: 936
     Services:
       CE:
         Description: Compute Element
@@ -71,15 +52,23 @@ Resources:
         Description: Compute Element
         Details:
           hidden: false  
-  OSG_US_UUTAH_NOTCHPEAK:
+  SLATE_US_UUTAH_NOTCHPEAK:
     Active: true
     ContactLists:
-      Resource Report Contact:
+      Administrative Contact:
         Primary:
-          ID:  030408ab932e143859b5f97a2d1c9e30ba2a9f0d
-          Name: Marco Mascheroni
+          ID:  40a181cc3b7a43593188c9607310d35cb079bda9
+          Name: Mitchell Steinman
+      Security Contact:
+        Primary:
+          ID:  40a181cc3b7a43593188c9607310d35cb079bda9
+          Name: Mitchell Steinman
+      Site Contact:
+        Primary:
+          ID:  ddfa10c8a8500e5c31818e7c1a063b3ce5ab6a8b
+          Name: CHPC OSG Support
     Description: Hosted CE for the notchpeak cluster
-    FQDN: hosted-ce24.grid.uchicago.edu
+    FQDN: sl-uu-hce3.slateci.io
     ID: 936
     Services:
       CE:

--- a/topology/University of Utah/CHPC/CHPC Group.yaml
+++ b/topology/University of Utah/CHPC/CHPC Group.yaml
@@ -2,33 +2,6 @@ GroupDescription: Primary CE for the University of Utah
 GroupID: 440
 Production: true
 Resources:
-  OSG_US_UUTAH_EMBER:
-    Active: true
-    ContactLists:
-      Administrative Contact:
-        Primary:
-          ID:  030408ab932e143859b5f97a2d1c9e30ba2a9f0d
-          Name: Marco Mascheroni
-      Resource Report Contact:
-        Primary:
-          ID:  030408ab932e143859b5f97a2d1c9e30ba2a9f0d
-          Name: Marco Mascheroni
-      Security Contact:
-        Primary:
-          ID:  030408ab932e143859b5f97a2d1c9e30ba2a9f0d
-          Name: Marco Mascheroni
-      Site Contact:
-        Primary:
-          ID:  ddfa10c8a8500e5c31818e7c1a063b3ce5ab6a8b
-          Name: CHPC OSG Support
-    Description: Hosted CE for the Ember cluster at CHPC
-    FQDN: hosted-ce15.grid.uchicago.edu
-    ID: 938
-    Services:
-      CE:
-        Description: Compute Element
-        Details:
-          hidden: false
   OSG_US_UUTAH_KINGSPEAK:
     Active: true
     ContactLists:


### PR DESCRIPTION
-The ember cluster is retiring and will no longer be supported

-CEs for Kingspeak and Notchpeak have been converted to SLATE

-Old CEs for all cluster have been disabled