### PR TITLE
Schedule Full Vanderbilt ACCRE downtime September 17-18

### DIFF
--- a/topology/Vanderbilt University/Vanderbilt ACCRE/Vanderbilt_downtime.yaml
+++ b/topology/Vanderbilt University/Vanderbilt ACCRE/Vanderbilt_downtime.yaml
@@ -415,9 +415,9 @@
   ID: 961985989
   Description: Operating System Updates and Reconfiguration
   Severity: Outage
-  StartTime: September 17, 2021 05:00 +0000
-  EndTime: September 19, 2021 05:00 +0000
-  CreatedTime: September 13, 2021 11:00 +0000
+  StartTime: Sep 17, 2021 05:00 +0000
+  EndTime: Sep 19, 2021 05:00 +0000
+  CreatedTime: Sep 13, 2021 11:00 +0000
   ResourceName: Vanderbilt_Gridftp
   Services:
   - GridFtp
@@ -425,9 +425,9 @@
   ID: 961985990
   Description: Operating System Updates and Reconfiguration
   Severity: Outage
-  StartTime: September 17, 2021 05:00 +0000
-  EndTime: September 19, 2021 05:00 +0000
-  CreatedTime: September 13, 2021 11:00 +0000
+  StartTime: Sep 17, 2021 05:00 +0000
+  EndTime: Sep 19, 2021 05:00 +0000
+  CreatedTime: Sep 13, 2021 11:00 +0000
   ResourceName: Vanderbilt_CE5
   Services:
   - CE
@@ -435,9 +435,9 @@
   ID: 961985991
   Description: Operating System Updates and Reconfiguration
   Severity: Outage
-  StartTime: September 17, 2021 05:00 +0000
-  EndTime: September 19, 2021 05:00 +0000
-  CreatedTime: September 13, 2021 11:00 +0000
+  StartTime: Sep 17, 2021 05:00 +0000
+  EndTime: Sep 19, 2021 05:00 +0000
+  CreatedTime: Sep 13, 2021 11:00 +0000
   ResourceName: Vanderbilt_CE6
   Services:
   - CE

--- a/topology/Vanderbilt University/Vanderbilt ACCRE/Vanderbilt_downtime.yaml
+++ b/topology/Vanderbilt University/Vanderbilt ACCRE/Vanderbilt_downtime.yaml
@@ -410,3 +410,34 @@
   ResourceName: Vanderbilt_CE6
   Services:
   - CE
+# ----------------------------------------------------------
+- Class: SCHEDULED
+  ID: 961985989
+  Description: Operating System Updates and Reconfiguration
+  Severity: Outage
+  StartTime: September 17, 2021 05:00 +0000
+  EndTime: September 19, 2021 05:00 +0000
+  CreatedTime: September 13, 2021 11:00 +0000
+  ResourceName: Vanderbilt_Gridftp
+  Services:
+  - GridFtp
+- Class: SCHEDULED
+  ID: 961985990
+  Description: Operating System Updates and Reconfiguration
+  Severity: Outage
+  StartTime: September 17, 2021 05:00 +0000
+  EndTime: September 19, 2021 05:00 +0000
+  CreatedTime: September 13, 2021 11:00 +0000
+  ResourceName: Vanderbilt_CE5
+  Services:
+  - CE
+- Class: SCHEDULED
+  ID: 961985991
+  Description: Operating System Updates and Reconfiguration
+  Severity: Outage
+  StartTime: September 17, 2021 05:00 +0000
+  EndTime: September 19, 2021 05:00 +0000
+  CreatedTime: September 13, 2021 11:00 +0000
+  ResourceName: Vanderbilt_CE6
+  Services:
+  - CE


### PR DESCRIPTION
This downtime is to upgrade the operating system of our worker nodes and much of our infrastructure and to reconfigure some parameters related to the interface between the CEs and our internal slurm scheduler.