### PR TITLE
Drop FQDNAlias for sc-origin2000.chtc.wisc.edu

### DIFF
--- a/topology/University of Wisconsin/CHTC/CHTC.yaml
+++ b/topology/University of Wisconsin/CHTC/CHTC.yaml
@@ -389,8 +389,6 @@ Resources:
           ID: 3f306d87236d84ef770ddf0c34844908e2d94dfa
           Name: Timothy Slauson
     FQDN: sc-origin2000.chtc.wisc.edu
-    FQDNAliases:
-      - sc-origin.chtc.wisc.edu
     DN: /CN=sc-origin2000.chtc.wisc.edu
     Services:
       XRootD origin server:


### PR DESCRIPTION
We've decided not to go ahead with the CNAME to simplify things.