### PR TITLE
Update Purdue_downtime.yaml

### DIFF
--- a/topology/Purdue University/Purdue CMS/Purdue_downtime.yaml
+++ b/topology/Purdue University/Purdue CMS/Purdue_downtime.yaml
@@ -976,7 +976,7 @@
   Description: Routine Cluster Maintenance
   Severity: Outage
   StartTime: Nov 03, 2020 13:00 +0000
-  EndTime: Nov 04, 2020 05:00 +0000
+  EndTime: Nov 04, 2020 15:00 +0000
   CreatedTime: Oct 26, 2020 20:06 +0000
   ResourceName: Purdue-Hammer-CE
   Services:
@@ -987,7 +987,7 @@
   Description: Planned cluster maintenance.
   Severity: Severe
   StartTime: Nov 03, 2020 13:00 +0000
-  EndTime: Nov 03, 2020 23:00 +0000
+  EndTime: Nov 04, 2020 15:00 +0000
   CreatedTime: Oct 28, 2020 15:58 +0000
   ResourceName: Purdue-Hadoop-SE-Gridftp
   Services:
@@ -998,7 +998,7 @@
   Description: Planned cluster maintenance.
   Severity: Severe
   StartTime: Nov 03, 2020 13:00 +0000
-  EndTime: Nov 03, 2020 23:00 +0000
+  EndTime: Nov 04, 2020 15:00 +0000
   CreatedTime: Oct 29, 2020 18:57 +0000
   ResourceName: Purdue-Halstead
   Services:
@@ -1009,7 +1009,7 @@
   Description: Planned cluster maintenance.
   Severity: Severe
   StartTime: Nov 03, 2020 13:00 +0000
-  EndTime: Nov 03, 2020 23:00 +0000
+  EndTime: Nov 04, 2020 15:00 +0000
   CreatedTime: Oct 29, 2020 18:58 +0000
   ResourceName: Purdue-Brown
   Services:
@@ -1020,7 +1020,7 @@
   Description: Planned cluster maintenance.
   Severity: Severe
   StartTime: Nov 03, 2020 13:00 +0000
-  EndTime: Nov 03, 2020 23:00 +0000
+  EndTime: Nov 04, 2020 15:00 +0000
   CreatedTime: Oct 29, 2020 18:59 +0000
   ResourceName: Purdue-Rice
   Services:


### PR DESCRIPTION
We were informed that the central /home filesystem will need extra time, so we are extending the CMS outage accordingly.
We used the opportunity to also align all outages on the same time-boundaries.