### PR TITLE
Update UFlorida-HPC.yaml 4 new perfsonar machines

### DIFF
--- a/topology/University of Florida/UF HPC/UFlorida-HPC.yaml
+++ b/topology/University of Florida/UF HPC/UFlorida-HPC.yaml
@@ -7,36 +7,36 @@ Resources:
     ContactLists:
       Administrative Contact:
         Primary:
-          ID: 
+          ID: 8fe996dae2ee3abd17af9f8c0f57fa6d166be5ff
           Name: University of Florida CMS Tier 2 Admins
         Secondary:
-          ID:
+          ID: 2d9012f731159dd45a082164c6aac6577167e725
           Name: Bockjoo Kim
       Miscellaneous Contact:
         Primary:
-          ID:
+          ID: 8fe996dae2ee3abd17af9f8c0f57fa6d166be5ff
           Name: University of Florida CMS Tier 2 Admins
         Secondary:
-          ID:
+          ID: 2d9012f731159dd45a082164c6aac6577167e725
           Name: Bockjoo Kim
       Resource Report Contact:
         Primary:
-          ID:
+          ID: 8fe996dae2ee3abd17af9f8c0f57fa6d166be5ff
           Name: University of Florida CMS Tier 2 Admins
         Secondary:
-          ID:
+          ID: 2d9012f731159dd45a082164c6aac6577167e725
           Name: Bockjoo Kim
       Security Contact:
         Primary:
-          ID:
+          ID: 8fe996dae2ee3abd17af9f8c0f57fa6d166be5ff
           Name: University of Florida CMS Tier 2 Admins
         Secondary:
-          ID:
+          ID: 2d9012f731159dd45a082164c6aac6577167e725
           Name: Bockjoo Kim
     Description: This is the perfSONAR-ps latency instance at the University of Florida
       CMS T2 site for IPv4 and IPv6
     FQDN: perfsonar1.rc.ufl.edu
-    ID:
+    ID: 1228
     Services:
       net.perfSONAR.Latency:
         Description: PerfSonar Latency monitoring node
@@ -49,36 +49,36 @@ Resources:
     ContactLists:
       Administrative Contact:
         Primary:
-          ID:
+          ID: 8fe996dae2ee3abd17af9f8c0f57fa6d166be5ff
           Name: University of Florida CMS Tier 2 Admins
         Secondary:
-          ID:
+          ID: 2d9012f731159dd45a082164c6aac6577167e725
           Name: Bockjoo Kim
       Miscellaneous Contact:
         Primary:
-          ID:
+          ID: 8fe996dae2ee3abd17af9f8c0f57fa6d166be5ff
           Name: University of Florida CMS Tier 2 Admins
         Secondary:
-          ID:
+          ID: 2d9012f731159dd45a082164c6aac6577167e725
           Name: Bockjoo Kim
       Resource Report Contact:
         Primary:
-          ID:
+          ID: 8fe996dae2ee3abd17af9f8c0f57fa6d166be5ff
           Name: University of Florida CMS Tier 2 Admins
         Secondary:
-          ID:
+          ID: 2d9012f731159dd45a082164c6aac6577167e725
           Name: Bockjoo Kim
       Security Contact:
         Primary:
-          ID:
+          ID: 8fe996dae2ee3abd17af9f8c0f57fa6d166be5ff
           Name: University of Florida CMS Tier 2 Admins
         Secondary:
-          ID:
+          ID: 2d9012f731159dd45a082164c6aac6577167e725
           Name: Bockjoo Kim
     Description: This is the perfSONAR-ps bandwidth instance at the University of Florida
       CMS T2 site for IPv4 and IPv6
     FQDN: perfsonar2.rc.ufl.edu
-    ID:
+    ID: 1229
     Services:
       net.perfSONAR.Latency:
         Description: PerfSonar Bandwidth monitoring node


### PR DESCRIPTION
I am registering T2_US_Florida_LT and T2_US_Florida_BW to replace T2_Florida_LT and T2_Florida_BW_IPv6.
I have marked  T2_Florida_LT and T2_Florida_BW_IPv6 inactive (Active: false).