### PR TITLE
Replicate belle.kek.jp

### DIFF
--- a/virtual-organizations/Belle.yaml
+++ b/virtual-organizations/Belle.yaml
@@ -59,7 +59,9 @@ OASIS:
     - Name: Kiyoshi Hayasaka
       DNs: /C=JP/O=KEK/OU=CRC/CN=HAYASAKA Kiyoshi
       ID: a576382ce7f50940632597dbf12b34eaa718bae2
-  UseOASIS: true
+  UseOASIS: false
+  OASISRepoURLs:
+    - http://cvmfs-stratum-zero.cc.kek.jp/cvmfs/belle.kek.jp
 PrimaryURL: http://belle.kek.jp
 PurposeURL: http://belle.kek.jp
 ReportingGroups:


### PR DESCRIPTION
This adds replication of the belle.kek.jp cvmfs repository.  BNL has already been replicating it for a long time.

@zvada fyi