### PR TITLE
Add Resource to UWM NEMO site

### DIFF
--- a/topology/University of Wisconsin Milwaukee/UWM - NEMO/NEMO.yaml
+++ b/topology/University of Wisconsin Milwaukee/UWM - NEMO/NEMO.yaml
@@ -30,7 +30,7 @@ Resources:
         Details:
           hidden: false
   NEMO-submit-dev:
-    ID: <ID>
+    ID: 1046
     Active: false
     Description: UWM-NEMO testing and development submit node for NEMO cluster.
     ContactLists:

--- a/topology/University of Wisconsin Milwaukee/UWM - NEMO/NEMO.yaml
+++ b/topology/University of Wisconsin Milwaukee/UWM - NEMO/NEMO.yaml
@@ -29,3 +29,22 @@ Resources:
         Description: UWM-NEMO Hosted CE
         Details:
           hidden: false
+  NEMO-submit-dev:
+    ID: <ID>
+    Active: false
+    Description: UWM-NEMO testing and development submit node for NEMO cluster.
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          Name: Shawn Kwang
+          ID: 115b5c0fb1a160df841dde4591b96c180ba6d778
+      Security Contact:
+        Primary:
+          Name: Shawn Kwang
+          ID: 115b5c0fb1a160df841dde4591b96c180ba6d778
+    FQDN: submit-osg-dev.ligo.uwm.edu
+    Services:
+      Submit Node:
+        Description: testing/development OSG Submit Node
+        Details:
+          hidden: false


### PR DESCRIPTION
Added resource submit-osg-dev.ligo.uwm.edu, a testing/development OSG submit node.

ID needs to be filled-in/added. Active is set to false, and can be changed once the submit node is fully configured.