### PR TITLE
yaml spec requires a colon to be followed by a space for a mapping

### DIFF
--- a/virtual-organizations/LIGO.yaml
+++ b/virtual-organizations/LIGO.yaml
@@ -80,7 +80,7 @@ DataFederations:
   StashCache:
     Namespaces:
       /user/ligo:
-        - FQAN:/osg/ligo
+        - FQAN: /osg/ligo
         - SciTokens:
             Issuer: https://scitokens.org/ligo
             Base Path: /user/ligo


### PR DESCRIPTION
https://yaml.org/spec/1.2/spec.html#:%20mapping%20value//