### PR TITLE
Update SPRACE_downtime.yaml

### DIFF
--- a/topology/Universidade Estadual Paulista/SPRACE/SPRACE_downtime.yaml
+++ b/topology/Universidade Estadual Paulista/SPRACE/SPRACE_downtime.yaml
@@ -597,3 +597,14 @@
   Services:
   - Squid
 # ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 463723331
+  Description: Severe storms and flooding around the campus area.
+  Severity: Outage
+  StartTime: Feb 10, 2020 16:04 +0000
+  EndTime: Feb 11, 2020 16:04 +0000
+  CreatedTime: Feb 10, 2020 16:05 +0000
+  ResourceName: SPRACE
+  Services:
+  - CE
+# ---------------------------------------------------------


### PR DESCRIPTION
São Paulo is facing a long standing rain since the first hours of today the area around the campus is flooded and the rain does not seems to stop so soon. We are shutting down the site due to the risk of flooding in our power cabin.