### PR TITLE
T2_US_Wisconsin scheduled downtime on 2021-01-19 due to HDFS update

### DIFF
--- a/topology/University of Wisconsin/GLOW/GLOW_downtime.yaml
+++ b/topology/University of Wisconsin/GLOW/GLOW_downtime.yaml
@@ -1312,4 +1312,47 @@
   Services:
   - CE
 # ---------------------------------------------------------
-
+- Class: SCHEDULED
+  ID: 757624048
+  Description: HDFS update disables access to files on /store
+  Severity: Severe
+  StartTime: Jan 19, 2021 14:00 +0000
+  EndTime: Jan 19, 2021 21:00 +0000
+  CreatedTime: Jan 15, 2021 20:00 +0000
+  ResourceName: GLOW
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 757624627
+  Description: HDFS update disables access to files on /store
+  Severity: Severe
+  StartTime: Jan 19, 2021 14:00 +0000
+  EndTime: Jan 19, 2021 21:00 +0000
+  CreatedTime: Jan 15, 2021 20:01 +0000
+  ResourceName: GLOW-CMS
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 757625184
+  Description: HDFS update disables access to files on /store
+  Severity: Severe
+  StartTime: Jan 19, 2021 14:00 +0000
+  EndTime: Jan 19, 2021 21:00 +0000
+  CreatedTime: Jan 15, 2021 20:01 +0000
+  ResourceName: GLOW-CMS-SE
+  Services:
+  - SRMv2
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 757625647
+  Description: HDFS update disables access to files on /store
+  Severity: Severe
+  StartTime: Jan 19, 2021 14:00 +0000
+  EndTime: Jan 19, 2021 21:00 +0000
+  CreatedTime: Jan 15, 2021 20:02 +0000
+  ResourceName: GLOW-CONDOR-CE
+  Services:
+  - CE
+# ---------------------------------------------------------


### PR DESCRIPTION
HDFS update disables access to files on /store on 2021-01-19 14:00-21:00 UTC. Jobs on the CEs may fail without file access, and SE will not be accessible.