### PR TITLE
More OASIS cleanup (SOFTWARE-4279)

### DIFF
--- a/virtual-organizations/ACCRE.yaml
+++ b/virtual-organizations/ACCRE.yaml
@@ -16,15 +16,11 @@ Contacts:
   Administrative Contact:
   - ID: 11107327543306be8c340cfa2281444a2d428318
     Name: Andrew Malone Melo
-  - ID: 22ae3f93d335f46cea9be2f7c9e0551f31df44bf
-    Name: Eric Appelt
 
   # Security Contact is a list of people to contact regarding security issues
   Security Contact:
   - ID: 11107327543306be8c340cfa2281444a2d428318
     Name: Andrew Malone Melo
-  - ID: 22ae3f93d335f46cea9be2f7c9e0551f31df44bf
-    Name: Eric Appelt
 
 FieldsOfScience:
   PrimaryFields:

--- a/virtual-organizations/ADMX.yaml
+++ b/virtual-organizations/ADMX.yaml
@@ -28,13 +28,6 @@ OASIS:
     - Name: Derek Weitzel
       DNs: /DC=org/DC=cilogon/C=US/O=University of Nebraska-Lincoln/CN=Derek Weitzel A31419551
       ID: 5d324b2a0011c48462f5c6d981b307e3733cb8b6
-    - Name: Robert Illingworth
-      DNs:
-      - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Robert Illingworth
-        1724
-      - /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Robert Illingworth
-        1724
-      ID: 5e96f41b876c2b42c727d1ad476cd025e5584b5b
   OASISRepoURLs:
   - http://oasiscfs.fnal.gov:8000/cvmfs/admx.opensciencegrid.org
   UseOASIS: true

--- a/virtual-organizations/ADMX.yaml
+++ b/virtual-organizations/ADMX.yaml
@@ -20,17 +20,9 @@ ID: 53
 LongName: Fermilab/ADMX
 MembershipServicesURL: https://voms.fnal.gov:8443/voms/fermilab
 OASIS:
-  Managers:
-    - Name: Brian Bockelman
-      DNs: /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=bbockelm/CN=659869/CN=Brian
-        Paul Bockelman
-      ID: 66ee5cfb622a7343dac85dee42815d1f4fbc2d85
-    - Name: Derek Weitzel
-      DNs: /DC=org/DC=cilogon/C=US/O=University of Nebraska-Lincoln/CN=Derek Weitzel A31419551
-      ID: 5d324b2a0011c48462f5c6d981b307e3733cb8b6
   OASISRepoURLs:
   - http://oasiscfs.fnal.gov:8000/cvmfs/admx.opensciencegrid.org
-  UseOASIS: true
+  UseOASIS: false
 ParentVO:
   ID: 9
   Name: Fermilab

--- a/virtual-organizations/Belle.yaml
+++ b/virtual-organizations/Belle.yaml
@@ -47,18 +47,6 @@ ID: 69
 LongName: The Belle Experiment at KEK
 MembershipServicesURL: https://voms.cc.kek.jp:8443/voms/belle
 OASIS:
-  Managers:
-    - Name: Hideki Miyake
-      DNs: /C=JP/O=KEK/OU=CRC/CN=Hideki Miyake
-      ID: 6329edd750ea546a7b519d29a50902e3515bab0b
-    - Name: I Ueda
-      DNs:
-      - /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=ueda/CN=482702/CN=I Ueda
-      - /C=JP/O=KEK/OU=CRC/CN=UEDA Ikuo
-      ID: 912a123a80b973b4abdfe9a116387294cc6c1da2
-    - Name: Kiyoshi Hayasaka
-      DNs: /C=JP/O=KEK/OU=CRC/CN=HAYASAKA Kiyoshi
-      ID: a576382ce7f50940632597dbf12b34eaa718bae2
   UseOASIS: false
   OASISRepoURLs:
     - http://cvmfs-stratum-zero.cc.kek.jp/cvmfs/belle.kek.jp

