### PR TITLE
Clean up oasis managers (SOFTWARE-4279)

### DIFF
--- a/virtual-organizations/ACCRE.yaml
+++ b/virtual-organizations/ACCRE.yaml
@@ -40,12 +40,4 @@ PurposeURL: https://www.vanderbilt.edu/accre/overview/
 SupportURL: https://www.vanderbilt.edu/accre/support/helpdesk/
 ### OASIS (optional) is information about OASIS usage by the VO
 OASIS:
-    UseOASIS: true
-####### Managers (optional) are one or more people with manager access to this VO's OASIS space
-    Managers:
-      - Name: Andrew Malone Melo
-        DNs:  /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=meloam/CN=692113/CN=Andrew Malone Melo
-        ID:  11107327543306be8c340cfa2281444a2d428318
-      - Name: Eric Appelt
-        DNs: /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=eappelt/CN=693395/CN=Eric Andrew Appelt
-        ID: 22ae3f93d335f46cea9be2f7c9e0551f31df44bf
+  UseOASIS: true

--- a/virtual-organizations/Argoneut.yaml
+++ b/virtual-organizations/Argoneut.yaml
@@ -24,15 +24,9 @@ ID: 65
 LongName: Fermilab/Argoneut
 MembershipServicesURL: https://voms.fnal.gov:8443/voms/fermilab
 OASIS:
-  Managers:
-    - Name: Gabriele Garzoglio
-      DNs:
-      - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Gabriele Garzoglio
-        203
-      ID: 81b1a18848c9e41c87ee7104aac70b5fcf0c2176
   OASISRepoURLs:
-  - http://oasiscfs.fnal.gov:8000/cvmfs/argoneut.opensciencegrid.org/
-  UseOASIS: true
+    - http://oasiscfs.fnal.gov:8000/cvmfs/argoneut.opensciencegrid.org/
+  UseOASIS: false
 ParentVO:
   ID: 9
   Name: Fermilab

--- a/virtual-organizations/CMS.yaml
+++ b/virtual-organizations/CMS.yaml
@@ -34,21 +34,8 @@ ID: 3
 LongName: Compact Muon Solenoid
 MembershipServicesURL: https://lcg-voms.cern.ch:8443/voms/cms
 OASIS:
-  Managers:
-    - Name: David Alexander Mason
-      DNs: /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=dmason/CN=664436/CN=David Alexander
-        Mason
-      ID: fbc689042bf0b68df85561edb1a1fb33e1c799a3
-    - Name: HYUNWOO KIM
-      DNs:
-      - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=HYUNWOO KIM 882
-      - /DC=gov/DC=fnal/O=Fermilab/OU=People/CN=Hyun woo Kim/CN=UID:hyunwoo
-      - /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=HYUNWOO KIM 882
-      - /DC=org/DC=cilogon/C=US/O=Fermi National Accelerator Laboratory/OU=People/CN=Hyun
-        Kim/CN=UID:hyunwoo
-      ID: e2799203e652f11e24de11fcf85b7e8d2b1783f7
   OASISRepoURLs:
-  - http://oasiscfs.fnal.gov:8000/cvmfs/cms-lpc.opensciencegrid.org
+    - http://oasiscfs.fnal.gov:8000/cvmfs/cms-lpc.opensciencegrid.org
   UseOASIS: true
 PrimaryURL: http://www.uscms.org
 PurposeURL: http://www.uscms.org/SoftwareComputing/Grid/index.html

--- a/virtual-organizations/CMS.yaml
+++ b/virtual-organizations/CMS.yaml
@@ -36,7 +36,7 @@ MembershipServicesURL: https://lcg-voms.cern.ch:8443/voms/cms
 OASIS:
   OASISRepoURLs:
     - http://oasiscfs.fnal.gov:8000/cvmfs/cms-lpc.opensciencegrid.org
-  UseOASIS: true
+  UseOASIS: false
 PrimaryURL: http://www.uscms.org
 PurposeURL: http://www.uscms.org/SoftwareComputing/Grid/index.html
 ReportingGroups:

--- a/virtual-organizations/COUPP.yaml
+++ b/virtual-organizations/COUPP.yaml
@@ -28,14 +28,9 @@ OASIS:
       DNs: /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Christophe
         Bonnaud 3139
       ID: 8cc594d4724bec67b459ff043a26b389a5286382
-    - Name: Gabriele Garzoglio
-      DNs:
-      - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Gabriele Garzoglio
-        203
-      ID: 81b1a18848c9e41c87ee7104aac70b5fcf0c2176
   OASISRepoURLs:
