### PR TITLE
Update MWT2.yaml to replace SRMv2 with GrdFTP.

### DIFF
--- a/topology/University of Chicago/MWT2 ATLAS UC/MWT2.yaml
+++ b/topology/University of Chicago/MWT2 ATLAS UC/MWT2.yaml
@@ -621,7 +621,7 @@ Resources:
     ID: 70
     Services:
       GridFtp:
-        Description: GrdFTP endpoint
+        Description: GridFTP endpoint
         Details:
           hidden: false
     VOOwnership:

--- a/topology/University of Chicago/MWT2 ATLAS UC/MWT2.yaml
+++ b/topology/University of Chicago/MWT2 ATLAS UC/MWT2.yaml
@@ -620,8 +620,8 @@ Resources:
     - uct2-dc1.uchicago.edu
     ID: 70
     Services:
-      SRMv2:
-        Description: SRM V2 Storage Element
+      GridFtp:
+        Description: GrdFTP endpoint
         Details:
           hidden: false
     VOOwnership:


### PR DESCRIPTION
CRIC does not recognize SRM and therefore downtime requests made with SRM fail. CRIC does recognize GrdFTP.