### PR TITLE
Update BU_ATLAS_Tier2_downtime.yaml

### DIFF
--- a/topology/Boston University/Boston University ATLAS Tier2/BU_ATLAS_Tier2_downtime.yaml
+++ b/topology/Boston University/Boston University ATLAS Tier2/BU_ATLAS_Tier2_downtime.yaml
@@ -125,7 +125,7 @@
   Description: 'GPFS file system '
   Severity: Outage
   StartTime: Jan 21, 2021 19:00 +0000
-  EndTime: Jan 22, 2021 19:00 +0000
+  EndTime: Jan 25, 2021 19:00 +0000
   CreatedTime: Jan 21, 2021 20:08 +0000
   ResourceName: NET2
   Services:


### PR DESCRIPTION
Extending downtime for NET2_DATADISK, NET2_LOCALGROUPDISK and NET2_SCRATCHDISK...   NESE_DATADISK and NESE_SCRATCHDISK remain up.