-  - http://oasiscfs.fnal.gov:8000/cvmfs/coupp.opensciencegrid.org/
-  UseOASIS: true
+    - http://oasiscfs.fnal.gov:8000/cvmfs/coupp.opensciencegrid.org/
+  UseOASIS: false
 ParentVO:
   ID: 9
   Name: Fermilab

--- a/virtual-organizations/CSIU.yaml
+++ b/virtual-organizations/CSIU.yaml
@@ -41,13 +41,6 @@ FieldsOfScience:
 ID: 72
 LongName: Computational Sciences at Indiana University
 OASIS:
-  Managers:
-    - Name: Scott Teige
-      DNs:
-      - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Scott Teige 652
-      - /DC=org/DC=cilogon/C=US/O=Indiana University/CN=Scott Teige A7052
-      - /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Scott Teige 1
-      ID: 238d6d2794a7aa5391ae3d13297561a015026bb2
   UseOASIS: true
 PrimaryURL: https://twiki.grid.iu.edu/bin/view/VirtualOrganizations/CSatIU
 PurposeURL: https://twiki.grid.iu.edu/bin/view/VirtualOrganizations/CSatIU

--- a/virtual-organizations/EMPHATIC.yaml
+++ b/virtual-organizations/EMPHATIC.yaml
@@ -23,9 +23,6 @@ LongName: Fermilab/EMPHATIC
 MembershipServicesURL: https://voms.fnal.gov:8443/voms/fermilab
 OASIS:
   Managers:
-    - Name: Jonathan Paley
-      DNs: /DC=org/DC=cilogon/C=US/O=Fermi National Accelerator Laboratory/OU=People/CN=Jonathan Paley/CN=UID:jpaley
-      ID: c2b26b70bda13a42cd1edd871a4549cec74512b6
     - Name: Brian Bockelman
       DNs: /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=bbockelm/CN=659869/CN=Brian
         Paul Bockelman
@@ -41,8 +38,8 @@ OASIS:
         1724
       ID: 5e96f41b876c2b42c727d1ad476cd025e5584b5b
   OASISRepoURLs:
-  - http://oasiscfs.fnal.gov:8000/cvmfs/emphatic.opensciencegrid.org
-  UseOASIS: true
+    - http://oasiscfs.fnal.gov:8000/cvmfs/emphatic.opensciencegrid.org
+  UseOASIS: false
 ParentVO:
   ID: 9
   Name: Fermilab

--- a/virtual-organizations/ENMR.yaml
+++ b/virtual-organizations/ENMR.yaml
@@ -48,10 +48,6 @@ ID: 73
 LongName: A worldwide e-Infrastructure for NMR and structural biology
 MembershipServicesURL: https://voms2.cnaf.infn.it:8443/voms/enmr.eu/
 OASIS:
-  Managers:
-    - Name: Marco Verlato
-      DNs: /DC=org/DC=terena/DC=tcs/C=IT/O=Istituto Nazionale di Fisica Nucleare/CN=Marco Verlato verlato@infn.it
-      ID: 0966df4f0f20720c3fbc4bf5f9fbd434148a8506
   UseOASIS: true
 PrimaryURL: http://www.wenmr.eu
 PurposeURL: http://www.wenmr.eu

--- a/virtual-organizations/Fermilab.yaml
+++ b/virtual-organizations/Fermilab.yaml
@@ -44,28 +44,14 @@ ID: 9
 LongName: Fermi National Accelerator Laboratory
 MembershipServicesURL: https://voms2.fnal.gov:8443/voms/fermilab
 OASIS:
-  Managers:
-    - Name: Dave Dykstra
-      DNs:
-      - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Dave Dykstra 508
-      - /DC=org/DC=cilogon/C=US/O=Fermi National Accelerator Laboratory/OU=People/CN=Dave
-        Dykstra/CN=UID:dwd
-      - /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Dave Dykstra 508
-      ID: 85fe79f7c8a447834460b6852f46d3eef32fb714
-    - Name: Lynn Garren
-      DNs:
-      - /DC=gov/DC=fnal/O=Fermilab/OU=People/CN=Lynn A. Garren/CN=UID:garren
-      - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Lynn Garren 217
-      - /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Lynn Garren 217
-      ID: 848367d300cbdf6ae1c61ef86594ce7b642f2984
   OASISRepoURLs:
-  - http://oasiscfs.fnal.gov:8000/cvmfs/fermilab.opensciencegrid.org
-  - http://oasiscfs.fnal.gov:8000/cvmfs/larsoft.opensciencegrid.org
-  - http://rcds01.fnal.gov:8000/cvmfs/fifeuser1.opensciencegrid.org
-  - http://rcds01.fnal.gov:8000/cvmfs/fifeuser2.opensciencegrid.org
-  - http://rcds02.fnal.gov:8000/cvmfs/fifeuser3.opensciencegrid.org
-  - http://rcds02.fnal.gov:8000/cvmfs/fifeuser4.opensciencegrid.org
-  UseOASIS: true
+    - http://oasiscfs.fnal.gov:8000/cvmfs/fermilab.opensciencegrid.org
+    - http://oasiscfs.fnal.gov:8000/cvmfs/larsoft.opensciencegrid.org
+    - http://rcds01.fnal.gov:8000/cvmfs/fifeuser1.opensciencegrid.org
+    - http://rcds01.fnal.gov:8000/cvmfs/fifeuser2.opensciencegrid.org
+    - http://rcds02.fnal.gov:8000/cvmfs/fifeuser3.opensciencegrid.org
+    - http://rcds02.fnal.gov:8000/cvmfs/fifeuser4.opensciencegrid.org
+  UseOASIS: false
 PrimaryURL: http://fermigrid.fnal.gov/
 PurposeURL: http://www.fnal.gov/
 ReportingGroups:

--- a/virtual-organizations/GLOW.yaml
+++ b/virtual-organizations/GLOW.yaml
@@ -18,13 +18,9 @@ Contacts:
   Registration Authority:
   - ID: 46a55ac4815b2b8c00ff283549f413113b45d628
     Name: Aaron Moate
-  - ID: 210d07bf782db9938049eaf11820ec908fdda3b5
-    Name: Daniel Bradley
   Security Contact:
   - ID: 46a55ac4815b2b8c00ff283549f413113b45d628
     Name: Aaron Moate
-  - ID: 210d07bf782db9938049eaf11820ec908fdda3b5
-    Name: Daniel Bradley
   VO Manager:
   - ID: 48e1c2f26dc3479a6cf9b2de7c79d654ac27b1d1
     Name: Miron Livny

--- a/virtual-organizations/ILC.yaml
+++ b/virtual-organizations/ILC.yaml
@@ -25,16 +25,6 @@ OASIS:
     - Name: Andre Philippe Sailer
       DNs: /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=sailer/CN=683529/CN=Andre Sailer
       ID: ee4849a97f735597bed71dff0b7866d90065a5f3
-    - Name: Dorian Kcira
-      DNs: /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=dkcira/CN=655958/CN=Dorian
-        Kcira
-      ID: 1fd41017c89ee21ca274634207ddb71cf35518af
-    - Name: Scott Teige
-      DNs:
-      - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Scott Teige 652
-      - /DC=org/DC=cilogon/C=US/O=Indiana University/CN=Scott Teige A7052
-      - /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Scott Teige 1
-      ID: 238d6d2794a7aa5391ae3d13297561a015026bb2
   OASISRepoURLs:
   - http://grid-cvmfs-null.desy.de:8000/cvmfs/ilc.desy.de
   UseOASIS: true

--- a/virtual-organizations/LArSoft.yaml
+++ b/virtual-organizations/LArSoft.yaml
@@ -25,13 +25,9 @@ ID: 132
 LongName: Liquid Argon Software Collaboration
 MembershipServicesURL: https://voms2.fnal.gov:8443/voms/fermilab
 OASIS:
-  Managers:
-    - Name: Vito Di Benedetto
-      DNs: /DC=org/DC=cilogon/C=US/O=Fermi National Accelerator Laboratory/OU=People/CN=Vito Di Benedetto/CN=UID:vito
-      ID: 5c9580f5962b49aa0ac84eef4022327566b946aa
   OASISRepoURLs:
-  - http://oasiscfs.fnal.gov:8000/cvmfs/larsoft-ib.opensciencegrid.org
-  UseOASIS: True
+    - http://oasiscfs.fnal.gov:8000/cvmfs/larsoft-ib.opensciencegrid.org
+  UseOASIS: false
 ParentVO:
   ID: 9
   Name: Fermilab

--- a/virtual-organizations/LIGO.yaml
+++ b/virtual-organizations/LIGO.yaml
@@ -57,16 +57,6 @@ OASIS:
       DNs: /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=James Alexander
         Clark 4038
       ID: 504894b714071a10a647aaaa4e1fe7ee3186430b
