### PR TITLE
Remove OASIS from Genie -- it is part of fermilab repo

### DIFF
--- a/virtual-organizations/Genie.yaml
+++ b/virtual-organizations/Genie.yaml
@@ -22,16 +22,6 @@ FieldsOfScience:
 ID: 223
 LongName: Fermilab/Genie
 MembershipServicesURL: https://voms.fnal.gov:8443/voms/fermilab
-OASIS:
-  Managers:
-    - Name: Joe Boyd
-      DNs:
-      - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Joe Boyd 579
-      - /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Joe Boyd 3582
-      ID: cb55ac2721726ebc83c3781ebe798e05ba425c47
-  OASISRepoURLs:
-  - http://oasiscfs.fnal.gov:8000/cvmfs/fermilab.opensciencegrid.org/genie
-  UseOASIS: true
 ParentVO:
   ID: 9
   Name: Fermilab


### PR DESCRIPTION
There should not have been an OASIS entry for Genie, because it does not have its own repository and it does not use a directory in the oasis.opensciencegrid.org repository.  It is just part of the fermilab.opensciencegrid.org repository.  This has been causing warning messages in a log on the oasis.opensciencegrid.org machine and I just noticed it: it was attempting to add the URL as a new repository and failing.  The OASISRepoURLs are not for documentation, they automatically add new repositories.