### PR TITLE
create cached object for cilogon ldap data (SOFTWARE-4528)

### DIFF
--- a/src/webapp/cilogon_ldap.py
+++ b/src/webapp/cilogon_ldap.py
@@ -42,3 +42,25 @@ def cilogon_id_map_to_ssh_keys(m):
         if 'sshPublicKey' in v['data']
     }
 
+
+def _entry2cinfo(entry):
+    ci = {'DNs': [entry['dn']]}
+    emails = entry['data'].get('mail')
+    if emails:
+        ci['PrimaryEmail'] = emails[0].lower()
+        if len(emails) >= 2:
+            ci['SecondaryEmail'] = emails[1].lower()
+    else:
+        ci['PrimaryEmail'] = None
+    return ci
+
+
+def cilogon_id_map_to_yaml_data(m):
+    return {
+        id_: {'CILogonID'          : id_,
+              'FullName'           : entry['data']['cn'],
+              'ContactInformation' : _entry2cinfo(entry)}
+        for id_, entry in m.items()
+    }
+
+

--- a/src/webapp/cilogon_ldap.py
+++ b/src/webapp/cilogon_ldap.py
@@ -65,3 +65,10 @@ def cilogon_id_map_to_yaml_data(m):
     }
 
 
+def merge_yaml_data(yaml_data_main, yaml_data_secondary):
+    yd = dict(yaml_data_main)
+    for id_, contact in yaml_data_secondary.items():
+        if id_ not in yd:
+            yd[id_] = contact
+    return yd
+

--- a/src/webapp/cilogon_ldap.py
+++ b/src/webapp/cilogon_ldap.py
@@ -51,7 +51,7 @@ def _entry2cinfo(entry):
         if len(emails) >= 2:
             ci['SecondaryEmail'] = emails[1].lower()
     else:
-        ci['PrimaryEmail'] = None
+        return None
     return ci
 
 
@@ -59,8 +59,9 @@ def cilogon_id_map_to_yaml_data(m):
     return {
         id_: {'CILogonID'          : id_,
               'FullName'           : entry['data']['cn'],
-              'ContactInformation' : _entry2cinfo(entry)}
+              'ContactInformation' : cinfo}
         for id_, entry in m.items()
+        for cinfo in [_entry2cinfo(entry)] if cinfo
     }
 
 

--- a/src/webapp/cilogon_ldap.py
+++ b/src/webapp/cilogon_ldap.py
@@ -61,7 +61,7 @@ def cilogon_id_map_to_yaml_data(m):
         cinfo = _entry2cinfo(entry)
         if cinfo:
             data[id_] = {'CILogonID'          : id_,
-                         'FullName'           : entry['data']['cn'],
+                         'FullName'           : entry['data']['cn'][0],
                          'ContactInformation' : cinfo}
     return data
 

--- a/src/webapp/cilogon_ldap.py
+++ b/src/webapp/cilogon_ldap.py
@@ -56,13 +56,14 @@ def _entry2cinfo(entry):
 
 
 def cilogon_id_map_to_yaml_data(m):
-    return {
-        id_: {'CILogonID'          : id_,
-              'FullName'           : entry['data']['cn'],
-              'ContactInformation' : cinfo}
-        for id_, entry in m.items()
-        for cinfo in [_entry2cinfo(entry)] if cinfo
-    }
+    data = {}
+    for id_, entry in m.items()
+        cinfo = _entry2cinfo(entry)
+        if cinfo:
+            data[id_] = {'CILogonID'          : id_,
+                         'FullName'           : entry['data']['cn'],
+                         'ContactInformation' : cinfo}
+    return data
 
 
 def merge_yaml_data(yaml_data_main, yaml_data_secondary):

--- a/src/webapp/cilogon_ldap.py
+++ b/src/webapp/cilogon_ldap.py
@@ -44,7 +44,7 @@ def cilogon_id_map_to_ssh_keys(m):
 
 
 def _entry2cinfo(entry):
-    ci = {'DNs': [entry['dn']]}
+    ci = {}
     emails = entry['data'].get('mail')
     if emails:
         ci['PrimaryEmail'] = emails[0].lower()

--- a/src/webapp/cilogon_ldap.py
+++ b/src/webapp/cilogon_ldap.py
@@ -8,16 +8,16 @@ def get_contact_cilogon_id_map(global_data):
 
 
 # cilogon ldap query constants
-_ldap_url = "ldaps://ldap.cilogon.org"
-_username = "uid=readonly_user,ou=system,o=OSG,o=CO,dc=cilogon,dc=org"
+#_ldap_url = "ldaps://ldap.cilogon.org"
+#_username = "uid=readonly_user,ou=system,o=OSG,o=CO,dc=cilogon,dc=org"
 _basedn   = "o=OSG,o=CO,dc=cilogon,dc=org"
 
 
