### PR TITLE
Remove accidentally added ara.osgstorage.org

### DIFF
--- a/virtual-organizations/ARA.yaml
+++ b/virtual-organizations/ARA.yaml
@@ -29,7 +29,6 @@ OASIS:
       ID: b512ff43d2e9239b62fb63bf3b30202fa30731e9
   OASISRepoURLs:
   - http://cvmfs-stratum0.wipac.wisc.edu/cvmfs/ara.opensciencegrid.org
-  - http://hcc-cvmfs-repo.unl.edu:8000/cvmfs/ara.osgstorage.org
   UseOASIS: true
 ParentVO:
   ID: 38


### PR DESCRIPTION
This entry for ara.osgstorage.org was probably accidentally copied from some other entry and was never officially requested.  It has been putting warnings into log files on the oasis machine ever since which have been largely ignored, but the line should be removed.

@dsschult 