### PR TITLE
Updating the outage for USCMS-FNAL-WC1-CE4

### DIFF
--- a/topology/Fermi National Accelerator Laboratory/FNAL USCMS Tier1/USCMS-FNAL-WC1_downtime.yaml
+++ b/topology/Fermi National Accelerator Laboratory/FNAL USCMS Tier1/USCMS-FNAL-WC1_downtime.yaml
@@ -572,7 +572,7 @@
   Description: Host went down
   Severity: Outage
   StartTime: May 04, 2020 15:00 +0000
-  EndTime: May 05, 2020 17:00 +0000
+  EndTime: May 04, 2020 17:10 +0000
   CreatedTime: May 04, 2020 16:20 +0000
   ResourceName: USCMS-FNAL-WC1-CE4
   Services:


### PR DESCRIPTION
The issue was fixed earlier than expected, so adjusting the end time accordingly