### PR TITLE
Add downtime for Georgia Tech Resources due to quarterly maintenance

### DIFF
--- a/topology/Georgia Institute of Technology/Georgia Tech/Georgia Tech PACE_downtime.yaml
+++ b/topology/Georgia Institute of Technology/Georgia Tech/Georgia Tech PACE_downtime.yaml
@@ -363,3 +363,38 @@
   - GridFtp
   - XRootD cache server
 # ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 665275334
+  Description: Quarterly Scheduled Maintenance
+  Severity: Outage
+  StartTime: Oct 14, 2020 06:00 +0000
+  EndTime: Oct 16, 2020 23:59 +0000
+  CreatedTime: Sep 30, 2020 23:45 +0000
+  ResourceName: Georgia_Tech_LIGO_Submit_1
+  Services:
+  - Submit Node
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 665275858
+  Description: Quarterly Scheduled Maintenance
+  Severity: Outage
+  StartTime: Oct 14, 2020 06:00 +0000
+  EndTime: Oct 16, 2020 23:59 +0000
+  CreatedTime: Sep 30, 2020 23:46 +0000
+  ResourceName: Georgia_Tech_PACE_CE_1
+  Services:
+  - CE
+  - Squid
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 665276110
+  Description: Quarterly Scheduled Maintenance
+  Severity: Outage
+  StartTime: Oct 14, 2020 06:00 +0000
+  EndTime: Oct 16, 2020 23:59 +0000
+  CreatedTime: Sep 30, 2020 23:46 +0000
+  ResourceName: Georgia_Tech_PACE_GridFTP
+  Services:
+  - GridFtp
+  - XRootD cache server
+# ---------------------------------------------------------

--- a/topology/Georgia Institute of Technology/Georgia Tech/Georgia Tech PACE_downtime.yaml
+++ b/topology/Georgia Institute of Technology/Georgia Tech/Georgia Tech PACE_downtime.yaml
@@ -367,8 +367,8 @@
   ID: 665275334
   Description: Quarterly Scheduled Maintenance
   Severity: Outage
-  StartTime: Oct 14, 2020 06:00 +0000
-  EndTime: Oct 16, 2020 23:59 +0000
+  StartTime: Oct 14, 2020 10:00 +0000
+  EndTime: Oct 17, 2020 03:59 +0000
   CreatedTime: Sep 30, 2020 23:45 +0000
   ResourceName: Georgia_Tech_LIGO_Submit_1
   Services:
@@ -378,8 +378,8 @@
   ID: 665275858
   Description: Quarterly Scheduled Maintenance
   Severity: Outage
-  StartTime: Oct 14, 2020 06:00 +0000
-  EndTime: Oct 16, 2020 23:59 +0000
+  StartTime: Oct 14, 2020 10:00 +0000
+  EndTime: Oct 17, 2020 03:59 +0000
   CreatedTime: Sep 30, 2020 23:46 +0000
   ResourceName: Georgia_Tech_PACE_CE_1
   Services:
@@ -390,8 +390,8 @@
   ID: 665276110
   Description: Quarterly Scheduled Maintenance
   Severity: Outage
-  StartTime: Oct 14, 2020 06:00 +0000
-  EndTime: Oct 16, 2020 23:59 +0000
+  StartTime: Oct 14, 2020 10:00 +0000
+  EndTime: Oct 17, 2020 03:59 +0000
   CreatedTime: Sep 30, 2020 23:46 +0000
   ResourceName: Georgia_Tech_PACE_GridFTP
   Services:


### PR DESCRIPTION
Systems will be offline between 10/14 (Tue) and 10/16 (Thr) for scheduled quarterly maintenance.