### PR TITLE
Break out cilogon ldap stuff into separate module (SOFTWARE-4528)

### DIFF
--- a/src/webapp/cilogon_ldap.py
+++ b/src/webapp/cilogon_ldap.py
@@ -1,0 +1,44 @@
+import ldap3
+
+
+def get_contact_cilogon_id_map(global_data):
+    """ return contacts dict, limited to users with a CILogonID """
+    contacts = global_data.get_contacts_data().users_by_id;
+    return { k: v for k, v in contacts.items() if v.cilogon_id is not None }
+
+
+# cilogon ldap query constants
+_ldap_url = "ldaps://ldap.cilogon.org"
+_username = "uid=readonly_user,ou=system,o=OSG,o=CO,dc=cilogon,dc=org"
+_basedn   = "o=OSG,o=CO,dc=cilogon,dc=org"
+
+
+def get_cilogon_ldap_id_map(ldappass):
+    """ return dict of cilogon ldap data for each CILogonID, with the
+        structure: {CILogonID: { "dn": dn, "data": data }, ...} """
+    server = ldap3.Server(_ldap_url)
+    conn = ldap3.Connection(server, _username, ldappass)
+    if not conn.bind():
+        return None  # connection failure
+    conn.search(_basedn, '(voPersonID=*)', attributes=['*'])
+    result_data = [ (e.entry_dn, e.entry_attributes_as_dict)
+                    for e in conn.entries ]
+    conn.unbind()
+    return {
+        voPersonID: { "dn": dn, "data": data }
+        for dn, data in result_data
+        if "voPersonID" in data
+        for voPersonID  in data["voPersonID"]
+    }
+
+
+def cilogon_id_map_to_ssh_keys(m):
+    """ convert id map (as returned by get_cilogon_ldap_id_map) to a dict with
+        structure: {CILogonID: [sshPublicKey, ...], ...} for each id that has
+        ssh public keys defined """
+    return {
+        k: v['data']['sshPublicKey']
+        for k, v in m.items()
+        if 'sshPublicKey' in v['data']
+    }
+

--- a/src/webapp/common.py
+++ b/src/webapp/common.py
@@ -145,6 +145,19 @@ def expand_attr_list(data: Dict, namekey: str, ordering: Union[List, None]=None,
     return newdata
 
 
+def safe_dict_get(item, *keys, default=None):
+    """ traverse dict hierarchy without producing KeyErrors:
+        safe_dict_get(item, key1, key2, ..., default=default)
+        -> item[key1][key2][...] if defined and not None, else default
+    """
+    for key in keys:
+        if isinstance(item, dict):
+            item = item.get(key)
+        else:
+            return default
+    return default if item is None else item
+
+
 def order_dict(value: Dict, ordering: List, ignore_missing=False) -> OrderedDict:
     """
     Convert a dict to an OrderedDict with key order provided by ``ordering``.

--- a/src/webapp/oasis_managers.py
+++ b/src/webapp/oasis_managers.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3
 
-import ldap3
+
+from webapp.common import safe_dict_get
+from webapp.cilogon_ldap import get_cilogon_ldap_id_map
+from webapp.cilogon_ldap import cilogon_id_map_to_ssh_keys
+from webapp.cilogon_ldap import get_contact_cilogon_id_map
 
 
 def get_oasis_manager_endpoint_info(global_data, vo, ldappass):
@@ -56,12 +60,6 @@ def get_managers_info(managers, contact_cilogon_ids, ssh_keys_map):
     return info
 
 
-def get_contact_cilogon_id_map(global_data):
-    """ return contacts dict, limited to users with a CILogonID """
-    contacts = global_data.get_contacts_data().users_by_id;
-    return { k: v for k, v in contacts.items() if v.cilogon_id is not None }
-
-
 def get_vo_oasis_managers(global_data, vo):
     """return OASIS Managers list for given vo, if any, else an empty list"""
     vos_data = global_data.get_vos_data()
@@ -81,52 +79,4 @@ def _extract_vo_oasis_managers(vos, vo):
         return []
     return managers
 
-
-def safe_dict_get(item, *keys, default=None):
-    """ traverse dict hierarchy without producing KeyErrors:
-        safe_dict_get(item, key1, key2, ..., default=default)
-        -> item[key1][key2][...] if defined and not None, else default
-    """
-    for key in keys:
-        if isinstance(item, dict):
-            item = item.get(key)
-        else:
-            return default
-    return default if item is None else item
-
-
-# cilogon ldap query constants
-_ldap_url = "ldaps://ldap.cilogon.org"
-_username = "uid=readonly_user,ou=system,o=OSG,o=CO,dc=cilogon,dc=org"
-_basedn   = "o=OSG,o=CO,dc=cilogon,dc=org"
-
-
-def get_cilogon_ldap_id_map(ldappass):
-    """ return dict of cilogon ldap data for each CILogonID, with the
-        structure: {CILogonID: { "dn": dn, "data": data }, ...} """
-    server = ldap3.Server(_ldap_url)
-    conn = ldap3.Connection(server, _username, ldappass)
-    if not conn.bind():
-        return None  # connection failure
-    conn.search(_basedn, '(voPersonID=*)', attributes=['*'])
-    result_data = [ (e.entry_dn, e.entry_attributes_as_dict)
-                    for e in conn.entries ]
-    conn.unbind()
-    return {
-        voPersonID: { "dn": dn, "data": data }
-        for dn, data in result_data
-        if "voPersonID" in data
-        for voPersonID  in data["voPersonID"]
-    }
-
-
-def cilogon_id_map_to_ssh_keys(m):
-    """ convert id map (as returned by get_cilogon_ldap_id_map) to a dict with
-        structure: {CILogonID: [sshPublicKey, ...], ...} for each id that has
-        ssh public keys defined """
-    return {
-        k: v['data']['sshPublicKey']
-        for k, v in m.items()
-        if 'sshPublicKey' in v['data']
-    }
 


### PR DESCRIPTION
inspired by SOFTWARE-4528, which uses cilogon info for purposes
unrelated to oasis managers

Also, move safe_dict_get into common.  (Currently it's only used in
oasis_managers, but it is a generic helper function with perhaps
broader applicability.)