### PR TITLE
Schedule Full Vanderbilt ACCRE downtime May 18-19

### DIFF
--- a/topology/Vanderbilt University/Vanderbilt ACCRE/Vanderbilt_downtime.yaml
+++ b/topology/Vanderbilt University/Vanderbilt ACCRE/Vanderbilt_downtime.yaml
@@ -379,3 +379,34 @@
   ResourceName: Vanderbilt_CE6
   Services:
   - CE
+# ----------------------------------------------------------
+- Class: SCHEDULED
+  ID: 856779945
+  Description: Operating system and software updates
+  Severity: Outage
+  StartTime: May 18, 2021 00:01 +0000
+  EndTime: May 19, 2021 23:59 +0000
+  CreatedTime: May 11, 2021 21:01 +0000
+  ResourceName: Vanderbilt_Gridftp
+  Services:
+  - GridFtp
+- Class: SCHEDULED
+  ID: 856779946
+  Description: Operating system and software updates
+  Severity: Outage
+  StartTime: May 18, 2021 00:01 +0000
+  EndTime: May 19, 2021 23:59 +0000
+  CreatedTime: May 11, 2021 21:01 +0000
+  ResourceName: Vanderbilt_CE5
+  Services:
+  - CE
+- Class: SCHEDULED
+  ID: 856779947
+  Description: Operating system and software updates
+  Severity: Outage
+  StartTime: May 18, 2021 00:01 +0000
+  EndTime: May 19, 2021 23:59 +0000
+  CreatedTime: May 11, 2021 21:01 +0000
+  ResourceName: Vanderbilt_CE6
+  Services:
+  - CE


### PR DESCRIPTION
This downtime is to upgrade the operating system of our worker nodes and much of our infrastructure and also update the scheduler software.