### PR TITLE
Remove old/unused Purdue sites

### DIFF
--- a/topology/Purdue University/Purdue NWICG/SITE.yaml
+++ b/topology/Purdue University/Purdue NWICG/SITE.yaml
@@ -1,7 +1,0 @@
-City: West Lafayette
-Country: United States
-ID: 10072
-Latitude: 40.424923
-Longitude: -87.1
-State: IN
-Zipcode: '47907'

--- a/topology/Purdue University/Purdue Physics/SITE.yaml
+++ b/topology/Purdue University/Purdue Physics/SITE.yaml
@@ -1,7 +1,0 @@
-City: West Lafayette
-Country: United States
-ID: 10004
-Latitude: 40.424923
-Longitude: -86.916215
-State: IN
-Zipcode: '47907'


### PR DESCRIPTION
These sites are no longer in use at Purdue and can be removed.