### PR TITLE
Adding SciTokens configuration for origin

### DIFF
--- a/bin/osg-origin-scitokens-config
+++ b/bin/osg-origin-scitokens-config
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+A script to generate a SciTokens config for a StashCache cache in the OSG
+"""
+import argparse
+import os
+import sys
+
+if __name__ == "__main__" and __package__ is None:
+    _parent = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path.append(_parent + "/src")
+
+import webapp.models
+import stashcache
+
+parser = argparse.ArgumentParser(description="Generate a SciTokens config for a StashCache cache server.")
+parser.add_argument("fqdn", metavar="Cache_FQDN", help="FQDN of the cache for config generation.")
+
+args = parser.parse_args()
+
+global_data = webapp.models.GlobalData()
+
+vodata = global_data.get_vos_data()
+resource_groups = global_data.get_topology().get_resource_group_list()
+
+cache_scitokens = stashcache.generate_origin_scitokens(vodata,
+                                                      resource_groups,
+                                                      fqdn=args.fqdn,
+                                                      suppress_errors=False)
+print(cache_scitokens, end="")  # config already has trailing newline

--- a/src/app.py
+++ b/src/app.py
@@ -184,15 +184,23 @@ def scitokens():
     if not stashcache:
         return Response("Can't get scitokens config: stashcache module unavailable", status=503)
     cache_fqdn = request.args.get("cache_fqdn")
-    if not cache_fqdn:
-        return Response("FQDN of cache server required in the 'cache_fqdn' argument", status=400)
+    origin_fqdn = request.args.get("origin_fqdn")
+    if not cache_fqdn and not origin_fqdn:
+        return Response("FQDN of cache or origin server required in the 'cache_fqdn' or 'origin_fqdn' argument", status=400)
 
     try:
-        cache_scitokens = stashcache.generate_cache_scitokens(global_data.get_vos_data(),
-                                                              global_data.get_topology().get_resource_group_list(),
-                                                              fqdn=cache_fqdn,
-                                                              suppress_errors=False)
-        return Response(cache_scitokens, mimetype="text/plain")
+        if cache_fqdn:
+            cache_scitokens = stashcache.generate_cache_scitokens(global_data.get_vos_data(),
+                                                                global_data.get_topology().get_resource_group_list(),
+                                                                fqdn=cache_fqdn,
+                                                                suppress_errors=False)
+            return Response(cache_scitokens, mimetype="text/plain")
+        elif origin_fqdn:
+            cache_scitokens = stashcache.generate_origin_scitokens(global_data.get_vos_data(),
+                                                                global_data.get_topology().get_resource_group_list(),
+                                                                fqdn=origin_fqdn,
+                                                                suppress_errors=False)
+            return Response(cache_scitokens, mimetype="text/plain")
     except stashcache.NotRegistered as e:
         return Response("# No resource registered for {}\n"
                         "# Please check your query or contact help@opensciencegrid.org\n"

--- a/src/app.py
+++ b/src/app.py
@@ -200,7 +200,7 @@ def scitokens():
                                                                 global_data.get_topology().get_resource_group_list(),
                                                                 fqdn=origin_fqdn,
                                                                 suppress_errors=False)
-            return Response(cache_scitokens, mimetype="text/plain")
+            return Response(origin_scitokens, mimetype="text/plain")
     except stashcache.NotRegistered as e:
         return Response("# No resource registered for {}\n"
                         "# Please check your query or contact help@opensciencegrid.org\n"

--- a/src/app.py
+++ b/src/app.py
@@ -196,7 +196,7 @@ def scitokens():
                                                                 suppress_errors=False)
             return Response(cache_scitokens, mimetype="text/plain")
         elif origin_fqdn:
-            cache_scitokens = stashcache.generate_origin_scitokens(global_data.get_vos_data(),
+            origin_scitokens = stashcache.generate_origin_scitokens(global_data.get_vos_data(),
                                                                 global_data.get_topology().get_resource_group_list(),
                                                                 fqdn=origin_fqdn,
                                                                 suppress_errors=False)

--- a/src/stashcache.py
+++ b/src/stashcache.py
@@ -481,7 +481,7 @@ def generate_origin_scitokens(vo_data: VOsData, resource_groups: List[ResourceGr
 
     template = """\
 [Global]
-audience = {allowed_vos}
+audience = {allowed_vos_str}
 
 {issuer_blocks_str}
 """

--- a/src/stashcache.py
+++ b/src/stashcache.py
@@ -270,7 +270,7 @@ def generate_cache_scitokens(vo_data: VOsData, resource_groups: List[ResourceGro
     """
     template = """\
 [Global]
-audience = {resource.name}, https://{fqdn}
+audience = {allowed_vos}
 
 {issuer_blocks_str}
 """
@@ -285,6 +285,7 @@ audience = {resource.name}, https://{fqdn}
     if not resource:
         return ""
 
+    allowed_vos = []
     issuer_blocks = []
     for vo_name, vo_data in vo_data.vos.items():
         stashcache_data = vo_data.get('DataFederations', {}).get('StashCache')
