### PR TITLE
Add --regex argument to get-scitokens-mapfile to print output in regex format; also use SCITOKENS instead of SCITOKEN

### DIFF
--- a/bin/get-scitokens-mapfile
+++ b/bin/get-scitokens-mapfile
@@ -50,7 +50,7 @@ def main(argv):
             url = token_issuer.get("URL")
             if url:
                 if args.regex:
-                    url = f'/{re.escape(url)}/'
+                    url = f'/^{re.escape(url)},/'
                 else:
                     url = f'"{url}"'
             unix_user = token_issuer.get("DefaultUnixUser")

--- a/bin/get-scitokens-mapfile
+++ b/bin/get-scitokens-mapfile
@@ -6,6 +6,7 @@ Create a scitokens issuer -> unix user mapfile from topology data
 """
 
 import os
+import re
 import sys
 
 if __name__ == "__main__" and __package__ is None:
@@ -31,6 +32,11 @@ def main(argv):
         help="Bail on invalid scitoken or on no scitokens info. "
         "Otherwise just add a comment to the result.",
     )
+    parser.add_argument(
+        "--regex",
+        action="store_true",
+        help="Use the regex format for issuer lines (HTCondor 9.0+)",
+    )
 
     args = parser.parse_args(argv[1:])
 
@@ -43,12 +49,15 @@ def main(argv):
         for token_issuer in vo_data["Credentials"]["TokenIssuers"]:
             url = token_issuer.get("URL")
             if url:
-                url = f'"{url}"'
+                if args.regex:
+                    url = f'/{re.escape(url)}/'
+                else:
+                    url = f'"{url}"'
             unix_user = token_issuer.get("DefaultUnixUser")
             if url and unix_user:
-                mapfile += f"SCITOKEN {url} {unix_user}\n"
+                mapfile += f"SCITOKENS {url} {unix_user}\n"
             else:
-                mapfile += f"# invalid SCITOKEN: {url or '<NO URL>'} {unix_user or '<NO UNIX USER>'}\n"
+                mapfile += f"# invalid SCITOKENS: {url or '<NO URL>'} {unix_user or '<NO UNIX USER>'}\n"
                 if args.strict:
                     print(mapfile, file=sys.stderr)
                     sys.exit("Invalid scitoken found in strict mode")


### PR DESCRIPTION
Without:
```
# OSG
SCITOKENS "https://scitokens.org/osg-connect" osg
# GLOW
SCITOKENS "https://scitokens.org/chtc" glow
```

With:
```
# OSG
SCITOKENS /https\:\/\/scitokens\.org\/osg\-connect/ osg
# GLOW
SCITOKENS /https\:\/\/scitokens\.org\/chtc/ glow
```