### PR TITLE
[CIT_CMS_T2] No need for downtime. Change date to previous day. All C…

### DIFF
--- a/topology/California Institute of Technology/Caltech CMS Tier2/CIT_CMS_T2_downtime.yaml
+++ b/topology/California Institute of Technology/Caltech CMS Tier2/CIT_CMS_T2_downtime.yaml
@@ -1782,8 +1782,8 @@
   ID: 941476039
   Description:  HTCondor-CE Update to 5/9.0.4 release
   Severity: Outage
-  StartTime: Aug 20, 2021 08:00 -0700
-  EndTime: Aug 27, 2021 17:00 -0700
+  StartTime: Aug 19, 2021 08:00 -0700
+  EndTime: Aug 19, 2021 08:00 -0700
   CreatedTime: Aug 18, 2021 12:00 -0700
   ResourceName: CIT_CMS_T2
   Services:


### PR DESCRIPTION
…Es/Condors >9 release.