### PR TITLE
Add downtime for NET2 due to Storage Hardware

### DIFF
--- a/topology/Boston University/Boston University ATLAS Tier2/BU_ATLAS_Tier2_downtime.yaml
+++ b/topology/Boston University/Boston University ATLAS Tier2/BU_ATLAS_Tier2_downtime.yaml
@@ -84,3 +84,15 @@
   - CE
   - SRMv2
 # ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 579465543
+  Description: Trying to set downtime again
+  Severity: Outage
+  StartTime: Jun 23, 2020 12:00 +0000
+  EndTime: Jun 23, 2020 21:00 +0000
+  CreatedTime: Jun 23, 2020 16:09 +0000
+  ResourceName: NET2
+  Services:
+  - CE
+  - SRMv2
+# ---------------------------------------------------------


### PR DESCRIPTION
Storage downtime to repair a GPFS server.  Site is effectively down for ATLAS purposes.