### PR TITLE
Update JLab.yaml

### DIFF
--- a/virtual-organizations/JLab.yaml
+++ b/virtual-organizations/JLab.yaml
@@ -40,7 +40,7 @@ LongName: Jefferson Lab
 OASIS:
   OASISRepoURLs:
   - http://hcc-cvmfs-repo.unl.edu:8000/cvmfs/jlab.osgstorage.org
-  UseOASIS: true
+  UseOASIS: false
 PrimaryURL: http://www.jlab.org/div_dept/cio/index.html
 ReportingGroups:
 - JLab


### PR DESCRIPTION
An interim update of the JLAB VO.  It now includes more contacts and some of what is needed to use oasis, though for the moment it is set to false