### PR TITLE
Fix up some automerge check issues

### DIFF
--- a/src/webapp/automerge_check.py
+++ b/src/webapp/automerge_check.py
@@ -156,10 +156,7 @@ def looks_like_downtime(fname):
     return re.search(br'^topology/[^/]+/[^/]+/[^/]+_downtime.yaml$', fname)
 
 def zsplit(txt):
-    items = txt.split(b'\0')
-    if items[-1:] == [b'']:
-        items[-1:] = []
-    return items
+    return txt.rstrip(b'\0').split(b'\0')
 
 def get_modified_files(sha_a, sha_b):
     args = ['git', 'diff', '-z', '--name-only', sha_a, sha_b]

--- a/src/webapp/automerge_check.py
+++ b/src/webapp/automerge_check.py
@@ -195,8 +195,8 @@ def list_dir_at_version(sha, path):
     return zsplit(out)
 
 def get_organizations_at_version(sha):
-    projects = [ parse_yaml_at_version(sha, "projects/" + fname, {})
-                 for fname in list_dir_at_version(sha, "projects")
+    projects = [ parse_yaml_at_version(sha, b"projects/" + fname, {})
+                 for fname in list_dir_at_version(sha, b"projects")
                  if re.search(br'.\.yaml$', fname) ]
     return set( p.get("Organization") for p in projects )
 

--- a/src/webapp/automerge_check.py
+++ b/src/webapp/automerge_check.py
@@ -20,6 +20,15 @@ except ImportError:
 import xml.etree.ElementTree as et
 
 
+# NOTE: throughout this program, git shas are of type str, while paths and
+# filenames are of type bytes.  The motivation behind this is to handle
+# potentially arbitrary filenames in an arbitrary git tree submitted in
+# an arbitrary pull request.  This also means that git blob references
+# in the form "sha:path" must be of type bytes.
+#
+# So if the b'' strings look peculiar, that's why.
+
+
 def usage():
     print("Usage: %s BASE_SHA HEAD_SHA[:MERGE_COMMIT_SHA] [GitHubUser]"
                    % os.path.basename(__file__))
@@ -165,6 +174,7 @@ def get_modified_files(sha_a, sha_b):
         sys.exit(1)
     return zsplit(out)
 
+# NB: returns stdout for cmdline as bytes
 def runcmd(cmdline, **popen_kw):
     from subprocess import Popen, PIPE
     p = Popen(cmdline, stdout=PIPE, **popen_kw)

--- a/src/webapp/automerge_check.py
+++ b/src/webapp/automerge_check.py
@@ -208,7 +208,7 @@ def commit_is_merged(sha_a, sha_b):
 def get_merge_base(sha_a, sha_b):
     args = ['git', 'merge-base', sha_a, sha_b]
     ret, out = runcmd(args, stderr=_devnull)
-    return out.strip() if ret == 0 else None
+    return out.strip().decode() if ret == 0 else None
 
 def parse_yaml_at_version(sha, fname, default):
     txt = get_file_at_version(sha, fname)


### PR DESCRIPTION
Apparently after 946d46849e, we started getting some random failures for the automerge-check script, which after adding 
#1632 revealed new python tracebacks like the one in #1685 .  Yay for debuggability.

Apparently the system python3 (used after 946d46849e) behaves different than the previous python in the venv, although that  was also python3.  Don't know exactly why that caused the behavior to change, but in any case the new one is tripping over / exposing this str vs bytes bug.

As noted in the new comment text, the automerge check script handles paths and filenames as bytes strings, since git trees from unknown PRs can contain arbitrary filenames, which are not necessarily valid utf-8.  However, the script was passing in the "projects" path as a regular str, instead of a bytes string, which is what was causing the exception in the traceback.