### PR TITLE
Decommissioning the cluster

### DIFF
--- a/topology/Georgia Institute of Technology/Georgia Tech/Georgia Tech PACE.yaml
+++ b/topology/Georgia Institute of Technology/Georgia Tech/Georgia Tech PACE.yaml
@@ -1,9 +1,9 @@
 GroupDescription: Resources in the Georgia Tech PACE cluster, to be used by LIGO.
 GroupID: 423
-Production: true
+Production: false
 Resources:
   Georgia_Tech_PACE_CE_1:
-    Active: true
+    Active: false
     ContactLists:
       Administrative Contact:
         Primary:
@@ -70,7 +70,7 @@ Resources:
     VOOwnership:
       LIGO: 100
   Georgia_Tech_PACE_GridFTP:
-    Active: true
+    Active: false
     ContactLists:
       Administrative Contact:
         Primary:
@@ -133,7 +133,7 @@ Resources:
     VOOwnership:
       LIGO: 100
   Georgia_Tech_LIGO_Submit_1:
-    Active: true
+    Active: false
     ContactLists:
       Administrative Contact:
         Primary:

--- a/topology/Georgia Institute of Technology/Georgia Tech/Georgia Tech PACE.yaml
+++ b/topology/Georgia Institute of Technology/Georgia Tech/Georgia Tech PACE.yaml
@@ -1,6 +1,6 @@
 GroupDescription: Resources in the Georgia Tech PACE cluster, to be used by LIGO.
 GroupID: 423
-Production: false
+Production: true
 Resources:
   Georgia_Tech_PACE_CE_1:
     Active: false


### PR DESCRIPTION
Georgia Tech is in the process of vacating the old data center and this cluster will need to be decommissioned in favor of the new cluster that's being built and configured. The access to the old cluster was disabled on 3/23.