### PR TITLE
Beocat self-hosted Hosted CE is a proof-of-concept for GP-ARGO

### DIFF
--- a/topology/Kansas State University/Beocat/BEOCAT-SLATE.yaml
+++ b/topology/Kansas State University/Beocat/BEOCAT-SLATE.yaml
@@ -26,3 +26,5 @@ Resources:
         Description: Compute Element
         Details:
           hidden: false
+    Tags:
+      - CC*


### PR DESCRIPTION
@kylehutson @Mansalu if I understood correctly, the new Beocat self-hosted Hosted-CE is part of GP-ARGO and therefore it is CC*. Is that correct?