### PR TITLE
Adding a downtime for USCMS-FNAL-WC1-CE4

### DIFF
--- a/topology/Fermi National Accelerator Laboratory/FNAL USCMS Tier1/USCMS-FNAL-WC1_downtime.yaml
+++ b/topology/Fermi National Accelerator Laboratory/FNAL USCMS Tier1/USCMS-FNAL-WC1_downtime.yaml
@@ -567,6 +567,16 @@
   - FTS
   - SRMv2
 # ---------------------------------------------------------
-
+- Class: UNSCHEDULED
+  ID: 536272182
+  Description: Host went down
+  Severity: Outage
+  StartTime: May 04, 2020 15:00 +0000
+  EndTime: May 05, 2020 17:00 +0000
+  CreatedTime: May 04, 2020 16:20 +0000
+  ResourceName: USCMS-FNAL-WC1-CE4
+  Services:
+  - CE
+# ---------------------------------------------------------
 
 


### PR DESCRIPTION
The node crashed during a kernel reboot.