### PR TITLE
Fix hsf.org urls

### DIFF
--- a/virtual-organizations/OSG.yaml
+++ b/virtual-organizations/OSG.yaml
@@ -58,8 +58,8 @@ OASIS:
   - http://osg-cvmfs.grid.uchicago.edu:8000/cvmfs/connect.opensciencegrid.org
   # These are for common software from HSF, which is not a VO, so 
   #  we include them here in the OSG VO.
-  - http://cvmfs-stratum-one.cern.ch:8000/cvmfs/sw.hsf.org
-  - http://cvmfs-stratum-one.cern.ch:8000/cvmfs/sw-nightlies.hsf.org
+  - http://cvmfs-stratum-zero.cern.ch:8000/cvmfs/sw.hsf.org
+  - http://cvmfs-stratum-zero.cern.ch:8000/cvmfs/sw-nightlies.hsf.org
   UseOASIS: true
 PrimaryURL: http://www.opensciencegrid.org
 PurposeURL: http://www.opensciencegrid.org


### PR DESCRIPTION
Correct the mistake I had made on the hsf.org repo urls.  The should have been stratum zero instead of stratum one.