--- a/virtual-organizations/COUPP.yaml
+++ b/virtual-organizations/COUPP.yaml
@@ -23,11 +23,6 @@ ID: 86
 LongName: Chicagoland Observatory for Underground Particle Physics
 MembershipServicesURL: https://voms.fnal.gov:8443/voms/fermilab
 OASIS:
-  Managers:
-    - Name: Christophe Bonnaud
-      DNs: /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Christophe
-        Bonnaud 3139
-      ID: 8cc594d4724bec67b459ff043a26b389a5286382
   OASISRepoURLs:
     - http://oasiscfs.fnal.gov:8000/cvmfs/coupp.opensciencegrid.org/
   UseOASIS: false

--- a/virtual-organizations/Darkside.yaml
+++ b/virtual-organizations/Darkside.yaml
@@ -26,7 +26,7 @@ MembershipServicesURL: https://voms.fnal.gov:8443/voms/fermilab
 OASIS:
   OASISRepoURLs:
   - http://oasiscfs.fnal.gov:8000/cvmfs/darkside.opensciencegrid.org
-  UseOASIS: true
+  UseOASIS: false
 ParentVO:
   ID: 9
   Name: Fermilab

--- a/virtual-organizations/EMPHATIC.yaml
+++ b/virtual-organizations/EMPHATIC.yaml
@@ -22,21 +22,6 @@ ID: 222
 LongName: Fermilab/EMPHATIC
 MembershipServicesURL: https://voms.fnal.gov:8443/voms/fermilab
 OASIS:
-  Managers:
-    - Name: Brian Bockelman
-      DNs: /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=bbockelm/CN=659869/CN=Brian
-        Paul Bockelman
-      ID: 66ee5cfb622a7343dac85dee42815d1f4fbc2d85
-    - Name: Derek Weitzel
-      DNs: /DC=org/DC=cilogon/C=US/O=University of Nebraska-Lincoln/CN=Derek Weitzel A31419551
-      ID: 5d324b2a0011c48462f5c6d981b307e3733cb8b6
-    - Name: Robert Illingworth
-      DNs:
-      - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Robert Illingworth
-        1724
-      - /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Robert Illingworth
-        1724
-      ID: 5e96f41b876c2b42c727d1ad476cd025e5584b5b
   OASISRepoURLs:
     - http://oasiscfs.fnal.gov:8000/cvmfs/emphatic.opensciencegrid.org
   UseOASIS: false

--- a/virtual-organizations/HCC.yaml
+++ b/virtual-organizations/HCC.yaml
@@ -49,15 +49,7 @@ ID: 67
 LongName: Holland Computing Center at the University of Nebraska.
 MembershipServicesURL: https://hcc-voms.unl.edu:8443/voms/hcc/Login.do
 OASIS:
-  Managers:
-    - Name: Brian Bockelman
-      DNs: /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=bbockelm/CN=659869/CN=Brian
-        Paul Bockelman
-      ID: 66ee5cfb622a7343dac85dee42815d1f4fbc2d85
-    - Name: Derek Weitzel
-      DNs: /DC=org/DC=cilogon/C=US/O=University of Nebraska-Lincoln/CN=Derek Weitzel A31419551
-      ID: 5d324b2a0011c48462f5c6d981b307e3733cb8b6
-  UseOASIS: true
+  UseOASIS: false
 PrimaryURL: http://hcc.unl.edu
 PurposeURL: http://hcc.unl.edu/GridNebraska
 ReportingGroups:

--- a/virtual-organizations/IceCube.yaml
+++ b/virtual-organizations/IceCube.yaml
@@ -37,7 +37,7 @@ OASIS:
   OASISRepoURLs:
   - http://cvmfs-stratum0.wipac.wisc.edu/cvmfs/icecube.opensciencegrid.org
   - http://hcc-cvmfs-repo.unl.edu:8000/cvmfs/icecube.osgstorage.org
