### PR TITLE
Adding a new compute element to NMSU Discovery

### DIFF
--- a/topology/New Mexico State University/New Mexico State Discovery/NMSU_DISCOVERY.yaml
+++ b/topology/New Mexico State University/New Mexico State Discovery/NMSU_DISCOVERY.yaml
@@ -34,3 +34,34 @@ Resources:
         Description: NMSU Hosted CE
         Details:
           hidden: false
+  SLATE_US_NMSU_DISCOVERY:
+    Active: true
+    ID: 1072
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          Name: Nicholas Von Wolff
+          ID: 243c442622f34b7e283d95ef53c88928f4986110
+        Secondary:
+          Name: Strahinja Trecakov
+          ID: d891e1b64e13be9f607ad47543918681fe8c2708
+      Security Contact:
+        Primary:
+          Name: Nicholas Von Wolff
+          ID: 243c442622f34b7e283d95ef53c88928f4986110
+        Secondary:
+          Name: Strahinja Trecakov
+          ID: d891e1b64e13be9f607ad47543918681fe8c2708
+      Site Contact:
+        Primary:
+          Name: Nicholas Von Wolff
+          ID: 243c442622f34b7e283d95ef53c88928f4986110
+        Secondary:
+          Name: Strahinja Trecakov
+          ID: d891e1b64e13be9f607ad47543918681fe8c2708
+    FQDN: osg-ce.nmsu.edu
+    Services:
+      CE:
+        Description: NMSU SlateCI Self-Hosted CE
+        Details:
+          hidden: false


### PR DESCRIPTION
This adds a new SlateCI Self-Hosted CE to replace the OSG hosted resource.