-    - Name: Peter Couvares
-      DNs: /DC=org/DC=cilogon/C=US/O=LIGO/CN=Peter Couvares peter.couvares@ligo.org
-      ID: 547c65a6ed5e9e755c023418a47b8b92e88f0523
-    - Name: Sharon Brunett
-      DNs: /DC=org/DC=cilogon/C=US/O=California Institute of Technology/CN=Sharon
-        Brunett A20751
-      ID: e817cc79849447cc8c98f376e2d0052dda7c675b
-    - Name: Duncan MacLeod
-      DNs: /DC=org/DC=cilogon/C=US/O=LIGO/CN=Duncan Macleod duncan.macleod@ligo.org
-      ID: 1e153a63463094d82c7b2786bd2f57f996974984
   OASISRepoURLs:
   - http://hcc-cvmfs-repo.unl.edu:8000/cvmfs/ligo.osgstorage.org
   - http://hcc-cvmfs-repo.unl.edu:8000/cvmfs/gwosc.osgstorage.org

--- a/virtual-organizations/LZ.yaml
+++ b/virtual-organizations/LZ.yaml
@@ -46,17 +46,9 @@ ID: 117
 LongName: LUX-ZEPLIN
 MembershipServicesURL: https://voms.hep.wisc.edu:8443/voms/lz
 OASIS:
-  Managers:
-    - Name: Daniel Bradley
-      DNs: /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=dbradley/CN=614788/CN=Daniel
-        Charles Bradley
-      ID: 210d07bf782db9938049eaf11820ec908fdda3b5
-    - Name: Sridhara Dasu
-      DNs: /DC=org/DC=doegrids/OU=People/CN=Sridhara Rao Dasu 610586
-      ID: 529b7136c6572fde3a9b138ba80acc94136df454
   OASISRepoURLs:
-  - http://cvmfslz.hep.wisc.edu:8000/cvmfs/lz.opensciencegrid.org
-  UseOASIS: true
+    - http://cvmfslz.hep.wisc.edu:8000/cvmfs/lz.opensciencegrid.org
+  UseOASIS: false
 PrimaryURL: http://lz.lbl.gov/
 PurposeURL: http://www.hep.wisc.edu/lz
 ReportingGroups:

--- a/virtual-organizations/SPT.yaml
+++ b/virtual-organizations/SPT.yaml
@@ -46,14 +46,9 @@ ID: 124
 LongName: South Pole Telescope
 MembershipServicesURL: https://spt-mgt.grid.uchicago.edu:8443/voms/SPT
 OASIS:
-  Managers:
-    - Name: Nathan Whitehorn
-      DNs: /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Nathan Whitehorn
-        3937
-      ID: d7ebadcbca04bf37b33f6183bea3245431eedf38
   OASISRepoURLs:
-  - http://osg-cvmfs.grid.uchicago.edu:8000/cvmfs/spt.opensciencegrid.org
-  UseOASIS: true
+    - http://osg-cvmfs.grid.uchicago.edu:8000/cvmfs/spt.opensciencegrid.org
+  UseOASIS: false
 PrimaryURL: http://pole.uchicago.edu
 ReportingGroups:
 - SPT

--- a/virtual-organizations/XENON.yaml
+++ b/virtual-organizations/XENON.yaml
@@ -39,13 +39,9 @@ ID: 104
 LongName: XENON Collaboration
 MembershipServicesURL: https://voms.grid.sara.nl:8443/voms/xenon.biggrid.nl
 OASIS:
-  Managers:
-    - Name: Luca Scotto Lavina
-      DNs: /O=GRID-FR/C=FR/O=CNRS/OU=LPNHE/CN=Luca Scotto Lavina
-      ID: 34d0a2a03bbffad439ae7c732042d7ad6a609da8
   OASISRepoURLs:
-  - http://osg-cvmfs.grid.uchicago.edu:8000/cvmfs/xenon.opensciencegrid.org
-  UseOASIS: true
+    - http://osg-cvmfs.grid.uchicago.edu:8000/cvmfs/xenon.opensciencegrid.org
+  UseOASIS: false
 PrimaryURL: http://xenon.astro.columbia.edu
 PurposeURL: http://xenon.astro.columbia.edu
 ReportingGroups:

--- a/virtual-organizations/auger.yaml
+++ b/virtual-organizations/auger.yaml
@@ -22,7 +22,7 @@ MembershipServicesURL: https://voms1.egee.cesnet.cz:8443/voms/auger
 OASIS:
   OASISRepoURLs:
     - http://cvmfs-stratum0.gridpp.rl.ac.uk:8000/cvmfs/auger.egi.eu
-  UseOASIS: true
+  UseOASIS: false
 PrimaryURL: http://www.auger.org
 PurposeURL: http://operations-portal.egi.eu/vo/view/voname/auger
 ReportingGroups:

