### PR TITLE
Update AGLT2_TEST_downtime.yaml

### DIFF
--- a/topology/University of Michigan/AGLT2/AGLT2_TEST_downtime.yaml
+++ b/topology/University of Michigan/AGLT2/AGLT2_TEST_downtime.yaml
@@ -13,7 +13,7 @@
   Description: Continue recovering from site wide network problems
   Severity: Outage
   StartTime: May 21, 2021 14:00 +0000
-  EndTime: May 21, 2021 22:00 +0000
+  EndTime: May 25, 2021 04:00 +0000
   CreatedTime: May 21, 2021 14:17 +0000
   ResourceName: AGLT2_TEST_CE
   Services:


### PR DESCRIPTION
Extending AGLT2 outage till end of Monday midnight EDT.