### PR TITLE
Update BU_ATLAS_Tier2_downtime.yaml

### DIFF
--- a/topology/Boston University/Boston University ATLAS Tier2/BU_ATLAS_Tier2_downtime.yaml
+++ b/topology/Boston University/Boston University ATLAS Tier2/BU_ATLAS_Tier2_downtime.yaml
@@ -96,3 +96,15 @@
   - CE
   - SRMv2
 # ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 620849981
+  Description: Hardware error in central BU N7K module.  Network engineers are working
+    on it.  DDM and production are down.
+  Severity: Outage
+  StartTime: Aug 10, 2020 00:01 +0000
+  EndTime: Aug 10, 2020 23:00 +0000
+  CreatedTime: Aug 10, 2020 13:43 +0000
+  ResourceName: NET2
+  Services:
+  - CE
+# ---------------------------------------------------------


### PR DESCRIPTION
Unscheduled downtime due to central BU networking hardware issue in one of the N7K modules.  Network engineers are working on it.