### PR TITLE
Add resource group UCL-INGRID with StashCache Origin resource

### DIFF
--- a/topology/Universite catholique de Louvain/UCL-INGRID/UCL-INGRID.yaml
+++ b/topology/Universite catholique de Louvain/UCL-INGRID/UCL-INGRID.yaml
@@ -1,0 +1,27 @@
+Production: true
+SupportCenter: Self Supported
+GroupDescription: StashCache Origin in Louvain
+GroupID: 1097
+Resources:
+  UCL-Virgo-StashCache-Origin:
+    Active: true
+    Description: Virgo StashCache Origin
+    ID: 1108
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          Name: Andres Tanasijczuk
+          ID: 7142b387956966f21dfcedf7fa4eef637c15837c 
+        Secondary:
+          Name: Pavel Demin
+          ID: a1697df7d81a4fe12d6f156922ef6c7b82bd3479
+      Security Contact:
+        Primary:
+          Name: Pavel Demin
+          ID: a1697df7d81a4fe12d6f156922ef6c7b82bd3479 
+    FQDN: ingrid-se07.cism.ucl.ac.be 
+    Services:
+      XRootD origin server:
+        Description: Virgo StashCache Origin Server
+    AllowedVOs:
+      - ANY


### PR DESCRIPTION
UCL-INGRID will host a StashCache Origin for data of the Virgo gravitational waves experiment. Currently this data are in the UNL StashCache Origin, which hosts data from both LIGO and Virgo.

The UNL Caching Infrastructure yaml file lists only LIGO as Allowed VO. I have put LIGO and Virgo. Should I only put LIGO?

I am not sure if SupportCenter should be "Self Supported" (as I put) or "Community Support Center".