### PR TITLE
Update MarkupSafe to avoid bnug reintroduced by a steuptools update

### DIFF
--- a/requirements-apache.txt
+++ b/requirements-apache.txt
@@ -14,7 +14,7 @@ idna==2.7
 itsdangerous==0.24
 Jinja2>=2.10.1,<2.11
 ldap3>=2.6.1
-MarkupSafe==1.0
+MarkupSafe==1.1.1
 python-dateutil>=2.7.3,<2.8
 PyYAML>=4.2b1,<=4.2
 requests>=2.21.0,<2.22

--- a/requirements-apache.txt
+++ b/requirements-apache.txt
@@ -14,7 +14,7 @@ idna==2.7
 itsdangerous==0.24
 Jinja2>=2.10.1,<2.11
 ldap3>=2.6.1
-MarkupSafe==1.1.1
+MarkupSafe>=1.1.1<1.2
 python-dateutil>=2.7.3,<2.8
 PyYAML>=4.2b1,<=4.2
 requests>=2.21.0,<2.22

--- a/requirements-rootless.txt
+++ b/requirements-rootless.txt
@@ -14,7 +14,7 @@ idna==2.7
 itsdangerous==0.24
 Jinja2>=2.10.1,<2.11
 ldap3>=2.6.1
-MarkupSafe==1.0
+MarkupSafe==1.1.1
 python-dateutil>=2.7.3,<2.8
 PyYAML>=4.2b1,<=4.2
 requests>=2.21.0,<2.22

--- a/requirements-rootless.txt
+++ b/requirements-rootless.txt
@@ -14,7 +14,7 @@ idna==2.7
 itsdangerous==0.24
 Jinja2>=2.10.1,<2.11
 ldap3>=2.6.1
-MarkupSafe==1.1.1
+MarkupSafe>=1.1.1<1.2
 python-dateutil>=2.7.3,<2.8
 PyYAML>=4.2b1,<=4.2
 requests>=2.21.0,<2.22


### PR DESCRIPTION
https://github.com/pallets/markupsafe/issues/57#issuecomment-597105876

Worked fine in my local dev environment. It seems that Topology isn't currently triggering this because we're pulling in Python 3.6.7 for our CI whereas the contacts CI is pulling in 3.6.10.