### PR TITLE
Update downtime file for UERJ

### DIFF
--- a/topology/Universidade do Estado do Rio de Janeiro/T2_BR_UERJ/UERJ_downtime.yaml
+++ b/topology/Universidade do Estado do Rio de Janeiro/T2_BR_UERJ/UERJ_downtime.yaml
@@ -226,4 +226,65 @@
   Services:
   - CE
 # ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 773664923
+  Description: The university will undergo a big network maitenance that might affect
+    our services.
+  Severity: Outage
+  StartTime: Feb 05, 2021 03:00 +0000
+  EndTime: Feb 08, 2021 20:00 +0000
+  CreatedTime: Feb 03, 2021 15:34 +0000
+  ResourceName: UERJ_CE_2
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 773665734
+  Description: The university will undergo a big network maitenance that might affect
+    our services.
+  Severity: Outage
+  StartTime: Feb 05, 2021 03:00 +0000
+  EndTime: Feb 08, 2021 20:00 +0000
+  CreatedTime: Feb 03, 2021 15:36 +0000
+  ResourceName: UERJ_SE
+  Services:
+  - SRMv2
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 773665883
+  Description: The university will undergo a big network maitenance that might affect
+    our services.
+  Severity: Outage
+  StartTime: Feb 05, 2021 03:00 +0000
+  EndTime: Feb 08, 2021 20:00 +0000
+  CreatedTime: Feb 03, 2021 15:36 +0000
+  ResourceName: UERJ_SQUID
+  Services:
+  - Squid
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 773666005
+  Description: The university will undergo a big network maitenance that might affect
+    our services.
+  Severity: Outage
+  StartTime: Feb 05, 2021 03:00 +0000
+  EndTime: Feb 08, 2021 20:00 +0000
+  CreatedTime: Feb 03, 2021 15:36 +0000
+  ResourceName: UERJ_perfSONAR_BW
+  Services:
+  - net.perfSONAR.Bandwidth
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 773666131
+  Description: The university will undergo a big network maitenance that might affect
+    our services.
+  Severity: Outage
+  StartTime: Feb 05, 2021 03:00 +0000
+  EndTime: Feb 08, 2021 20:00 +0000
+  CreatedTime: Feb 03, 2021 15:36 +0000
+  ResourceName: UERJ_perfSONAR_LT
+  Services:
+  - net.perfSONAR.Bandwidth
+# ---------------------------------------------------------
+
 


### PR DESCRIPTION
Add downtime for all T2_BR_UERJ resources because the university will undergo a big network maitenance that might affect our services.