### PR TITLE
Re-register old Utah CEs so GRACC can map resources to their sites

### DIFF
--- a/topology/University of Utah/Utah-SLATE-Kingspeak/Utah-SLATE-Kingspeak.yaml
+++ b/topology/University of Utah/Utah-SLATE-Kingspeak/Utah-SLATE-Kingspeak.yaml
@@ -19,6 +19,30 @@ Resources:
           Name: CHPC OSG Support
     Description: Hosted CE for the Kingspeak cluster at CHPC
     FQDN: sl-uu-hce1.slateci.io
+    ID: 1043
+    Services:
+      CE:
+        Description: Compute Element
+        Details:
+          hidden: false
+  # FIXME: resource can be removed after 2021-02-01
+  OSG_US_UUTAH_KINGSPEAK:
+    Active: false
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          ID:  030408ab932e143859b5f97a2d1c9e30ba2a9f0d
+          Name: Marco Mascheroni
+      Security Contact:
+        Primary:
+          ID:  030408ab932e143859b5f97a2d1c9e30ba2a9f0d
+          Name: Marco Mascheroni
+      Site Contact:
+        Primary:
+          ID:  ddfa10c8a8500e5c31818e7c1a063b3ce5ab6a8b
+          Name: CHPC OSG Support
+    Description: Hosted CE for the Kingspeak cluster at CHPC
+    FQDN: hosted-ce14.grid.uchicago.edu
     ID: 937
     Services:
       CE:

--- a/topology/University of Utah/Utah-SLATE-Lonepeak/Utah-SLATE-Lonepeak.yaml
+++ b/topology/University of Utah/Utah-SLATE-Lonepeak/Utah-SLATE-Lonepeak.yaml
@@ -25,4 +25,28 @@ Resources:
         Description: Compute Element
         Details:
           hidden: false
+  # FIXME: resource can be removed after 2021-02-01
+  OSG_US_UUTAH_LONEPEAK:
+    Active: false
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          ID:  030408ab932e143859b5f97a2d1c9e30ba2a9f0d
+          Name: Marco Mascheroni
+      Security Contact:
+        Primary:
+          ID:  030408ab932e143859b5f97a2d1c9e30ba2a9f0d
+          Name: Marco Mascheroni
+      Site Contact:
+        Primary:
+          ID:  ddfa10c8a8500e5c31818e7c1a063b3ce5ab6a8b
+          Name: CHPC OSG Support
+    Description: Hosted CE for the lonepeak cluster
+    FQDN: hosted-ce12.grid.uchicago.edu
+    ID: 1043
+    Services:
+      CE:
+        Description: Compute Element
+        Details:
+          hidden: false
 SupportCenter: Community Support Center

--- a/topology/University of Utah/Utah-SLATE-Notchpeak/Utah-SLATE-Notchpeak.yaml
+++ b/topology/University of Utah/Utah-SLATE-Notchpeak/Utah-SLATE-Notchpeak.yaml
@@ -25,14 +25,22 @@ Resources:
         Description: Compute Element
         Details:
           hidden: false
-  # FIXME: resource can be removed after 2020-08-01
+  # FIXME: resource can be removed after 2021-02-01
   OSG_US_UUTAH_NOTCHPEAK:
     Active: false
     ContactLists:
-      Resource Report Contact:
+      Administrative Contact:
         Primary:
           ID:  030408ab932e143859b5f97a2d1c9e30ba2a9f0d
           Name: Marco Mascheroni
+      Security Contact:
+        Primary:
+          ID:  030408ab932e143859b5f97a2d1c9e30ba2a9f0d
+          Name: Marco Mascheroni
+      Site Contact:
+        Primary:
+          ID:  ddfa10c8a8500e5c31818e7c1a063b3ce5ab6a8b
+          Name: CHPC OSG Support
     Description: Hosted CE for the notchpeak cluster
     FQDN: hosted-ce24.grid.uchicago.edu
     ID: 936


### PR DESCRIPTION
Factory entries still referenced these old resource
names (https://github.com/opensciencegrid/osg-gfactory/pull/2), which
were picked up by payload records. This was reflected in the GRACC
with OSG_US_UUTAH_KINGSPEAK and OSG_US_UUTAH_LONEPEAK site names.