### PR TITLE
The WT2 CE no longer need to report to WLCG

### DIFF
--- a/topology/Stanford University/SLAC/WT2.yaml
+++ b/topology/Stanford University/SLAC/WT2.yaml
@@ -96,9 +96,9 @@ Resources:
       APELNormalFactor: 12.49
       AccountingName: US-WT2
       HEPSPEC: 42486
-      InteropAccounting: true
-      InteropBDII: true
-      InteropMonitoring: true
+      InteropAccounting: false
+      InteropBDII: false
+      InteropMonitoring: false
       KSI2KMax: 1202
       KSI2KMin: 820
       StorageCapacityMax: 0


### PR DESCRIPTION
FD #64971