### PR TITLE
Add downtime for SLATE_US_NMSU_AGGIE_GRID for biannual servicing

### DIFF
--- a/topology/New Mexico State University/New Mexico State AggieGrid/NMSU_AGGIE_GRID_downtime.yaml
+++ b/topology/New Mexico State University/New Mexico State AggieGrid/NMSU_AGGIE_GRID_downtime.yaml
@@ -1,0 +1,10 @@
+- Class: SCHEDULED
+  ID: 727476720
+  Description: Biannual downtime for hardware and software upgrades.
+  Severity: Outage
+  StartTime: Dec 14, 2020 07:00 +0000
+  EndTime: Dec 28, 2020 23:59 +0000
+  CreatedTime: Dec 11, 2020 22:34 +0000
+  ResourceName: SLATE_US_NMSU_AGGIE_GRID
+  Services:
+  - CE


### PR DESCRIPTION
Kubernetes nodes hosting the CE are being re-racked and moved.  Downtime may end early but it is not a priority while we are working on the Discovery cluster in the same period.