### PR TITLE
Fix service name for CU backfill containers

### DIFF
--- a/topology/University of Colorado/CU - Research Computing/CUmulus.yaml
+++ b/topology/University of Colorado/CU - Research Computing/CUmulus.yaml
@@ -69,7 +69,7 @@ Resources:
     # Services is one or more services provided by this resource;
     # valid services are listed in topology/services.yaml with the format "<SERVICE NAME>: <ID>"
     Services:
-      CE:
+      Execution Endpoint:
         # Description is a brief description of the service
         Description: Backfill containers running on CUmulus nodes
         ### Details (optional)


### PR DESCRIPTION
Was marked as a CE since we didn't have a dedicated service type yet