### PR TITLE
Add new PS servers iut2-net1[1-6]

### DIFF
--- a/topology/University of Chicago/MWT2 ATLAS UC/MWT2.yaml
+++ b/topology/University of Chicago/MWT2 ATLAS UC/MWT2.yaml
@@ -1044,7 +1044,7 @@ Resources:
           Name: Lincoln Bryant
     Description: MWT2 perfSONAR-PS Bandwidth instance at Indiana University (Replaces iut2-net4)
     FQDN: iut2-net12.iu.edu
-    ID: 1229
+    ID: 1235
     Services:
       net.perfSONAR.Bandwidth:
         Description: PerfSonar Bandwidth monitoring node
@@ -1351,7 +1351,7 @@ Resources:
           Name: Lincoln Bryant
     Description: MWT2 perfSONAR-PS Latency instance at Indiana University (replaces iut2-net3)
     FQDN: iut2-net11.iu.edu
-    ID: 1228
+    ID: 1234
     Services:
       net.perfSONAR.Latency:
         Description: PerfSonar Latency monitoring node


### PR DESCRIPTION
Added 6 more PS servers which are 3 physical servers using 2 NICs for PS. The 1G NIC does the latency tests and the 40G NIC does the bandwidth tests. I received 1228 from next_resource_id and assumed that the other 5 servers would get 1229-1233.