### PR TITLE
Update BU_ATLAS_Tier2_downtime.yaml

### DIFF
--- a/topology/Boston University/Boston University ATLAS Tier2/BU_ATLAS_Tier2_downtime.yaml
+++ b/topology/Boston University/Boston University ATLAS Tier2/BU_ATLAS_Tier2_downtime.yaml
@@ -143,3 +143,15 @@
   - CE
   - SRMv2
 # ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 839671566
+  Description: NESE Core Network upgrade
+  Severity: Severe
+  StartTime: Apr 22, 2021 18:00 +0000
+  EndTime: Apr 23, 2021 03:00 +0000
+  CreatedTime: Apr 21, 2021 01:05 +0000
+  ResourceName: NET2
+  Services:
+  - CE
+  - SRMv2
+# ---------------------------------------------------------


### PR DESCRIPTION
NESE Core network upgrade.  NESE Storage will be unavailable.  NET2_DATADISK,_SCRATCHDISK, PanDA queues and perfsonars will remain up