-  UseOASIS: true
+  UseOASIS: false
 PrimaryURL: https://grid-voms.desy.de:8443/voms/icecube/
 PurposeURL: http://www.icecube.wisc.edu/
 ReportingGroups:

--- a/virtual-organizations/Mu2e.yaml
+++ b/virtual-organizations/Mu2e.yaml
@@ -18,19 +18,11 @@ ID: 59
 LongName: Fermilab/Mu2e
 MembershipServicesURL: https://voms.fnal.gov:8443/voms/fermilab
 OASIS:
-  Managers:
-    - Name: Brian Bockelman
-      DNs: /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=bbockelm/CN=659869/CN=Brian
-        Paul Bockelman
-      ID: 66ee5cfb622a7343dac85dee42815d1f4fbc2d85
-    - Name: Derek Weitzel
-      DNs: /DC=org/DC=cilogon/C=US/O=University of Nebraska-Lincoln/CN=Derek Weitzel A31419551
-      ID: 5d324b2a0011c48462f5c6d981b307e3733cb8b6
   OASISRepoURLs:
   - http://oasiscfs.fnal.gov:8000/cvmfs/mu2e.opensciencegrid.org
   - http://oasiscfs.fnal.gov:8000/cvmfs/mu2e-development.opensciencegrid.org
   - http://hcc-cvmfs-repo.unl.edu:8000/cvmfs/mu2e.osgstorage.org
-  UseOASIS: true
+  UseOASIS: false
 ParentVO:
   ID: 9
   Name: Fermilab

--- a/virtual-organizations/Mu2e.yaml
+++ b/virtual-organizations/Mu2e.yaml
@@ -26,10 +26,6 @@ OASIS:
     - Name: Derek Weitzel
       DNs: /DC=org/DC=cilogon/C=US/O=University of Nebraska-Lincoln/CN=Derek Weitzel A31419551
       ID: 5d324b2a0011c48462f5c6d981b307e3733cb8b6
-    - Name: Raymond Lloyd Culbertson
-      DNs: /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Raymond Lloyd
-        Culbertson 1119
-      ID: d2c84720987c5e6a0d6290f84a9677c044147808
   OASISRepoURLs:
   - http://oasiscfs.fnal.gov:8000/cvmfs/mu2e.opensciencegrid.org
   - http://oasiscfs.fnal.gov:8000/cvmfs/mu2e-development.opensciencegrid.org

--- a/virtual-organizations/Nova.yaml
+++ b/virtual-organizations/Nova.yaml
@@ -24,19 +24,11 @@ ID: 53
 LongName: Fermilab/Nova
 MembershipServicesURL: https://voms.fnal.gov:8443/voms/fermilab
 OASIS:
-  Managers:
-    - Name: Brian Bockelman
-      DNs: /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=bbockelm/CN=659869/CN=Brian
-        Paul Bockelman
-      ID: 66ee5cfb622a7343dac85dee42815d1f4fbc2d85
-    - Name: Derek Weitzel
-      DNs: /DC=org/DC=cilogon/C=US/O=University of Nebraska-Lincoln/CN=Derek Weitzel A31419551
-      ID: 5d324b2a0011c48462f5c6d981b307e3733cb8b6
   OASISRepoURLs:
   - http://oasiscfs.fnal.gov:8000/cvmfs/nova.opensciencegrid.org
   - http://hcc-cvmfs-repo.unl.edu:8000/cvmfs/nova.osgstorage.org
   - http://oasiscfs.fnal.gov:8000/cvmfs/nova-development.opensciencegrid.org
-  UseOASIS: true
+  UseOASIS: false
 ParentVO:
   ID: 9
   Name: Fermilab

--- a/virtual-organizations/Nova.yaml
+++ b/virtual-organizations/Nova.yaml
@@ -25,9 +25,6 @@ LongName: Fermilab/Nova
 MembershipServicesURL: https://voms.fnal.gov:8443/voms/fermilab
 OASIS:
   Managers:
