### PR TITLE
Add SRMv2 disk and tape services (SOFTWARE-4732)

### DIFF
--- a/topology/Brookhaven National Laboratory/BNL ATLAS Tier1/BNL-ATLAS.yaml
+++ b/topology/Brookhaven National Laboratory/BNL ATLAS Tier1/BNL-ATLAS.yaml
@@ -358,10 +358,10 @@ Resources:
     FQDN: dcsrm.usatlas.bnl.gov
     ID: 5
     Services:
-      SRMv2:
-        Description: SRM V2 Storage Element
-        Details:
-          hidden: false
+      SRMv2.disk:
+        Description: SRM V2 endpoint for the disk system
+      SRMv2.tape:
+        Description: SRM V2 endpoint for the tape system
     VOOwnership:
       ATLAS: 100
     WLCGInformation:

--- a/topology/services.yaml
+++ b/topology/services.yaml
@@ -33,6 +33,8 @@ Message Bus: 154
 Topology Server: 155
 Execution Endpoint: 157
 WebDAV: 158
+SRMv2.disk: 159
+SRMv2.tape: 160
 # deprecated
 GUMS Server: 101
 VOMS Server: 102


### PR DESCRIPTION
BNL's SRM endpoint is used to access their underlying disk and tape systems and they'll often take one of these systems down for maintenance but not the other. This is required for proper downtime propagation to CRIC.