### PR TITLE
Adding the Expanse site

### DIFF
--- a/topology/University of California San Diego/SDSC-Expanse/SDSC-Expanse.yaml
+++ b/topology/University of California San Diego/SDSC-Expanse/SDSC-Expanse.yaml
@@ -1,0 +1,112 @@
+# Production is true if the resource is for production and not testing use
+Production: true
+# SupportCenter is one of the support centers in topology/support-centers.yaml
+SupportCenter: Community Support Center
+
+# GroupDescription is a long description of the resource group; may be multiple lines.
+GroupDescription: SDSC-Expanse cluster
+
+# If you have an up-to-date local git clone, fill GroupID with the output from `bin/next_resource_group_id`
+# Otherwise, leave it blank and we will fill in the appropriate value for you.
+GroupID: 1094
+
+# Resources contains one or more resources in this
+# ResourceGroup. A resource provides one or more services
+Resources:
+  # Resource Name should be a short descriptor of the resource.
+  # e.g. the Center for High Throughput Computing's GlideinWMS Frontend is "CHTC-glidein2"
+  # Resource Names need to be unique across all resources in the OSG.
+  SDSC-Expanse:
+    # Active is true if the resource is accepting requests, and false otherwise.
+    # When first registering a resource, set this to false. Set it to true when it's ready for production.
+    Active: true
+    # Description is a long description of the resource; may be multiple lines
+    Description: Hosted CE serving SDSC-Triton_Stratus
+    # If you have an up-to-date local git clone, fill ID with the output from `bin/next_resource_id`
+    # Otherwise, leave it blank and we will fill in the appropriate value for you.
+    ID: 1103
+    # ContactLists contain information about people to contact regarding this resource.
+    # The "ID" is a hash of their email address available at https://my.opensciencegrid.org/miscuser/xml
+    # If you cannot find the contact above XML, please register the contact:
+    # https://opensciencegrid.org/docs/common/registration/#registering-contacts
+    ContactLists:
+      # Administrative Contact is one to three people to contact regarding administrative issues
+      Administrative Contact:
+        Primary:
+          Name: Edgar Mauricio Fajardo Hernandez
+          ID: a89087e73b4e9d1732c5a7112332688940f06440
+        Secondary:
+          Name: Jeffrey Michael Dost
+          ID: 3a8eb6436a8b78ca50f7e93bb2a4d1f0141212ba
+      Security Contact:
+        Primary:
+          Name: Edgar Mauricio Fajardo Hernandez
+          ID: a89087e73b4e9d1732c5a7112332688940f06440
+        Secondary:
+          Name: Jeffrey Michael Dost
+          ID: 3a8eb6436a8b78ca50f7e93bb2a4d1f0141212ba
+      Site Contact:
+        Primary:
+          ID: a89087e73b4e9d1732c5a7112332688940f06440
+          Name: Edgar Mauricio Fajardo Hernandez
+
+    # FQDN is the fully qualified domain name of the host running this resource
+    FQDN: hosted-ce41.opensciencegrid.org
+    ### FQDNAliases (optional) are any other DNS aliases by which this host can be accessed
+    # FQDNAliases:
+    #   - <HOSTNAME1>
+    #   - <HOSTNAME2>
+
+    ### DN (optional except for XCache resources) is the DN of the host cert of the resource
+    # in OpenSSL 1.0 format (i.e. /DC=org/DC=incommon/C=US/...)
+    # DN: <DN>
+
+    # Services is one or more services provided by this resource;
+    # valid services are listed in topology/services.yaml with the format "<SERVICE NAME>: <ID>"
+    Services:
+      CE:
+        # Description is a brief description of the service
+        Description: SDSC-Triton_Stratus Hosted-CE
+        ### Details (optional)
+        # Details:
+        #   # hidden
+        #   hidden: false
+        #   ### uri_override (optional, use if your service is on some non-standard URL)
+        #   # uri_override: <HOST>:<PORT>
+        #   ### sam_uri (optional)
+        #   # sam_uri: htcondor://...
+        #   ### endpoint (for perfSONAR services)
+        #   # endpoint: <HOSTNAME>
+
+      # Other services if you have any
+      # <SERVICE NAME>:
+      # ...
+
+    ### Tags (optional) is a list of tags associated with the resource.
+    ### Include the tag "CC*" if applicable for a CC* CE.
+    Tags:
+
+    ### VOOwnership (optional) is the percentage of the resource owned by one or more VOs.
+    ### If part of the resource is not owned by the VO, do not list it.
+    ### The total percentage cannot exceed 100.
+    # VOOwnership:
+    #   <VO1>: <PERCENT>
+    #   <VO2>: <PERCENT>
+
+    ### WLCGInformation (optional) is only for resources that are part of the WLCG
+    # WLCGInformation:
+    #   APELNormalFactor: 0.0
+    #   AccountingName: <name>
+    #   HEPSPEC: 0
+    #   InteropAccounting: true
+    #   InteropBDII: true
+    #   InteropMonitoring: true
+    #   KSI2KMax: 0
+    #   KSI2KMin: 0
+    #   StorageCapacityMax: 0
+    #   StorageCapacityMin: 0
+    #   TapeCapacity: 0
+
+  # Other resources if you have any...
+  # <RESOURCE NAME>:
+  # ...

--- a/topology/University of California San Diego/SDSC-Expanse/SITE.yaml
+++ b/topology/University of California San Diego/SDSC-Expanse/SITE.yaml
@@ -1,0 +1,29 @@
+# LongName is the expanded name of the site
+LongName: SDSC-Expanse
+# Description is a brief description of your site
+Description: Expanse is a High-Performance Computing (HPC) cluster operated by the San Diego Supercomputer Center
+
+# If you have an up-to-date local git clone, fill ID with the output from `bin/next_site_id`
+# Otherwise, leave it blank and we will fill in the appropriate value for you.
+ID: 10281
+
+# AddressLine1 is the street address of the site
+AddressLine1: 10100 Hopkins Drive
+### AddressLine2 (optional) is the second line of the street address
+# AddressLine2: Room 101
+# City is the city the site is located in
+City: La Jolla
+
+# Country is the country the site is located in
+Country: USA
+### State (optional) is the state or province the site is located in
+State: CA
+### Zipcode (optional) is the zipcode/postal code of the site
+Zipcode: "92093"
+
+# Latitude is the latitude of the site (positive values are in the northern hemisphere)
+Latitude: 32.8844113
+# Longitude is the longitude of the site (positive values are in the eastern hemisphere)
+Longitude: -117.2412158
+
+


### PR DESCRIPTION
@djw8605 

I see that there is already use by @rynge in gracc on expanse [here](https://gracc.opensciencegrid.org/d/000000079/site-summary?orgId=1&var-site=SDSC-Expanse&var-type=Payload&refresh=30s&from=now-7d&to=now).

So I just want to make sure this pull request matches the names so we don't end up with two Expanse sites on topology.