### PR TITLE
CIT: IP renumbering. cit-gatekeeper host will change its public IP

### DIFF
--- a/topology/California Institute of Technology/Caltech CMS Tier2/CIT_CMS_T2_downtime.yaml
+++ b/topology/California Institute of Technology/Caltech CMS Tier2/CIT_CMS_T2_downtime.yaml
@@ -1209,6 +1209,20 @@
 # --------------------------------------------------------
 
 
+# --------------------------------------------------------
+# IP renumbering cit-gatekeeper host will change its public IP
+
+- Class: SCHEDULED
+  ID: 603597111
+  Description: IP renumbering cit-gatekeeper host will change its public IP
+  Severity: Outage
+  StartTime: Oct 20, 2020 08:00 -0700
+  EndTime: Oct 21, 2020 07:59 -0700
+  CreatedTime: Oct 19, 2020 20:38 +0000
+  ResourceName: CIT_CMS_T2
+  Services:
+    - CE
+
 
 
 


### PR DESCRIPTION
cit-gatekeeper.ultralight.org IPv4 address will change from 198.32.44.231 to 198.32.44.9