### PR TITLE
Move Topology container upload to GHA (SOFTWARE-4652)

### DIFF
--- a/.github/workflows/build-sw-container.yml
+++ b/.github/workflows/build-sw-container.yml
@@ -18,7 +18,7 @@ jobs:
       id: generate-tag-list
       run: |
         docker_repo=${GITHUB_REPOSITORY/opensciencegrid\/docker-/opensciencegrid/}
-        tag_list=$docker_repo:latest,$docker_repo:${GITHUB_REF#v}
+        tag_list=$docker_repo:latest,$docker_repo:${GITHUB_REF##*/v}
         echo "::set-output name=taglist::$tag_list"
 
     - name: Set up Docker Buildx


### PR DESCRIPTION
Change `${GITHUB_REF#v}` to `${GITHUB_REF##*/v}` to get just the version number but not the complete git ref.