### PR TITLE
Convenience script to run most of the next_*_id scripts and display their output in a table

### DIFF
--- a/bin/next_ids
+++ b/bin/next_ids
@@ -1,0 +1,9 @@
+#!/bin/bash
+progdir=$(dirname "$0")
+printf "%-15s: %6d\n" \
+"Project" "$("$progdir/next_project_id")" \
+"VO" "$("$progdir/next_virtual_organization_id")" \
+"Facility" "$("$progdir/next_facility_id")" \
+"Site" "$("$progdir/next_site_id")" \
+"Resource Group" "$("$progdir/next_resource_group_id")" \
+"Resource" "$("$progdir/next_resource_id")"

--- a/bin/next_ids
+++ b/bin/next_ids
@@ -1,9 +1,9 @@
 #!/bin/bash
-progdir=$(dirname "$0")
+cd "$(dirname "$0")"
 printf "%-15s: %6d\n" \
-"Project" "$("$progdir/next_project_id")" \
-"VO" "$("$progdir/next_virtual_organization_id")" \
-"Facility" "$("$progdir/next_facility_id")" \
-"Site" "$("$progdir/next_site_id")" \
-"Resource Group" "$("$progdir/next_resource_group_id")" \
-"Resource" "$("$progdir/next_resource_id")"
+Project $(./next_project_id) \
+VO $(./next_virtual_organization_id) \
+Facility $(./next_facility_id) \
+Site $(./next_site_id) \
+"Resource Group" $(./next_resource_group_id) \
+Resource $(./next_resource_id)

--- a/bin/next_ids
+++ b/bin/next_ids
@@ -1,9 +1,9 @@
 #!/bin/bash
 cd "$(dirname "$0")"
 printf "%-15s: %6d\n" \
-Project $(./next_project_id) \
-VO $(./next_virtual_organization_id) \
-Facility $(./next_facility_id) \
-Site $(./next_site_id) \
+Project          $(./next_project_id) \
+VO               $(./next_virtual_organization_id) \
+Facility         $(./next_facility_id) \
+Site             $(./next_site_id) \
 "Resource Group" $(./next_resource_group_id) \
-Resource $(./next_resource_id)
+Resource         $(./next_resource_id)


### PR DESCRIPTION
Often I need an ID both for a resource group and a resource; sometimes I need that
plus a new site and facility.  This is less annoying than running those scripts one
at a time.

I added Project and VO for completeness; I omitted Downtime (that's time based, not
sequence based) and Service Center (we're avoiding those).
