### PR TITLE
Fix "dictionary changed size during iteration error"

### DIFF
--- a/src/topology_utils.py
+++ b/src/topology_utils.py
@@ -342,7 +342,7 @@ def filter_contacts(args, results):
 
     if args.contact_type != 'all':
         # filter out undesired contact types
-        for name in results.keys():
+        for name in list(results.keys()):
             contact_list = []
             for contact in results[name]:
                 contact_type = contact['ContactType']


### PR DESCRIPTION
I got the following error with osg-notify:
```
$ osg-notify --type production --no-sign --message /etc/motd --subject 'OASIS upgrade' --recipients "dwd@fnal.gov" --oim-recipients resources --oim-contact-type administrative --dry-run
Traceback (most recent call last):
  File "/nashome/d/dwd/work/topology/bin/osg-notify", line 250, in <module>
    main()
  File "/nashome/d/dwd/work/topology/bin/osg-notify", line 192, in main
    results = topology_utils.filter_contacts(args, results)
  File "/nashome/d/dwd/work/topology/src/topology_utils.py", line 345, in filter_contacts
    for name in results.keys():
RuntimeError: dictionary changed size during iteration
```
This PR applies a hint from [stack overflow](https://stackoverflow.com/questions/11941817/how-to-avoid-runtimeerror-dictionary-changed-size-during-iteration-error).