--- a/virtual-organizations/auger.yaml
+++ b/virtual-organizations/auger.yaml
@@ -20,13 +20,8 @@ ID: 102
 LongName: Pierre Auger Observatory
 MembershipServicesURL: https://voms1.egee.cesnet.cz:8443/voms/auger
 OASIS:
-  Managers:
-    - Name: Jiri Chudoba
-      DNs: /DC=cz/DC=cesnet-ca/O=Institute of Physics of the Academy of Sciences of
-        the CR/CN=Jiri Chudoba
-      ID: 3e40fb9b1d433ca8af3aff19a62d68d8809c3d06
   OASISRepoURLs:
-  - http://cvmfs-stratum0.gridpp.rl.ac.uk:8000/cvmfs/auger.egi.eu
+    - http://cvmfs-stratum0.gridpp.rl.ac.uk:8000/cvmfs/auger.egi.eu
   UseOASIS: true
 PrimaryURL: http://www.auger.org
 PurposeURL: http://operations-portal.egi.eu/vo/view/voname/auger

--- a/virtual-organizations/icarus.yaml
+++ b/virtual-organizations/icarus.yaml
@@ -18,19 +18,10 @@ ID: 127
 LongName: Imaging Cosmic And Rare Underground Signals
 MembershipServicesURL: https://voms2.fnal.gov:8443/voms/fermilab
 OASIS:
-  Managers:
-    - Name: HYUNWOO KIM
-      DNs:
-      - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=HYUNWOO KIM 882
-      - /DC=gov/DC=fnal/O=Fermilab/OU=People/CN=Hyun woo Kim/CN=UID:hyunwoo
-      - /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=HYUNWOO KIM 882
-      - /DC=org/DC=cilogon/C=US/O=Fermi National Accelerator Laboratory/OU=People/CN=Hyun
-        Kim/CN=UID:hyunwoo
-      ID: e2799203e652f11e24de11fcf85b7e8d2b1783f7
   OASISRepoURLs:
-  - http://oasiscfs.fnal.gov:8000/cvmfs/icarus.opensciencegrid.org
-  - http://hcc-cvmfs-repo.unl.edu:8000/cvmfs/icarus.osgstorage.org
-  UseOASIS: true
+    - http://oasiscfs.fnal.gov:8000/cvmfs/icarus.opensciencegrid.org
+    - http://hcc-cvmfs-repo.unl.edu:8000/cvmfs/icarus.osgstorage.org
+  UseOASIS: false
 ParentVO:
   ID: 9
   Name: Fermilab

--- a/virtual-organizations/nanoHUB.yaml
+++ b/virtual-organizations/nanoHUB.yaml
@@ -26,12 +26,6 @@ ID: 26
 LongName: nanoHUB Network for Computational Nanotechnology (NCN)
 OASIS:
   Managers:
-    - Name: Scott Teige
-      DNs:
-      - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Scott Teige 652
-      - /DC=org/DC=cilogon/C=US/O=Indiana University/CN=Scott Teige A7052
-      - /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Scott Teige 1
-      ID: 238d6d2794a7aa5391ae3d13297561a015026bb2
     - Name: Steven Clark
       DNs:
       - /CN=Steven M Clark/OU=Purdue TeraGrid/O=Purdue University/ST=Indiana/C=US

--- a/virtual-organizations/next.yaml
+++ b/virtual-organizations/next.yaml
@@ -18,14 +18,9 @@ ID: 131
 LongName: Neutrino Experiment with a Xenon TPC
 MembershipServicesURL: https://voms2.fnal.gov:8443/voms/fermilab
 OASIS:
-  Managers:
-    - Name: Michael Diesburg
-      DNs: /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Michael Diesburg
-        47
-      ID: ffc9ff0f27ebd113597fa3404c4b2de4a1e5d845
   OASISRepoURLs:
-  - http://oasiscfs.fnal.gov:8000/cvmfs/next.opensciencegrid.org
-  UseOASIS: true
+    - http://oasiscfs.fnal.gov:8000/cvmfs/next.opensciencegrid.org
+  UseOASIS: false
 ParentVO:
   ID: 9
   Name: Fermilab


### PR DESCRIPTION
@DrDaveD cleaning up OASIS managers that have not registered in COManage after giving them fair warning and a ~2 week grace period (apart from some managers that we did not contact). I followed the instructions in https://opensciencegrid.atlassian.net/browse/OPS-35 and checked the contents of the VO dirs on `oasis-login` and marked `UseOASIS: false` for VOs without managers + empty dirs.