### PR TITLE
Fixing end time for outage

### DIFF
--- a/topology/University of Michigan/AGLT2/AGLT2_downtime.yaml
+++ b/topology/University of Michigan/AGLT2/AGLT2_downtime.yaml
@@ -716,7 +716,7 @@
   Description: dCache headnode database corrupted...restoring from backup
   Severity: Outage
   StartTime: Mar 23, 2020 01:30 +0000
-  EndTime: Mar 23, 2020 18:00 +0000
+  EndTime: Mar 23, 2020 11:00 +0000
   CreatedTime: Mar 23, 2020 04:32 +0000
   ResourceName: AGLT2_SE
   Services:


### PR DESCRIPTION
dCache was back into production at 7 AM Eastern, 11:00 UTC