### PR TITLE
Remove admx.osgstorage.org

### DIFF
--- a/virtual-organizations/ADMX.yaml
+++ b/virtual-organizations/ADMX.yaml
@@ -37,7 +37,6 @@ OASIS:
       ID: 5e96f41b876c2b42c727d1ad476cd025e5584b5b
   OASISRepoURLs:
   - http://oasiscfs.fnal.gov:8000/cvmfs/admx.opensciencegrid.org
-  - http://hcc-cvmfs-repo.unl.edu:8000/cvmfs/admx.osgstorage.org
   UseOASIS: true
 ParentVO:
   ID: 9


### PR DESCRIPTION
ADMX is not yet ready to use the osgstorage.org repo.