### PR TITLE
test bad downtime for automerge with /check_suite route (SOFTWARE-4119)

### DIFF
--- a/topology/University of Wisconsin/GLOW EDU/VDT-ITB_downtime.yaml
+++ b/topology/University of Wisconsin/GLOW EDU/VDT-ITB_downtime.yaml
@@ -9,3 +9,14 @@
   Services:
   - CE
 # ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 314407953
+  Description: Test downtime with duplicate ID
+  Severity: No Significant Outage Expected
+  StartTime: Aug 05, 2020 00:00 +0000
+  EndTime: Sep 19, 2020 00:00 +0000
+  CreatedTime: Jun 05, 2020 21:26 +0000
+  ResourceName: VDT-ITB-MADISON
+  Services:
+  - CE
+# ---------------------------------------------------------


### PR DESCRIPTION
CI should fail due to duplicate downtime ID