### PR TITLE
Drop CHTC_STASHCACHE_ORIGIN from IceCube's AllowedOrigins list

### DIFF
--- a/virtual-organizations/IceCube.yaml
+++ b/virtual-organizations/IceCube.yaml
@@ -51,6 +51,5 @@ DataFederations:
     AllowedCaches:
       - ANY
     AllowedOrigins:
-      - CHTC_STASHCACHE_ORIGIN
       - IceCube_StashCache_origin
 


### PR DESCRIPTION
per FD #65990; IceCube now has their own origin.