@@ -314,10 +315,12 @@ audience = {resource.name}, https://{fqdn}
                     continue
                 issuer_blocks.append(_get_scitokens_issuer_block(vo_name, authz['SciTokens'],
                                                                  dirname, suppress_errors))
+                allowed_vos.append(vo_name)
 
     issuer_blocks_str = "\n".join(issuer_blocks)
+    allowed_vos_str = ", ".join(allowed_vos)
 
-    return template.format(**locals()).rstrip() + "\n"
+    return template.format(issuer_blocks_str=issuer_blocks_str, allowed_vos=allowed_vos_str).rstrip() + "\n"
 
 
 def _get_scitokens_issuer_block(vo_name: str, scitokens: Dict, dirname: str, suppress_errors: bool) -> str:
@@ -472,3 +475,44 @@ def generate_origin_authfile(origin_hostname, vo_data, resource_groups, suppress
     if public_namespaces:
         results += "\nu * {}\n".format(" ".join("{} lr".format(i) for i in sorted(public_namespaces)))
     return results
+
+
+def generate_origin_scitokens(vo_data: VOsData, resource_groups: List[ResourceGroup], fqdn: str, suppress_errors=True) -> str:
+
+    template = """\
+[Global]
+audience = {allowed_vos}
+
+{issuer_blocks_str}
+"""
+    allowed_vos = []
+    issuer_blocks = []
+    for vo_name, vo_data in vo_data.vos.items():
+        stashcache_data = vo_data.get('DataFederations', {}).get('StashCache')
+        if not stashcache_data:
+            continue
+
+        if not _origin_is_allowed(fqdn, vo_name, stashcache_data, resource_groups, suppress_errors=suppress_errors):
+            continue
+
+        namespaces = stashcache_data.get("Namespaces")
+        if not namespaces:
+            if suppress_errors:
+                continue
+            else:
+                raise DataError("VO {} in StashCache does not provide a Namespaces list.".format(vo_name))
+
+        for dirname, authz_list in namespaces.items():
+            for authz in authz_list:
+                if not isinstance(authz, dict) or not isinstance(authz.get("SciTokens"), dict):
+                    continue
+                issuer_blocks.append(_get_scitokens_issuer_block(vo_name, authz['SciTokens'],
+                                                                 dirname, suppress_errors))
+                allowed_vos.append(vo_name)
+
+
+
+    issuer_blocks_str = "\n".join(issuer_blocks)
+    allowed_vos_str = ", ".join(allowed_vos)
+
+    return template.format(issuer_blocks_str=issuer_blocks_str, allowed_vos=allowed_vos_str).rstrip() + "\n"

--- a/src/stashcache.py
+++ b/src/stashcache.py
@@ -320,7 +320,7 @@ audience = {allowed_vos_str}
     issuer_blocks_str = "\n".join(issuer_blocks)
     allowed_vos_str = ", ".join(allowed_vos)
 
-    return template.format(issuer_blocks_str=issuer_blocks_str, allowed_vos=allowed_vos_str).rstrip() + "\n"
+    return template.format(**locals()).rstrip() + "\n"
 
 
 def _get_scitokens_issuer_block(vo_name: str, scitokens: Dict, dirname: str, suppress_errors: bool) -> str:

--- a/src/stashcache.py
+++ b/src/stashcache.py
@@ -515,4 +515,4 @@ audience = {allowed_vos_str}
     issuer_blocks_str = "\n".join(issuer_blocks)
     allowed_vos_str = ", ".join(allowed_vos)
 
-    return template.format(issuer_blocks_str=issuer_blocks_str, allowed_vos=allowed_vos_str).rstrip() + "\n"
+    return template.format(**locals()).rstrip() + "\n"

--- a/src/stashcache.py
+++ b/src/stashcache.py
@@ -270,7 +270,7 @@ def generate_cache_scitokens(vo_data: VOsData, resource_groups: List[ResourceGro
     """
     template = """\
 [Global]
-audience = {allowed_vos}
+audience = {allowed_vos_str}
 
 {issuer_blocks_str}
 """

--- a/src/stashcache.py
+++ b/src/stashcache.py
@@ -503,6 +503,12 @@ audience = {allowed_vos_str}
                 raise DataError("VO {} in StashCache does not provide a Namespaces list.".format(vo_name))
 
         for dirname, authz_list in namespaces.items():
+            if not authz_list:
+                if suppress_errors:
+                    continue
+                else:
+                    raise DataError("Namespace {} (VO {}) does not provide any authorizations.".format(dirname, vo_name))
+
             for authz in authz_list:
                 if not isinstance(authz, dict) or not isinstance(authz.get("SciTokens"), dict):
                     continue


### PR DESCRIPTION
This changes some behavior for scitokens:

* The token audience is now the registered VO.  This is important to communicate to VO's who are generating the tokens.  The audience previously was the name of the cache, but all caches should be accessed by geoip.