### PR TITLE
Hardware failure on gpce04.fnal.gov

### DIFF
--- a/topology/Fermi National Accelerator Laboratory/FermiGrid/GPGRID_downtime.yaml
+++ b/topology/Fermi National Accelerator Laboratory/FermiGrid/GPGRID_downtime.yaml
@@ -76,3 +76,14 @@
   Services:
   - CE
 # ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 997651548
+  Description: Hardware failure
+  Severity: Outage
+  StartTime: Oct 20, 2021 17:00 +0000
+  EndTime: Oct 26, 2021 17:00 +0000
+  CreatedTime: Oct 20, 2021 21:25 +0000
+  ResourceName: FNAL_GPGRID_CE_04
+  Services:
+  - CE
+# ---------------------------------------------------------


### PR DESCRIPTION
we're working on replacing the machine so adding an outage for now.