-def get_cilogon_ldap_id_map(ldappass):
+def get_cilogon_ldap_id_map(ldap_url, username, ldappass):
     """ return dict of cilogon ldap data for each CILogonID, with the
         structure: {CILogonID: { "dn": dn, "data": data }, ...} """
-    server = ldap3.Server(_ldap_url)
-    conn = ldap3.Connection(server, _username, ldappass)
+    server = ldap3.Server(ldap_url)
+    conn = ldap3.Connection(server, username, ldappass)
     if not conn.bind():
         return None  # connection failure
     conn.search(_basedn, '(voPersonID=*)', attributes=['*'])

--- a/src/webapp/cilogon_ldap.py
+++ b/src/webapp/cilogon_ldap.py
@@ -57,7 +57,7 @@ def _entry2cinfo(entry):
 
 def cilogon_id_map_to_yaml_data(m):
     data = {}
-    for id_, entry in m.items()
+    for id_, entry in m.items():
         cinfo = _entry2cinfo(entry)
         if cinfo:
             data[id_] = {'CILogonID'          : id_,

--- a/src/webapp/models.py
+++ b/src/webapp/models.py
@@ -163,7 +163,7 @@ class GlobalData:
             return contacts_reader.get_contacts_data(None)
         elif self.comanage_data.should_update():
             try:
-                idmap = cilogon_ldap.get_cilogon_ldap_id_map(self)
+                idmap = self.get_cilogon_ldap_id_map()
                 data = cilogon_ldap.cilogon_id_map_to_yaml_data(idmap)
                 self.comanage_data.update(ContactsData(data))
             except Exception:

--- a/src/webapp/models.py
+++ b/src/webapp/models.py
@@ -154,7 +154,8 @@ class GlobalData:
         if self.comanage_data.should_update():
             try:
                 idmap = cilogon_ldap.get_cilogon_ldap_id_map()
-                self.comanage_data.update(idmap)
+                data = cilogon_ldap.cilogon_id_map_to_yaml_data(idmap)
+                self.comanage_data.update(ContactsData(data))
             except Exception:
                 if self.strict:
                     raise

--- a/src/webapp/models.py
+++ b/src/webapp/models.py
@@ -158,8 +158,10 @@ class GlobalData:
         """
         Get the contact information from comanage / cilogon ldap
         """
-        if not self.config.get("CILOGON_LDAP_URL", None):
-            log.debug("CILOGON_LDAP_URL not specified; getting empty contacts")
+        if not (self.cilogon_ldap_url and self.cilogon_ldap_user and
+                self.cilogon_ldap_passfile):
+            log.debug("CILOGON_LDAP_{URL|USER|PASSFILE} not specified; "
+                      "getting empty contacts")
             return contacts_reader.get_contacts_data(None)
         elif self.comanage_data.should_update():
             try:

--- a/src/webapp/models.py
+++ b/src/webapp/models.py
@@ -126,7 +126,7 @@ class GlobalData:
             return False
         return True
 
-    def get_contacts_data(self) -> ContactsData:
+    def get_contact_db_data(self) -> ContactsData:
         """
         Get the contact information from a private git repo
         """
@@ -165,14 +165,14 @@ class GlobalData:
 
         return self.comanage_data.data
 
-    def get_merged_contacts_data(self) -> ContactsData:
+    def get_contacts_data(self) -> ContactsData:
         """
         Get the contact information from a private git repo
         """
         if self.merged_contacts_data.should_update():
             try:
                 yd1 = self.get_comanage_data().yaml_data
-                yd2 = self.get_contacts_data().yaml_data
+                yd2 = self.get_contact_db_data().yaml_data
                 yd_merged = cilogon_ldap.merge_yaml_data(yd1, yd2)
                 self.merged_contacts_data.update(ContactsData(yd_merged))
             except Exception:

--- a/src/webapp/models.py
+++ b/src/webapp/models.py
@@ -8,6 +8,7 @@ from typing import Dict, Set, List
 import yaml
 
 from webapp import cilogon_ldap, common, contacts_reader, mappings, project_reader, rg_reader, vo_reader
+from webapp.common import readfile
 from webapp.contacts_reader import ContactsData
 from webapp.topology import Topology, Downtime
 from webapp.vos_data import VOsData
@@ -162,7 +163,7 @@ class GlobalData:
             return contacts_reader.get_contacts_data(None)
         elif self.comanage_data.should_update():
             try:
-                idmap = cilogon_ldap.get_cilogon_ldap_id_map()
+                idmap = cilogon_ldap.get_cilogon_ldap_id_map(self)
                 data = cilogon_ldap.cilogon_id_map_to_yaml_data(idmap)
                 self.comanage_data.update(ContactsData(data))
             except Exception:
@@ -172,6 +173,12 @@ class GlobalData:
                 self.comanage_data.try_again()
 
         return self.comanage_data.data
+
+    def get_cilogon_ldap_id_map(self):
+        url = self.cilogon_ldap_url
+        user = self.cilogon_ldap_user
+        ldappass = readfile(self.cilogon_ldap_passfile, log)
+        return cilogon_ldap.get_cilogon_ldap_id_map(url, user, ldappass)
 
     def get_contacts_data(self) -> ContactsData:
         """

--- a/src/webapp/models.py
+++ b/src/webapp/models.py
@@ -45,6 +45,9 @@ class GlobalData:
             config = {}
         config.setdefault("TOPOLOGY_DATA_DIR", ".")
         config.setdefault("CONTACT_DATA_DIR", None)
+        config.setdefault("CILOGON_LDAP_URL", "ldaps://ldap.cilogon.org")
+        config.setdefault("CILOGON_LDAP_USER",
+                "uid=readonly_user,ou=system,o=OSG,o=CO,dc=cilogon,dc=org")
         config.setdefault("NO_GIT", True)
         contact_cache_lifetime = config.get("CONTACT_CACHE_LIFETIME", config.get("CACHE_LIFETIME", 60*15))
         topology_cache_lifetime = config.get("TOPOLOGY_CACHE_LIFETIME", config.get("CACHE_LIFETIME", 60*15))
@@ -67,6 +70,8 @@ class GlobalData:
         self.webhook_gh_api_user = config.get("WEBHOOK_GH_API_USER")
         self.webhook_gh_api_token = config.get("WEBHOOK_GH_API_TOKEN")
         self.cilogon_ldap_passfile = config.get("CILOGON_LDAP_PASSFILE")
+        self.cilogon_ldap_url = config.get("CILOGON_LDAP_URL")
+        self.cilogon_ldap_user = config.get("CILOGON_LDAP_USER")
         if config["CONTACT_DATA_DIR"]:
             self.contacts_file = os.path.join(config["CONTACT_DATA_DIR"], "contacts.yaml")
         else:
@@ -152,7 +157,10 @@ class GlobalData:
         """
         Get the contact information from comanage / cilogon ldap
         """
-        if self.comanage_data.should_update():
+        if not self.config.get("CILOGON_LDAP_URL", None):
+            log.debug("CILOGON_LDAP_URL not specified; getting empty contacts")
+            return contacts_reader.get_contacts_data(None)
+        elif self.comanage_data.should_update():
             try:
                 idmap = cilogon_ldap.get_cilogon_ldap_id_map()
                 data = cilogon_ldap.cilogon_id_map_to_yaml_data(idmap)

--- a/src/webapp/models.py
+++ b/src/webapp/models.py
@@ -150,7 +150,7 @@ class GlobalData:
 
     def get_comanage_data(self) -> ContactsData:
         """
-        Get the contact information from a private git repo
+        Get the contact information from comanage / cilogon ldap
         """
         if self.comanage_data.should_update():
             try:

--- a/src/webapp/oasis_managers.py
+++ b/src/webapp/oasis_managers.py
@@ -28,8 +28,8 @@ def get_oasis_manager_endpoint_info(global_data, vo, ldappass):
         if not managers:
             return []
 
-    ldap_url = self.cilogon_ldap_url
-    ldap_user = self.cilogon_ldap_user
+    ldap_url = global_data.cilogon_ldap_url
+    ldap_user = global_data.cilogon_ldap_user
     cilogon_id_map = get_cilogon_ldap_id_map(ldap_url, ldap_user, ldappass)
     ssh_keys_map = cilogon_id_map_to_ssh_keys(cilogon_id_map)
     contact_cilogon_ids = get_contact_cilogon_id_map(global_data)

--- a/src/webapp/oasis_managers.py
+++ b/src/webapp/oasis_managers.py
@@ -28,7 +28,9 @@ def get_oasis_manager_endpoint_info(global_data, vo, ldappass):
         if not managers:
             return []
 
-    cilogon_id_map = get_cilogon_ldap_id_map(ldappass)
+    ldap_url = self.cilogon_ldap_url
+    ldap_user = self.cilogon_ldap_user
+    cilogon_id_map = get_cilogon_ldap_id_map(ldap_url, ldap_user, ldappass)
     ssh_keys_map = cilogon_id_map_to_ssh_keys(cilogon_id_map)
     contact_cilogon_ids = get_contact_cilogon_id_map(global_data)
 


### PR DESCRIPTION
for consistency, the contacts_reader.ContactsData class is entirely re-used for the cilogon/comanage data from ldap, which is accomplished here by transforming the relevant parts to match the structure from contacts.yaml.

still WIP at the moment but flaming criticism is welcome, i think.

(and yes at the moment plumbing needs to be added to read the ldap passwd from disk)