### PR TITLE
Update BU_ATLAS_Tier2_downtime.yaml

### DIFF
--- a/topology/Boston University/Boston University ATLAS Tier2/BU_ATLAS_Tier2_downtime.yaml
+++ b/topology/Boston University/Boston University ATLAS Tier2/BU_ATLAS_Tier2_downtime.yaml
@@ -120,3 +120,14 @@
   - CE
   - SRMv2
 # ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 762812933
+  Description: 'GPFS file system '
+  Severity: Outage
+  StartTime: Jan 21, 2021 19:00 +0000
+  EndTime: Jan 22, 2021 19:00 +0000
+  CreatedTime: Jan 21, 2021 20:08 +0000
+  ResourceName: NET2
+  Services:
+  - SRMv2
+# ---------------------------------------------------------


### PR DESCRIPTION
Unscheduled GPFS problem at NET2.  We still have NESE_DATADISK and should be able to continue ATLAS production.  However DDM transfers to and from NET2_DATADISK will fail.