### PR TITLE
Add downtime for AGLT2_SE due to dCache Bug

### DIFF
--- a/topology/University of Michigan/AGLT2/AGLT2_downtime.yaml
+++ b/topology/University of Michigan/AGLT2/AGLT2_downtime.yaml
@@ -722,3 +722,14 @@
   Services:
   - SRMv2
 # ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 564175404
+  Description: Upgrade/downgrade caused SRM failure
+  Severity: Outage
+  StartTime: Jun 05, 2020 17:00 +0000
+  EndTime: Jun 08, 2020 17:00 +0000
+  CreatedTime: Jun 05, 2020 23:25 +0000
+  ResourceName: AGLT2_SE
+  Services:
+  - SRMv2
+# ---------------------------------------------------------


### PR DESCRIPTION
Our attempt to upgrade dCache has lead to an outage.  Restoring the original version didn't fix the problem.  Have contacted dCache support (ticket #9968).
Shawn