### PR TITLE
JLab: add squid and CE

### DIFF
--- a/topology/Thomas Jefferson National Accelerator Facility/JLAB/Thomas Jefferson National Accelerator Facility GLUEX Glidein.yaml
+++ b/topology/Thomas Jefferson National Accelerator Facility/JLAB/Thomas Jefferson National Accelerator Facility GLUEX Glidein.yaml
@@ -10,7 +10,7 @@ Resources:
           ID: 818acb7ebcd1865a17551799f0cfeb5256e0db20
           Name: Kurt Strosahl
         Secondary:
-          ID: ea9db644eb6f8632cf87fd2cbac8a6e393c21f71 
+          ID: ea9db644eb6f8632cf87fd2cbac8a6e393c21f71
           Name: Wesley Moore
       Security Contact:
         Primary:
@@ -48,6 +48,49 @@ Resources:
           uri_override: sci-xrootd.jlab.org:2094
     AllowedVOs:
       - ANY
+    VOOwnership:
+      JLab: 100
+  JLab-FARM-Squid:
+    Active: true
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          ID: ea9db644eb6f8632cf87fd2cbac8a6e393c21f71
+          Name: Wesley Moore
+      Security Contact:
+        Primary:
+          ID: ea9db644eb6f8632cf87fd2cbac8a6e393c21f71
+          Name: Wesley Moore
+    FQDN: sci-squid.jlab.org
+    FQDNAliases:
+      - sci-squid.jlab.org
+    ID: FIXME
+    Services:
+      Squid:
+        Description: Squid server for JLab-FARM cluster
+    VOOwnership:
+      JLab: 100
+  JLab-FARM-CE:
+    Active: true
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          ID: ea9db644eb6f8632cf87fd2cbac8a6e393c21f71
+          Name: Wesley Moore
+      Security Contact:
+        Primary:
+          ID: ea9db644eb6f8632cf87fd2cbac8a6e393c21f71
+          Name: Wesley Moore
+    Description: HTcondor-CE server for JLab-FARM cluster
+    FQDN: osg-ce-1.jlab.org
+    FQDNAliases:
+    - osg-ce-1.jlab.org
+    ID: FIXME
+    Services:
+      CE:
+        Description: Compute Entry Point
+        Details:
+          hidden: false
     VOOwnership:
       JLab: 100
 SupportCenter: GLUEX


### PR DESCRIPTION
Adding resources for squid and CE.  ID's are flagged with FIXME and need to be set.