### PR TITLE
Adding IRISHEP-SSL-UCHICAGO for UChicago

### DIFF
--- a/topology/University of Chicago/IRISHEP-SSL-UCHICAGO/SITE.yaml
+++ b/topology/University of Chicago/IRISHEP-SSL-UCHICAGO/SITE.yaml
@@ -1,0 +1,9 @@
+Description: IRIS-HEP SSL Resources at the University of Chicago
+ID:
+AddressLine1: 5734 S Ellis ave
+City: Chicago
+Country: USA
+State: IL
+Zipcode: '60637'
+Latitude: 41.790270
+Longitude: -87.601670

--- a/topology/University of Chicago/IRISHEP-SSL-UCHICAGO/SITE.yaml
+++ b/topology/University of Chicago/IRISHEP-SSL-UCHICAGO/SITE.yaml
@@ -1,5 +1,5 @@
 Description: IRIS-HEP SSL Resources at the University of Chicago
-ID:
+ID: 10273
 AddressLine1: 5734 S Ellis ave
 City: Chicago
 Country: USA


### PR DESCRIPTION
Adding the IRISHEP-SSL-UCHICAGO site information in response to [#64730] IRISHEP-SSL-UCHICAGO Site Registration. ID field left blank