### PR TITLE
Add downtime for Georgia Tech - quarterly maintenance

### DIFF
--- a/topology/Georgia Institute of Technology/Georgia Tech/Georgia Tech PACE OSG 2_downtime.yaml
+++ b/topology/Georgia Institute of Technology/Georgia Tech/Georgia Tech PACE OSG 2_downtime.yaml
@@ -79,3 +79,50 @@
   Services:
   - net.perfSONAR.Bandwidth
 # ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 862597722
+  Description: Georgia Tech Quarterly Maintenance
+  Severity: Outage
+  StartTime: May 19, 2021 10:00 +0000
+  EndTime: May 22, 2021 04:00 +0000
+  CreatedTime: May 17, 2021 13:56 +0000
+  ResourceName: Georgia_Tech_LIGO_Submit_2
+  Services:
+  - Submit Node
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 862598656
+  Description: Georgia Tech Quarterly Maintenance
+  Severity: Outage
+  StartTime: May 19, 2021 10:00 +0000
+  EndTime: May 22, 2021 04:00 +0000
+  CreatedTime: May 17, 2021 13:57 +0000
+  ResourceName: Georgia_Tech_PACE_CE_2
+  Services:
+  - CE
+  - Squid
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 862599084
+  Description: Georgia Tech Quarterly Maintenance
+  Severity: Outage
+  StartTime: May 19, 2021 10:00 +0000
+  EndTime: May 22, 2021 04:00 +0000
+  CreatedTime: May 17, 2021 13:58 +0000
+  ResourceName: Georgia_Tech_PACE_GridFTP2
+  Services:
+  - GridFtp
+  - XRootD cache server
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 862599447
+  Description: Georgia Tech Quarterly Maintenance
+  Severity: Outage
+  StartTime: May 19, 2021 10:00 +0000
+  EndTime: May 22, 2021 04:00 +0000
+  CreatedTime: May 17, 2021 13:59 +0000
+  ResourceName: Georgia_Tech_PACE_perfSONAR_BW
+  Services:
+  - net.perfSONAR.Bandwidth
+# ---------------------------------------------------------
+

--- a/topology/Georgia Institute of Technology/Georgia Tech/Georgia Tech PACE_downtime.yaml
+++ b/topology/Georgia Institute of Technology/Georgia Tech/Georgia Tech PACE_downtime.yaml
@@ -433,3 +433,38 @@
   - GridFtp
   - XRootD cache server
 # ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 862677708
+  Description: Georgia Tech Quarterly Maintenance
+  Severity: Outage
+  StartTime: May 19, 2021 10:00 +0000
+  EndTime: May 22, 2021 04:00 +0000
+  CreatedTime: May 17, 2021 16:09 +0000
+  ResourceName: Georgia_Tech_LIGO_Submit_1
+  Services:
+  - Submit Node
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 862678091
+  Description: Georgia Tech Quarterly Maintenance
+  Severity: Outage
+  StartTime: May 19, 2021 10:00 +0000
+  EndTime: May 22, 2021 04:00 +0000
+  CreatedTime: May 17, 2021 16:10 +0000
+  ResourceName: Georgia_Tech_PACE_CE_1
+  Services:
+  - CE
+  - Squid
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 862678269
+  Description: Georgia Tech Quarterly Maintenance
+  Severity: Outage
+  StartTime: May 19, 2021 10:00 +0000
+  EndTime: May 22, 2021 04:00 +0000
+  CreatedTime: May 17, 2021 16:10 +0000
+  ResourceName: Georgia_Tech_PACE_GridFTP
+  Services:
+  - GridFtp
+  - XRootD cache server
+# ---------------------------------------------------------


### PR DESCRIPTION
Adding downtime for Georgia Tech due to our quarterly maintenance (May 19 6:00AM (eastern) through May 21 11:59PM (eastern)).  