### PR TITLE
Aligning FSU hosted-ce resource name with Glidein Resource Name

### DIFF
--- a/topology/Florida State University/FSU_HNPGRID/OSG_US_FSU_HNPGRID.yaml
+++ b/topology/Florida State University/FSU_HNPGRID/OSG_US_FSU_HNPGRID.yaml
@@ -2,7 +2,7 @@ GroupDescription: Hosted CE for GlueX and OSG support
 GroupID: 475
 Production: true
 Resources:
-  OSG_US_FSU_HNPGRID:
+  GLUEX_US_FSU_HNPGRID:
     Active: true
     ContactLists:
       Administrative Contact:

--- a/topology/Florida State University/FSU_HNPGRID/OSG_US_FSU_HNPGRID_downtime.yaml
+++ b/topology/Florida State University/FSU_HNPGRID/OSG_US_FSU_HNPGRID_downtime.yaml
@@ -2,7 +2,7 @@
   Description: Networking changes
   EndTime: Oct 9, 2017 22:00 +0000
   ID: 1005465
-  ResourceName: OSG_US_FSU_HNPGRID
+  ResourceName: GLUEX_US_FSU_HNPGRID
   Services:
   - CE
   Severity: Outage


### PR DESCRIPTION
Change the resource name to align with the Glidein resource name.  This change will only affect GRACC by changing the resource name it matches for Batch record.  Currently, the batch records only match to the fqdn of the CE, which is not changing in this request.

This change will affect payload records by allowing them to match correctly.