### PR TITLE
Change IceCube's StashCache namespace

### DIFF
--- a/virtual-organizations/IceCube.yaml
+++ b/virtual-organizations/IceCube.yaml
@@ -46,7 +46,7 @@ ReportingGroups:
 DataFederations:
   StashCache:
     Namespaces:
-      /icecube/PUBLIC:
+      /icecube/users:
         - PUBLIC
       # This path doesn't exist (nor does the issuer) but we need it to generate an acceptable scitokens.conf until SOFTWARE-4223 and/or SOFTWARE-4389 are done.
       /icecube/PROTECTED:


### PR DESCRIPTION
Change IceCube's StashCache namespace to be consistent with the existing CVMFS directory structure