### PR TITLE
Extending the downtime for USCMS-FNAL-WC1-CE4

### DIFF
--- a/topology/Fermi National Accelerator Laboratory/FNAL USCMS Tier1/USCMS-FNAL-WC1_downtime.yaml
+++ b/topology/Fermi National Accelerator Laboratory/FNAL USCMS Tier1/USCMS-FNAL-WC1_downtime.yaml
@@ -583,7 +583,7 @@
   Description: Replacing hardware
   Severity: Outage
   StartTime: May 07, 2020 14:00 +0000
-  EndTime: May 13, 2020 14:00 +0000
+  EndTime: May 14, 2020 16:00 +0000
   CreatedTime: May 05, 2020 20:29 +0000
   ResourceName: USCMS-FNAL-WC1-CE4
   Services:


### PR DESCRIPTION
We are experiencing delays in getting the CE back up. I am extending the downtime by another day.