### PR TITLE
* add topology for new cluster resource with our own local

### DIFF
--- a/topology/University of Connecticut/UConn-HPC/SITE.yaml
+++ b/topology/University of Connecticut/UConn-HPC/SITE.yaml
@@ -1,0 +1,10 @@
+LongName: University of Connecticut Storrs HPC Cluster
+Description: Storrs Campus Research Cluster
+ID: 10280
+AddressLine1: 196A Auditorium Road U-3138
+City: Storrs
+Country: USA
+State: Connecticut
+Zipcode: "06269-3138"
+Latitude: 41.8084
+Longitude: -72.2495

--- a/topology/University of Connecticut/UConn-HPC/UConn-HPC.yaml
+++ b/topology/University of Connecticut/UConn-HPC/UConn-HPC.yaml
@@ -1,0 +1,100 @@
+Production: true
+SupportCenter: GLUEX
+GroupDescription: OSG partition of the Storrs HPC Cluster
+GroupID: 1092
+Resources:
+  UConn-HPC_squid:
+    Active: true
+    Description: squid server for UConn-HPC
+    ID: 1093
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          ID: 650bf84a5cf49caf504fed22ce07b98580c6fa12
+          Name: Richard T. Jones
+      Miscellaneous Contact:
+        Primary:
+          ID: 650bf84a5cf49caf504fed22ce07b98580c6fa12
+          Name: Richard T. Jones
+      Resource Report Contact:
+        Primary:
+          ID: 650bf84a5cf49caf504fed22ce07b98580c6fa12
+          Name: Richard T. Jones
+      Security Contact:
+        Primary:
+          ID: 650bf84a5cf49caf504fed22ce07b98580c6fa12
+          Name: Richard T. Jones
+    FQDN: osgce.storrs.hpc.uconn.edu
+    FQDNAliases:
+      - cn410.storrs.hpc.uconn.edu
+    DN: /DC=org/DC=incommon/C=US/ST=Connecticut/L=Storrs/O=University of Connecticut/OU=Academic IT/CN=cn410.storrs.hpc.uconn.edu
+    Services:
+      Squid:
+        Description: squid server for Storrs HPC cluster
+    Tags:
+      - CC*
+    VOOwnership:
+      Gluex: 50
+      CLAS12: 50
+  UConn-HPC_CE:
+    Active: true
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          ID: 650bf84a5cf49caf504fed22ce07b98580c6fa12
+          Name: Richard T. Jones
+      Resource Report Contact:
+        Primary:
+          ID: 650bf84a5cf49caf504fed22ce07b98580c6fa12
+          Name: Richard T. Jones
+      Security Contact:
+        Primary:
+          ID: 650bf84a5cf49caf504fed22ce07b98580c6fa12
+          Name: Richard T. Jones
+    Description: HTcondor-CE server for the UConn-HPC compute resources
+    FQDN: osgce.storrs.hpc.uconn.edu
+    FQDNAliases:
+    - cn410.storrs.hpc.uconn.edu
+    ID: 1094
+    Services:
+      CE:
+        Description: Compute Element
+        Details:
+          hidden: false
+    VOOwnership:
+      Gluex: 50
+      CLAS12: 50
+  UConn-HPC_SE:
+    Active: true
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          ID: 650bf84a5cf49caf504fed22ce07b98580c6fa12
+          Name: Richard T. Jones
+      Resource Report Contact:
+        Primary:
+          ID: 650bf84a5cf49caf504fed22ce07b98580c6fa12
+          Name: Richard T. Jones
+      Security Contact:
+        Primary:
+          ID: 650bf84a5cf49caf504fed22ce07b98580c6fa12
+          Name: Richard T. Jones
+    Description: UConn-HPC grid storage resource
+    FQDN: osgse.storrs.hpc.uconn.edu
+    FQDNAliases:
+    - cn411.storrs.hpc.uconn.edu
+    ID: 1095
+    Services:
+      SRMv1:
+        Description: SRM V1 Storage Element
+        Details:
+          hidden: false
+          uri_override: osgse.storrs.hpc.uconn.edu:8443
+      SRMv2:
+        Description: SRM V2 Storage Element
+        Details:
+          hidden: false
+          uri_override: osgse.storrs.hpc.uconn.edu:8443
+    VOOwnership:
+      Gluex: 80
+      CLAS12: 20

--- a/topology/University of Connecticut/UConn-HPC/UConn-HPC.yaml
+++ b/topology/University of Connecticut/UConn-HPC/UConn-HPC.yaml
@@ -61,6 +61,8 @@ Resources:
         Description: Compute Element
         Details:
           hidden: false
+    Tags:
+      - CC*
     VOOwnership:
       Gluex: 50
       CLAS12: 50

--- a/topology/University of Connecticut/UConn-HPC/UConn-HPC.yaml
+++ b/topology/University of Connecticut/UConn-HPC/UConn-HPC.yaml
@@ -97,6 +97,8 @@ Resources:
         Details:
           hidden: false
           uri_override: osgse.storrs.hpc.uconn.edu:8443
+    Tags:
+      - CC*
     VOOwnership:
       Gluex: 80
       CLAS12: 20


### PR DESCRIPTION
  condor_ce and dcache instance, primary vo's are gluex and clas12.
* notice to reviewer -- Please take note that there is no facility
  on the UConn Storrs campus named cedar. There is a centrally hosted
  ce for the cedar cluster, but cedar is located on the campus of
  Simon Fraser University is British Columbia, CA. Please correct
  the metadata related to cedar, so it does not appear to be
  associated with UConn. Richard Jones is partnering with Zisis
  Papandreou (Univ. of Regina) in managing Gluex use of cedar, but
  it is not associated with UConn beyond that. -- Richard Jones --