### PR TITLE
NET2 downtime is over.  Adjusting the EndTime

### DIFF
--- a/topology/Boston University/Boston University ATLAS Tier2/BU_ATLAS_Tier2_downtime.yaml
+++ b/topology/Boston University/Boston University ATLAS Tier2/BU_ATLAS_Tier2_downtime.yaml
@@ -89,7 +89,7 @@
   Description: Trying to set downtime again
   Severity: Outage
   StartTime: Jun 23, 2020 12:00 +0000
-  EndTime: Jun 23, 2020 21:00 +0000
+  EndTime: Jun 23, 2020 18:00 +0000
   CreatedTime: Jun 23, 2020 16:09 +0000
   ResourceName: NET2
   Services:


### PR DESCRIPTION
Our downtime is over now.  I adjusted the EndTime, so we can start up a couple of hours early.