### PR TITLE
Add height to fix safari legend bug

### DIFF
--- a/src/templates/iframe.html.j2
+++ b/src/templates/iframe.html.j2
@@ -652,8 +652,8 @@ padding: 4px;
     <div><img src="/static/images/star_red_bigger.png">CC* Site</div>
 </div>
 <div id="legend_xrootd" class="legend" style="display: none"><h2>Legend</h2>
-    <div><img width="30" src="/static/images/XRootDOrigin.png">Origin</div>
-    <div><img width="30" src="/static/images/XRootDCache.png">Cache</div>
+    <div><img width="30" height="34" src="/static/images/XRootDOrigin.png">Origin</div>
+    <div><img width="30" height="34" src="/static/images/XRootDCache.png">Cache</div>
 </div>
 </div>
 


### PR DESCRIPTION
Of course safari would have different behavior than Chrome and Firefox.