### PR TITLE
Add downtime for SLATE_US_NMSU_AGGIE_GRID

### DIFF
--- a/topology/New Mexico State University/New Mexico State AggieGrid/NMSU_AGGIE_GRID_downtime.yaml
+++ b/topology/New Mexico State University/New Mexico State AggieGrid/NMSU_AGGIE_GRID_downtime.yaml
@@ -7,4 +7,14 @@
   CreatedTime: Dec 11, 2020 22:34 +0000
   ResourceName: SLATE_US_NMSU_AGGIE_GRID
   Services:
-  - CE
+    - CE
+- Class: UNSCHEDULED
+  ID: 866360155
+  Description: Administration issue which requires software upgrades/reconfiguration
+  Severity: Outage
+  StartTime: May 18, 2021 00:00 +0000
+  EndTime: Jun 04, 2021 23:59 +0000
+  CreatedTime: May 21, 2021 22:26 +0000
+  ResourceName: SLATE_US_NMSU_AGGIE_GRID
+  Services:
+    - CE


### PR DESCRIPTION
Add downtime for SLATE_US_NMSU_AGGIE_GRID due to administration changes causing a failure with CVMFS squid cache.  Fixing will require a redeployment of the compute VMs which will take some time to coordinate.