### PR TITLE
Fix NERSC-Cori-KNL FQDN (FD#68187)

### DIFF
--- a/topology/National Energy Research Scientific Computing Center/NERSC/NERSC-Cori.yaml
+++ b/topology/National Energy Research Scientific Computing Center/NERSC/NERSC-Cori.yaml
@@ -49,7 +49,7 @@ Resources:
         Primary:
           Name: Steve Timm
           ID: 2ab71c21032fd77a73523c3b65af0510ac30d4e3
-    FQDN: cori.nersc.gov
+    FQDN: cori.hepcloud.fnal.gov
     Services:
       CE:
         Description: Bosco SSH direct submit only


### PR DESCRIPTION
This FQDN is a duplicate of `NERSC-Cori-Haswell` so this updates it to match the ProbeName of records they're sending