### PR TITLE
swap Doug Benjamin in for John Hover for BNL USATLAS

### DIFF
--- a/topology/support-centers.yaml
+++ b/topology/support-centers.yaml
@@ -711,8 +711,8 @@ USATLAS:
     - ID: 1e47726bf41f2128059de31cf7bc9c8d5dcadad6
       Name: BNL Atlas Tier 1 support
     Security Contact:
-    - ID: fa0ca5484e97c3caa3a2fb59217caa70e8b3d66d
-      Name: John Hover
+    - ID: b39de31776fc01735eff9678a851c2126a3680be
+      Name: Doug Benjamin
   Description: USAtlas
   ID: 29
   LongName: United States ATLAS Collaboration


### PR DESCRIPTION
https://support.opensciencegrid.org/a/tickets/67235

>>> I noticed references to John Hover. He has left BNL a while ago and those reference should be removed.
>>
>> I see John Hover listed for various support center contacts for SDCC and USATLAS.  Do you want to replace him for all of these?
>
> For the US ATLAS at BNL yes. I will check with colleagues to see if I should be the replacement 
> For the rest.
