### PR TITLE
Update UMN-CMS.yaml

### DIFF
--- a/topology/University of Minnesota/School of Physics and Astronomy/UMN-CMS.yaml
+++ b/topology/University of Minnesota/School of Physics and Astronomy/UMN-CMS.yaml
@@ -133,7 +133,7 @@ Resources:
           ID: 4385b697e55b95ed097380e05d7b5157d370e469
           Name: Jeremiah Mans
     Description: University of Minnesota CMS Squid Server
-    FQDN: cache01.spa.umn.edu
+    FQDN: cse-app-squid-01.cse.umn.edu
     ID: 1044
     Services:
       Squid:
@@ -160,7 +160,7 @@ Resources:
           ID: 4385b697e55b95ed097380e05d7b5157d370e469
           Name: Jeremiah Mans
     Description: University of Minnesota CMS Squid Server
-    FQDN: cache02.spa.umn.edu
+    FQDN: cse-app-squid-02.cse.umn.edu
     ID: 1045
     Services:
       Squid:


### PR DESCRIPTION
Retiring cache01 cache02.spa.umn.edu and replacing with new servers cse-app-squid-01.cse.umn.edu and cse-app-squid-02.cse.umn.edu