### PR TITLE
Add CHTC_STASHCACHE_ORIGIN_AUTH_2000 resource

### DIFF
--- a/topology/University of Wisconsin/CHTC/CHTC.yaml
+++ b/topology/University of Wisconsin/CHTC/CHTC.yaml
@@ -797,4 +797,39 @@ Resources:
     VOOwnership:
       GLOW: 100
 
+  CHTC_STASHCACHE_ORIGIN_AUTH_2000:
+    Active: true
+    Description: This is a StashCache origin server at UW.
+    ID: 1192
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          ID: ec1013224934d6a11a2a46a5234b3337095f5ec4
+          Name: Matyas Selmeci
+        Secondary:
+          ID: 46a55ac4815b2b8c00ff283549f413113b45d628
+          Name: Aaron Moate
+        Tertiary:
+          ID: 3f306d87236d84ef770ddf0c34844908e2d94dfa
+          Name: Timothy Slauson
+      Security Contact:
+        Primary:
+          ID: ec1013224934d6a11a2a46a5234b3337095f5ec4
+          Name: Matyas Selmeci
+        Secondary:
+          ID: 46a55ac4815b2b8c00ff283549f413113b45d628
+          Name: Aaron Moate
+        Tertiary:
+          ID: 3f306d87236d84ef770ddf0c34844908e2d94dfa
+          Name: Timothy Slauson
+    FQDN: origin-auth2000.chtc.wisc.edu
+    DN: /CN=origin-auth2000.chtc.wisc.edu
+    Services:
+      XRootD origin server:
+        Description: StashCache origin server, see OPS-198
+    VOOwnership:
+      GLOW: 100
+    AllowedVOs:
+      - ANY
+
 SupportCenter: GLOW-TECH


### PR DESCRIPTION
Add CHTC_STASHCACHE_ORIGIN_AUTH_2000 resource

Representing origin-auth2000.chtc.wisc.edu
RT ticket #103913: Create Stash Origin that can be used to
serve protected data to jobs on the Open Science Pool
https://crt.cs.wisc.edu/rt/Ticket/Display.html?id=103913
OPS-198 'Prepare "submit6" at UW for OSPool'
https://opensciencegrid.atlassian.net/browse/OPS-198