### PR TITLE
Update UFlorida-HPC.yaml to change the xrootd endpoint

### DIFF
--- a/topology/University of Florida/UF HPC/UFlorida-HPC.yaml
+++ b/topology/University of Florida/UF HPC/UFlorida-HPC.yaml
@@ -273,14 +273,14 @@ Resources:
           ID: 2d9012f731159dd45a082164c6aac6577167e725
           Name: Bockjoo Kim
     Description: Xrootd Redirector
-    FQDN: cmsio5.rc.ufl.edu
+    FQDN: cmsio7.rc.ufl.edu
     ID: 1000
     Services:
       XRootD component:
         Description: Xrootd Redirector
         Details:
           hidden: false
-          uri_override: cmsio5.rc.ufl.edu:1094
+          uri_override: cmsio7.rc.ufl.edu:1094
     VOOwnership:
       CMS: 100
     WLCGInformation:


### PR DESCRIPTION
Redirector is changed from cmsio5.rc.ufl.edu to cmsio7.rc.ufl.edu due to the down cmsio5.