### PR TITLE
Add new slate resource for cedar

### DIFF
--- a/topology/University of Connecticut/UConn - cedar/cedar.yaml
+++ b/topology/University of Connecticut/UConn - cedar/cedar.yaml
@@ -34,3 +34,33 @@ Resources:
           hidden: false
     Tags:
       - CC*
+  UConn-CEDAR:
+    ID: 1073 
+    Description: The Hosted CE serving UConn-cedar
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          Name: Marco Mascheroni
+          ID: 030408ab932e143859b5f97a2d1c9e30ba2a9f0d
+        Secondary:
+          Name: Jeffrey Michael Dost
+          ID: 3a8eb6436a8b78ca50f7e93bb2a4d1f0141212ba
+      Security Contact:
+        Primary:
+          Name: Marco Mascheroni
+          ID: 030408ab932e143859b5f97a2d1c9e30ba2a9f0d
+        Secondary:
+          Name: Jeffrey Michael Dost
+          ID: 3a8eb6436a8b78ca50f7e93bb2a4d1f0141212ba
+      Site Contact:
+        Primary:
+          Name: Richard T. Jones
+          ID: 650bf84a5cf49caf504fed22ce07b98580c6fa12
+    FQDN: hosted-ce28.opensciencegrid.org
+    Services:
+      CE:
+        Description: UConn-CEDAR Hosted CE
+        Details:
+          hidden: false
+    Tags:
+      - CC*


### PR DESCRIPTION
Used naming convention from[1] while trying to maintain cedar as resource group (backward compatibility).

Setting:
            <attr name="GLIDEIN_ResourceName" const="True" glidein_publish="True" job_publish="True" parameter="True" publish="True" type="string" value="cedar"/>
            <attr name="GLIDEIN_Site" const="True" glidein_publish="True" job_publish="True" parameter="True" publish="True" type="string" value="cedar"/>


[1]https://docs.google.com/document/d/16YZpcfegXewEf1WeYLvtFIuDfQCv8U0m_TEgtw8zmJ8/edit#heading=h.ps1ea8hqqem3