### PR TITLE
Update BNL-Belle-II.yaml

### DIFF
--- a/topology/Brookhaven National Laboratory/Brookhaven Belle-II Tier1/BNL-Belle-II.yaml
+++ b/topology/Brookhaven National Laboratory/Brookhaven Belle-II Tier1/BNL-Belle-II.yaml
@@ -43,7 +43,7 @@ Resources:
       APELNormalFactor: 10.43
       AccountingName: BNL_BELLE_II_CE_1
       HEPSPEC: 0
-      InteropAccounting: true
+      InteropAccounting: false
       InteropBDII: false
       InteropMonitoring: false 
       KSI2KMax: 0


### PR DESCRIPTION
disable accounting reporting for bgk01 CE, as it's down now.