### PR TITLE
Add downtime for SLATE_US_NMSU_DISCOVERY

### DIFF
--- a/topology/New Mexico State University/New Mexico State Discovery/NMSU_DISCOVERY_downtime.yaml
+++ b/topology/New Mexico State University/New Mexico State Discovery/NMSU_DISCOVERY_downtime.yaml
@@ -8,3 +8,13 @@
   ResourceName: SLATE_US_NMSU_DISCOVERY
   Services:
   - CE
+- Class: SCHEDULED
+  ID: 926862201
+  Description: Bi-Annual Downtime For Cluster Upgrades
+  Severity: Outage
+  StartTime: Aug 02, 2021 14:00 +0000
+  EndTime: Aug 16, 2021 14:00 +0000
+  CreatedTime: Jul 30, 2021 23:03 +0000
+  ResourceName: SLATE_US_NMSU_DISCOVERY
+  Services:
+  - CE


### PR DESCRIPTION
Add downtime for SLATE_US_NMSU_DISCOVERY due to bi-annual downtime for the associated slurm cluster.