### PR TITLE
update BNL B2 site yaml

### DIFF
--- a/topology/Brookhaven National Laboratory/Brookhaven Belle-II Tier1/BNL-Belle-II.yaml
+++ b/topology/Brookhaven National Laboratory/Brookhaven Belle-II Tier1/BNL-Belle-II.yaml
@@ -7,26 +7,20 @@ Resources:
     ContactLists:
       Administrative Contact:
         Primary:
-          ID: a688fe1904cfc91c2c5529eb898a13f9ebfbadbe
-          Name: Xin Zhao
-        Secondary:
-          ID: cd664fe4b3ce5a2b429ddd41c8877f9ca030800b
-          Name: Hironori Ito
+          ID: b9c6c5b9aa527d9d0bfb2f2e712c8a448ddfa61d
+          Name: BNL Belle II Tier 1 support
       Miscellaneous Contact:
         Primary:
-          ID: cd664fe4b3ce5a2b429ddd41c8877f9ca030800b
-          Name: Hironori Ito
+          ID: b9c6c5b9aa527d9d0bfb2f2e712c8a448ddfa61d
+          Name: BNL Belle II Tier 1 support
       Resource Report Contact:
         Primary:
-          ID: a688fe1904cfc91c2c5529eb898a13f9ebfbadbe
-          Name: Xin Zhao
-        Secondary:
-          ID: cd664fe4b3ce5a2b429ddd41c8877f9ca030800b
-          Name: Hironori Ito
+          ID: b9c6c5b9aa527d9d0bfb2f2e712c8a448ddfa61d
+          Name: BNL Belle II Tier 1 support
       Security Contact:
         Primary:
-          ID: cd664fe4b3ce5a2b429ddd41c8877f9ca030800b
-          Name: Hironori Ito
+          ID: b9c6c5b9aa527d9d0bfb2f2e712c8a448ddfa61d
+          Name: BNL Belle II Tier 1 support
     Description: This is the HTCondor-CE for Belle II  at the Belle-II T1 center at
       BNL
     FQDN: bgk01.sdcc.bnl.gov
@@ -53,30 +47,24 @@ Resources:
     ContactLists:
       Administrative Contact:
         Primary:
-          ID: a688fe1904cfc91c2c5529eb898a13f9ebfbadbe
-          Name: Xin Zhao
-        Secondary:
-          ID: cd664fe4b3ce5a2b429ddd41c8877f9ca030800b
-          Name: Hironori Ito
+          ID: b9c6c5b9aa527d9d0bfb2f2e712c8a448ddfa61d
+          Name: BNL Belle II Tier 1 support
       Miscellaneous Contact:
         Primary:
-          ID: cd664fe4b3ce5a2b429ddd41c8877f9ca030800b
-          Name: Hironori Ito
+          ID: b9c6c5b9aa527d9d0bfb2f2e712c8a448ddfa61d
+          Name: BNL Belle II Tier 1 support
       Resource Report Contact:
         Primary:
-          ID: a688fe1904cfc91c2c5529eb898a13f9ebfbadbe
-          Name: Xin Zhao
-        Secondary:
-          ID: cd664fe4b3ce5a2b429ddd41c8877f9ca030800b
-          Name: Hironori Ito
+          ID: b9c6c5b9aa527d9d0bfb2f2e712c8a448ddfa61d
+          Name: BNL Belle II Tier 1 support
       Security Contact:
         Primary:
-          ID: cd664fe4b3ce5a2b429ddd41c8877f9ca030800b
-          Name: Hironori Ito
+          ID: b9c6c5b9aa527d9d0bfb2f2e712c8a448ddfa61d
+          Name: BNL Belle II Tier 1 support
       Submitter Contact:
         Primary:
-          ID: a688fe1904cfc91c2c5529eb898a13f9ebfbadbe
-          Name: Xin Zhao
+          ID: b9c6c5b9aa527d9d0bfb2f2e712c8a448ddfa61d
+          Name: BNL Belle II Tier 1 support
     Description: This is a HTCondor-CE for Belle II  at the Belle-II T1 center at
       BNL
     Disable: false
@@ -104,12 +92,12 @@ Resources:
     ContactLists:
       Administrative Contact:
         Primary:
-          ID: cd664fe4b3ce5a2b429ddd41c8877f9ca030800b
-          Name: Hironori Ito
+          ID: b9c6c5b9aa527d9d0bfb2f2e712c8a448ddfa61d
+          Name: BNL Belle II Tier 1 support
       Security Contact:
         Primary:
-          ID: cd664fe4b3ce5a2b429ddd41c8877f9ca030800b
-          Name: Hironori Ito
+          ID: b9c6c5b9aa527d9d0bfb2f2e712c8a448ddfa61d
+          Name: BNL Belle II Tier 1 support
     Description: BNL Belle II dCache
     FQDN: dcblsrm.sdcc.bnl.gov
     ID: 908


### PR DESCRIPTION
Changed all individual (Hiro & Xin) contact references to newly created BNL B2 site contact list entity. We have done this in order to enable GGUS to ticket/contact all our list members at once instead of relying on individuals to route tickets and issues.