### PR TITLE
Accept zero-length downtime

### DIFF
--- a/src/tests/verify_downtimes.py
+++ b/src/tests/verify_downtimes.py
@@ -54,8 +54,8 @@ def validate_downtime_file(dt_fname):
             dt_start = topology.Downtime.parsetime(downtime['StartTime'])
             dt_end   = topology.Downtime.parsetime(downtime['EndTime'])
 
-            if dt_start >= dt_end:
-                add_err("StartTime does not precede EndTime: '%s' -> '%s'" %
+            if dt_start > dt_end:
+                add_err("StartTime is after EndTime: '%s' -> '%s'" %
                         (downtime['StartTime'], downtime['EndTime']))
 
         except ValueError as e:


### PR DESCRIPTION
We don't know if our downstream consumers accept downtime deletions so have the tests accept zero-length downtimes as a way of effectively deleting it.