### PR TITLE
NMSU Discovery: retire old CE resource

### DIFF
--- a/topology/New Mexico State University/New Mexico State Discovery/NMSU_DISCOVERY.yaml
+++ b/topology/New Mexico State University/New Mexico State Discovery/NMSU_DISCOVERY.yaml
@@ -4,6 +4,7 @@ GroupID: 488
 GroupDescription: New Mexico State University High Performance Computing group
 Resources:
   OSG_US_NMSU_DISCOVERY:
+    Active: false
     ID: 952
     Description: This is a small cluster to test OSG / NMSU integration.
     ContactLists:


### PR DESCRIPTION
Retire old remote-hosted OSG CE in favor of our new self-hosted local OSG CE.  Testing on the new CE has gone well, after some troubleshooting with gfactory, and we are ready to proceed with the switchover.