### PR TITLE
Create Georgia Tech PACE OSG 2.yaml

### DIFF
--- a/topology/Georgia Institute of Technology/Georgia Tech/Georgia Tech PACE OSG 2.yaml
+++ b/topology/Georgia Institute of Technology/Georgia Tech/Georgia Tech PACE OSG 2.yaml
@@ -1,0 +1,184 @@
+GroupDescription: Resources in the Georgia Tech PACE cluster, to be used by LIGO, Icecube, CTA, OSG-Connect and others.
+GroupID: 
+Production: true
+Resources:
+  Georgia_Tech_PACE_CE_2:
+    Active: true
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          ID: bce6aa9f33442110ab7554a8bf716ab80ed7bef5
+          Name: Paul Manno
+        Secondary:
+          ID: 60aadecab2baceb94cd6cfdbf600a64581ba6af2
+          Name: Mehmet Belgin
+        Tertiary:
+          ID: 14769be06478f6ac7e1785c371d412f6396b3409
+          Name: Andre McNeill
+        Tertiary:
+          ID: 068fa784cd29b5aee10ccce2669a95cbaa66d88b
+          Name: Ruben Lara
+      Miscellaneous Contact:
+        Primary:
+          ID: 547c65a6ed5e9e755c023418a47b8b92e88f0523
+          Name: Peter Couvares
+        Secondary:
+          ID: bce6aa9f33442110ab7554a8bf716ab80ed7bef5
+          Name: Paul Manno
+        Tertiary:
+          ID: 60aadecab2baceb94cd6cfdbf600a64581ba6af2
+          Name: Mehmet Belgin
+      Resource Report Contact:
+        Primary:
+          ID: 547c65a6ed5e9e755c023418a47b8b92e88f0523
+          Name: Peter Couvares
+        Secondary:
+          ID: bce6aa9f33442110ab7554a8bf716ab80ed7bef5
+          Name: Paul Manno
+        Tertiary:
+          ID: 60aadecab2baceb94cd6cfdbf600a64581ba6af2
+          Name: Mehmet Belgin
+      Security Contact:
+        Primary:
+          ID: 547c65a6ed5e9e755c023418a47b8b92e88f0523
+          Name: Peter Couvares
+        Secondary:
+          ID: bce6aa9f33442110ab7554a8bf716ab80ed7bef5
+          Name: Paul Manno
+    Description: This is a Condor CE in front of the PACE cluster, for use by LIGO, Icecube, CTA, OSG-Connect and others.
+    FQDN: osg-sched2.pace.gatech.edu
+    ID: 
+    Services:
+      CE:
+        Description: Compute Element
+        Details:
+          hidden: false
+      Squid:
+        Description: Generic squid service
+    VOOwnership:
+      LIGO: 25
+      IceCube: 25
+      CTA: 25
+      OSG: 25
+  Georgia_Tech_PACE_GridFTP2:
+    Active: true
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          ID: bce6aa9f33442110ab7554a8bf716ab80ed7bef5
+          Name: Paul Manno
+        Secondary:
+          ID: 60aadecab2baceb94cd6cfdbf600a64581ba6af2
+          Name: Mehmet Belgin
+        Tertiary:
+          ID: 14769be06478f6ac7e1785c371d412f6396b3409
+          Name: Andre McNeill
+        Tertiary:
+          ID: 068fa784cd29b5aee10ccce2669a95cbaa66d88b
+          Name: Ruben Lara
+      Miscellaneous Contact:
+        Primary:
+          ID: bce6aa9f33442110ab7554a8bf716ab80ed7bef5
+          Name: Paul Manno
+        Secondary:
+          ID: 60aadecab2baceb94cd6cfdbf600a64581ba6af2
+          Name: Mehmet Belgin
+      Resource Report Contact:
+        Secondary:
+          ID: bce6aa9f33442110ab7554a8bf716ab80ed7bef5
+          Name: Paul Manno
+        Tertiary:
+          ID: 60aadecab2baceb94cd6cfdbf600a64581ba6af2
+          Name: Mehmet Belgin
+      Security Contact:
+        Primary:
+          ID: 547c65a6ed5e9e755c023418a47b8b92e88f0523
+          Name: Peter Couvares
+        Secondary:
+          ID: bce6aa9f33442110ab7554a8bf716ab80ed7bef5
+          Name: Paul Manno
+    Description: Second GridFTP server, initially for incoming LIGO, Icecube, CTA, OSG-Connect.
+    FQDN: osg-gftp2.pace.gatech.edu
+    DN:  /DC=org/DC=incommon/C=US/ST=Georgia/L=Atlanta/O=Georgia Institute of Technology/OU=Office of Information Technology/CN=osg-gftp2.pace.gatech.edu
+    ID: 1058
+    Services:
+      GridFtp:
+        Description: Second GridFtp Storage Element
+        Details:
+          hidden: false
+      XRootD cache server:
+        Description: Second Georgia Tech Caching Server
+    VOOwnership:
+      LIGO: 25
+      IceCube: 25
+      CTA: 25
+      OSG: 25
+  Georgia_Tech_LIGO_Submit_2:
+    Active: true
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          ID: 547c65a6ed5e9e755c023418a47b8b92e88f0523
+          Name: Peter Couvares
+        Secondary:
+          ID: bce6aa9f33442110ab7554a8bf716ab80ed7bef5
+          Name: Paul Manno
+        Tertiary:
+          ID: 14769be06478f6ac7e1785c371d412f6396b3409
+          Name: Andre McNeill
+        Tertiary:
+          ID: 068fa784cd29b5aee10ccce2669a95cbaa66d88b
+          Name: Ruben Lara
+      Miscellaneous Contact:
+        Primary:
+          ID: bce6aa9f33442110ab7554a8bf716ab80ed7bef5
+          Name: Paul Manno
+        Secondary:
+          ID: 60aadecab2baceb94cd6cfdbf600a64581ba6af2
+          Name: Mehmet Belgin
+        Tertiary:
+          ID: 14769be06478f6ac7e1785c371d412f6396b3409
+          Name: Andre McNeill
+        Tertiary:
+          ID: 068fa784cd29b5aee10ccce2669a95cbaa66d88b
+          Name: Ruben Lara
+      Resource Report Contact:
+        Primary:
+          ID: bce6aa9f33442110ab7554a8bf716ab80ed7bef5
+          Name: Paul Manno
+        Secondary:
+          ID: 60aadecab2baceb94cd6cfdbf600a64581ba6af2
+          Name: Mehmet Belgin
+        Tertiary:
+          ID: 14769be06478f6ac7e1785c371d412f6396b3409
+          Name: Andre McNeill
+        Tertiary:
+          ID: 068fa784cd29b5aee10ccce2669a95cbaa66d88b
+          Name: Ruben Lara
+      Security Contact:
+        Primary:
+          ID: 547c65a6ed5e9e755c023418a47b8b92e88f0523
+          Name: Peter Couvares
+        Secondary:
+          ID: bce6aa9f33442110ab7554a8bf716ab80ed7bef5
+          Name: Paul Manno
+        Tertiary:
+          ID: 14769be06478f6ac7e1785c371d412f6396b3409
+          Name: Andre McNeill
+        Tertiary:
+          ID: 068fa784cd29b5aee10ccce2669a95cbaa66d88b
+          Name: Ruben Lara
+    Description: Georgia Tech submit node for LIGO, Icecube, CTA, OSG-Connect.
+    FQDN: osg-login2.pace.gatech.edu
+    ID: 
+    Services:
+      Submit Node:
+        Description: OSG Submission Node 2
+        Details:
+          hidden: false
+    VOOwnership:
+      LIGO: 25
+      IceCube: 25
+      CTA: 25
+      OSG: 25
+SupportCenter: Advanced LIGO


### PR DESCRIPTION
Create Georgia Tech PACE OSG2.yaml for new OSG deployment distinct from current Georgia Tech PACE deployment for LIGO.  This new deployment would accept LIGO, IceCube, CTA and OSG-connect jobs.  I left the ID in for resource Georgia_Tech_PACE_GridFTP2: osg-gftp2.pace.gatech.edu but if it needs to be changed, from deleting from previous group and added to this new group, that is fine.