### PR TITLE
Update UFlorida-HPC_downtime.yaml

### DIFF
--- a/topology/University of Florida/UF HPC/UFlorida-HPC_downtime.yaml
+++ b/topology/University of Florida/UF HPC/UFlorida-HPC_downtime.yaml
@@ -874,3 +874,36 @@
   Services:
   - XRootD component
 # ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 919683856
+  Description: Local storage upgrade requires the SLURM scheduler to be turned off
+  Severity: Outage
+  StartTime: Aug 09, 2021 13:00 +0000
+  EndTime: Aug 16, 2021 23:00 +0000
+  CreatedTime: Jul 22, 2021 15:39 +0000
+  ResourceName: UFlorida-CMS
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 919684276
+  Description: Local storage upgrade requires the SLURM scheduler to be turned off
+  Severity: Outage
+  StartTime: Aug 09, 2021 13:00 +0000
+  EndTime: Aug 16, 2021 23:00 +0000
+  CreatedTime: Jul 22, 2021 15:40 +0000
+  ResourceName: UFlorida-HPC
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 919684607
+  Description: Local storage upgrade requires the SLURM scheduler to be turned off
+  Severity: Outage
+  StartTime: Aug 09, 2021 13:00 +0000
+  EndTime: Aug 16, 2021 23:00 +0000
+  CreatedTime: Jul 22, 2021 15:41 +0000
+  ResourceName: UFlorida-HPG2
+  Services:
+  - CE
+# ---------------------------------------------------------


### PR DESCRIPTION
Local storage upgrade requires the SLURM scheduler to be turned off