### PR TITLE
Update APELNormalFactor (HS06) numbers.

### DIFF
--- a/topology/University of Wisconsin/GLOW/GLOW.yaml
+++ b/topology/University of Wisconsin/GLOW/GLOW.yaml
@@ -38,7 +38,7 @@ Resources:
     VOOwnership:
       CMS: 100
     WLCGInformation:
-      APELNormalFactor: 9.9
+      APELNormalFactor: 10.17
       AccountingName: T2_US_Wisconsin
       HEPSPEC: 0
       InteropAccounting: true
@@ -84,7 +84,7 @@ Resources:
     VOOwnership:
       CMS: 100
     WLCGInformation:
-      APELNormalFactor: 9.9
+      APELNormalFactor: 10.17
       AccountingName: T2_US_Wisconsin
       HEPSPEC: 14000
       InteropAccounting: true
@@ -185,7 +185,7 @@ Resources:
     VOOwnership:
       CMS: 100
     WLCGInformation:
-      APELNormalFactor: 9.9
+      APELNormalFactor: 10.17
       AccountingName: T2_US_Wisconsin
       HEPSPEC: 0
       InteropAccounting: true
@@ -362,7 +362,7 @@ Resources:
     VOOwnership:
       CMS: 100
     WLCGInformation:
-      APELNormalFactor: 9.87
+      APELNormalFactor: 10.17
       AccountingName: T2_US_Wisconsin
       HEPSPEC: 0
       InteropAccounting: true
@@ -410,7 +410,7 @@ Resources:
     VOOwnership:
       CMS: 100
     WLCGInformation:
-      APELNormalFactor: 9.87
+      APELNormalFactor: 10.17
       AccountingName: T2_US_Wisconsin
       HEPSPEC: 0
       InteropAccounting: true
@@ -458,7 +458,7 @@ Resources:
     VOOwnership:
       CMS: 100
     WLCGInformation:
-      APELNormalFactor: 9.87
+      APELNormalFactor: 10.17
       AccountingName: T2_US_Wisconsin
       HEPSPEC: 0
       InteropAccounting: true
@@ -516,7 +516,7 @@ Resources:
     VOOwnership:
       CMS: 100
     WLCGInformation:
-      APELNormalFactor: 9.87
+      APELNormalFactor: 10.17
       AccountingName: T2_US_Wisconsin
       HEPSPEC: 0
       InteropAccounting: true
@@ -562,7 +562,7 @@ Resources:
     VOOwnership:
       GLOW: 100
     WLCGInformation:
-      APELNormalFactor: 9.87
+      APELNormalFactor: 10.17
       AccountingName: T2_US_Wisconsin
       HEPSPEC: 0
       InteropAccounting: true
@@ -611,7 +611,7 @@ Resources:
     VOOwnership:
       GLOW: 100
     WLCGInformation:
-      APELNormalFactor: 9.87
+      APELNormalFactor: 10.17
       AccountingName: T2_US_Wisconsin
       HEPSPEC: 0
       InteropAccounting: true
@@ -660,7 +660,7 @@ Resources:
     VOOwnership:
       CMS: 100
     WLCGInformation:
-      APELNormalFactor: 9.87
+      APELNormalFactor: 10.17
       AccountingName: T2_US_Wisconsin
       HEPSPEC: 0
       InteropAccounting: true


### PR DESCRIPTION
Dear OSG Help,

The APELNormalFactor (HS06) numbers are updated due to the addition of new hardware to T2_US_Wisconsin cluster. Please merge the updates. 

Thanks,
- Ajit
