### PR TITLE
Add hsf.org repositories

### DIFF
--- a/virtual-organizations/OSG.yaml
+++ b/virtual-organizations/OSG.yaml
@@ -52,6 +52,8 @@ OASIS:
   OASISRepoURLs:
   - http://hcc-cvmfs-repo.unl.edu:8000/cvmfs/singularity.opensciencegrid.org
   - http://hcc-cvmfs-repo.unl.edu:8000/cvmfs/scitokens.osgstorage.org
+  - http://cvmfs-stratum-one.cern.ch:8000/cvmfs/sw.hsf.org
+  - http://cvmfs-stratum-one.cern.ch:8000/cvmfs/sw-nightlies.hsf.org
   - http://osg-cvmfs.grid.uchicago.edu:8000/cvmfs/veritas.opensciencegrid.org
   - http://osg-cvmfs.grid.uchicago.edu:8000/cvmfs/nexo.opensciencegrid.org
   - http://osg-cvmfs.grid.uchicago.edu:8000/cvmfs/bnl.opensciencegrid.org

--- a/virtual-organizations/OSG.yaml
+++ b/virtual-organizations/OSG.yaml
@@ -52,12 +52,14 @@ OASIS:
   OASISRepoURLs:
   - http://hcc-cvmfs-repo.unl.edu:8000/cvmfs/singularity.opensciencegrid.org
   - http://hcc-cvmfs-repo.unl.edu:8000/cvmfs/scitokens.osgstorage.org
-  - http://cvmfs-stratum-one.cern.ch:8000/cvmfs/sw.hsf.org
-  - http://cvmfs-stratum-one.cern.ch:8000/cvmfs/sw-nightlies.hsf.org
   - http://osg-cvmfs.grid.uchicago.edu:8000/cvmfs/veritas.opensciencegrid.org
   - http://osg-cvmfs.grid.uchicago.edu:8000/cvmfs/nexo.opensciencegrid.org
   - http://osg-cvmfs.grid.uchicago.edu:8000/cvmfs/bnl.opensciencegrid.org
   - http://osg-cvmfs.grid.uchicago.edu:8000/cvmfs/connect.opensciencegrid.org
+  # These are for common software from HSF, which is not a VO, so 
+  #  we include them here in the OSG VO.
+  - http://cvmfs-stratum-one.cern.ch:8000/cvmfs/sw.hsf.org
+  - http://cvmfs-stratum-one.cern.ch:8000/cvmfs/sw-nightlies.hsf.org
   UseOASIS: true
 PrimaryURL: http://www.opensciencegrid.org
 PurposeURL: http://www.opensciencegrid.org


### PR DESCRIPTION
As requested by this [helpdesk ticket](https://support.opensciencegrid.org/public/tickets/c5c1f8536ffcb45e81b1b64dfdcd5a4bb6cce55283f3f9be2df91eea4b7e9062).   These are repositories of shared software from HSF, not tied to a VO, so we're registering them with the OSG VO.