-    - Name: Alexander I. Himmel
-      DNs: /DC=gov/DC=fnal/O=Fermilab/OU=People/CN=Alex I. Himmel/CN=UID:ahimmel
-      ID: 512449466954b8e2d2df17f25173d273e431e1c6
     - Name: Brian Bockelman
       DNs: /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=bbockelm/CN=659869/CN=Brian
         Paul Bockelman
@@ -35,13 +32,6 @@ OASIS:
     - Name: Derek Weitzel
       DNs: /DC=org/DC=cilogon/C=US/O=University of Nebraska-Lincoln/CN=Derek Weitzel A31419551
       ID: 5d324b2a0011c48462f5c6d981b307e3733cb8b6
-    - Name: Robert Illingworth
-      DNs:
-      - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Robert Illingworth
-        1724
-      - /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Robert Illingworth
-        1724
-      ID: 5e96f41b876c2b42c727d1ad476cd025e5584b5b
   OASISRepoURLs:
   - http://oasiscfs.fnal.gov:8000/cvmfs/nova.opensciencegrid.org
   - http://hcc-cvmfs-repo.unl.edu:8000/cvmfs/nova.osgstorage.org

--- a/virtual-organizations/annie.yaml
+++ b/virtual-organizations/annie.yaml
@@ -17,14 +17,9 @@ ID: 130
 LongName: Accelerator Neutrino Neutron Interaction Experiment
 MembershipServicesURL: https://voms.fnal.gov:8443/voms/fermilab
 OASIS:
-  Managers:
-    - Name: Arthur Kreymer
-      DNs:
-      - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Arthur Kreymer 965
-      ID: fa14f7cbd84a8b048e6ebd192a72a14bf298c354
   OASISRepoURLs:
   - http://oasiscfs.fnal.gov:8000/cvmfs/annie.opensciencegrid.org
-  UseOASIS: true
+  UseOASIS: false
 ParentVO:
   ID: 9
   Name: Fermilab

--- a/virtual-organizations/geant4.yaml
+++ b/virtual-organizations/geant4.yaml
@@ -26,12 +26,6 @@ LongName: Geant4 Software Toolkit
 MembershipServicesURL: https://lcg-voms.cern.ch:8443/voms/geant4
 OASIS:
   Managers:
-    - Name: Hans Wenzel
-      DNs:
-      - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Hans Wenzel 959
-      - /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Hans Wenzel 959
-      - /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Hans Wenzel
-      ID: c56ee64dbf3fa94b8e0836b8b8b78d3bcdb34060
     - Name: Krzysztof Genser
       DNs:
       - /DC=org/DC=cilogon/C=US/O=Fermi National Accelerator Laboratory/OU=People/CN=Krzysztof Genser/CN=UID:genser

--- a/virtual-organizations/snoplus.snolab.ca.yaml
+++ b/virtual-organizations/snoplus.snolab.ca.yaml
@@ -30,16 +30,6 @@ ID: 101
 LongName: SNO+ at SNOLAB
 MembershipServicesURL: https://voms.gridpp.ac.uk:8443/voms/snoplus.snolab.ca/
 OASIS:
-  Managers:
-    - Name: Freija Descamps
-      DNs: /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Freija Descamps
-        1236
-      ID: 5950a48f5d2a46e3aeb4f57252ec700073556ad8
-    - Name: Kevin Labe
-      DNs:
-      - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Kevin Labe 1781
-      - /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Kevin Labe 1781
-      ID: 09b73ac37893edd1f5df7f7112ef74a7d41a4c8b
   OASISRepoURLs:
   - http://cvmfs-stratum0.gridpp.rl.ac.uk:8000/cvmfs/snoplus.egi.eu
   UseOASIS: true


### PR DESCRIPTION
This PR includes

1. Removal of OASIS managers that did not register in COManage by the deadline
2. Setting `UseOasis: false` for VOs with empty dris and without any managers (or the only remaining managers were BrianB and Derek)

There are a bunch of VOs with `UseOASIS: true` with empty dirs that I left around because they've got a COManage-registered manager