### PR TITLE
Add some debug logging to getting the stashcache config (pass --debug flag to osg-scitokens-config)

### DIFF
--- a/bin/osg-scitokens-config
+++ b/bin/osg-scitokens-config
@@ -15,10 +15,18 @@ if __name__ == "__main__" and __package__ is None:
 import webapp.models
 import stashcache
 
+import logging
+
 parser = argparse.ArgumentParser(description="Generate a SciTokens config for a StashCache cache server.")
 parser.add_argument("fqdn", metavar="Cache_FQDN", help="FQDN of the cache for config generation.")
+parser.add_argument("--debug", action="store_true", help="Display debugging info.")
 
 args = parser.parse_args()
+
+if args.debug:
+    logging.basicConfig(level=logging.DEBUG)
+else:
+    logging.basicConfig(level=logging.WARNING)
 
 global_data = webapp.models.GlobalData()
 

--- a/src/stashcache.py
+++ b/src/stashcache.py
@@ -11,6 +11,9 @@ import hashlib
 from webapp.topology import Resource, ResourceGroup
 from webapp.vos_data import VOsData
 
+import logging
+
+log = logging.getLogger(__name__)
 
 __oid_map = {
    "DC": "0.9.2342.19200300.100.1.25",
@@ -131,6 +134,7 @@ def _cache_is_allowed(resource, vo_name, stashcache_data, public, suppress_error
     if ('ANY' not in allowed_vos and
             vo_name not in allowed_vos and
             (not public or 'ANY_PUBLIC' not in allowed_vos)):
+        log.debug(f"\tCache {resource.fqdn} does not allow {vo_name} in its AllowedVOs list")
         return False
 
     # For public data, caching is one-way: we OK things as long as the
@@ -145,7 +149,10 @@ def _cache_is_allowed(resource, vo_name, stashcache_data, public, suppress_error
         else:
             raise DataError("VO {} in StashCache does not provide an AllowedCaches list.".format(vo_name))
 
-    return 'ANY' in allowed_caches or resource.name in allowed_caches
+    ret = 'ANY' in allowed_caches or resource.name in allowed_caches
+    if not ret:
+        log.debug(f"\tVO {vo_name} does not allow cache {resource.fqdn} in its AllowedCaches list")
+    return ret
 
 
 def generate_cache_authfile(vo_data: VOsData, resource_groups: List[ResourceGroup], fqdn=None, legacy=True, suppress_errors=True) -> str:
@@ -285,6 +292,7 @@ audience = {allowed_vos_str}
     if not resource:
         return ""
 
+    log.debug(f"Generating stashcache cache config for {fqdn}")
     allowed_vos = []
     issuer_blocks = []
     for vo_name, vo_data in vo_data.vos.items():
@@ -296,6 +304,7 @@ audience = {allowed_vos_str}
         if not namespaces:
             continue
 
+        log.debug(f"Namespaces found for {vo_name}")
         needs_authz = False
         for authz_list in namespaces.values():
             for authz in authz_list:
@@ -303,6 +312,7 @@ audience = {allowed_vos_str}
                     needs_authz = True
                     break
         if not needs_authz:
+            log.debug(f"\tAuth not needed for {vo_name}")
             continue
 
         if not _cache_is_allowed(resource, vo_name, stashcache_data,
@@ -312,6 +322,7 @@ audience = {allowed_vos_str}
         for dirname, authz_list in namespaces.items():
             for authz in authz_list:
                 if not isinstance(authz, dict) or not isinstance(authz.get("SciTokens"), dict):
+                    log.debug(f"\tNo SciTokens info for {dirname} in {vo_name}")
                     continue
                 issuer_blocks.append(_get_scitokens_issuer_block(vo_name, authz['SciTokens'],
                                                                  dirname, suppress_errors))


### PR DESCRIPTION
This helped me diagnose why a cache was getting a blank scitokens config. There definitely needs to be more debugging (e.g. for getting authfile info or origin info), but this is a start.