### PR TITLE
Add "Description" and "Subject" fields to TokenIssuers lists (SOFTWARE-4915)

### DIFF
--- a/bin/get-scitokens-mapfile
+++ b/bin/get-scitokens-mapfile
@@ -45,19 +45,30 @@ def main(argv):
     for vo_name, vo_data in all_vos_data.vos.items():
         if is_null(vo_data, "Credentials", "TokenIssuers"):
             continue
-        mapfile += f"# {vo_name}\n"
+        mapfile += f"## {vo_name} ##\n"
         for token_issuer in vo_data["Credentials"]["TokenIssuers"]:
             url = token_issuer.get("URL")
+            subject = token_issuer.get("Subject", "")
+            description = token_issuer.get("Description")
+            pattern = ""
             if url:
-                if args.regex:
-                    url = f'/^{re.escape(url)},/'
+                if subject:
+                    if args.regex:
+                        pattern = f'/^{re.escape(url)},{re.escape(subject)}$/'
+                    else:
+                        pattern = f'"{url},{subject}"'
                 else:
-                    url = f'"{url}"'
+                    if args.regex:
+                        pattern = f'/^{re.escape(url)},/'
+                    else:
+                        pattern = f'"{url}"'
             unix_user = token_issuer.get("DefaultUnixUser")
-            if url and unix_user:
-                mapfile += f"SCITOKENS {url} {unix_user}\n"
+            if description:
+                mapfile += f"# {description}:\n"
+            if pattern and unix_user:
+                mapfile += f"SCITOKENS {pattern} {unix_user}\n"
             else:
-                mapfile += f"# invalid SCITOKENS: {url or '<NO URL>'} {unix_user or '<NO UNIX USER>'}\n"
+                mapfile += f"# invalid SCITOKENS: {pattern or '<NO URL>'} {unix_user or '<NO UNIX USER>'}\n"
                 if args.strict:
                     print(mapfile, file=sys.stderr)
                     sys.exit("Invalid scitoken found in strict mode")

--- a/bin/get-scitokens-mapfile
+++ b/bin/get-scitokens-mapfile
@@ -49,7 +49,7 @@ def main(argv):
         for token_issuer in vo_data["Credentials"]["TokenIssuers"]:
             url = token_issuer.get("URL")
             subject = token_issuer.get("Subject", "")
-            description = token_issuer.get("Description")
+            description = token_issuer.get("Description", "")
             pattern = ""
             if url:
                 if subject:

--- a/src/schema/vosummary.xsd
+++ b/src/schema/vosummary.xsd
@@ -187,6 +187,8 @@
                               <xsd:sequence>
                                 <xsd:element name="URL" type="xsd:string"/>
                                 <xsd:element name="DefaultUnixUser" type="xsd:string"/>
+                                <xsd:element name="Description" type="xsd:string"/>
+                                <xsd:element name="Subject" type="xsd:string"/>
                               </xsd:sequence>
                             </xsd:complexType>
                           </xsd:element>

--- a/src/webapp/vos_data.py
+++ b/src/webapp/vos_data.py
@@ -102,7 +102,9 @@ class VOsData(object):
                 new_token_issuers = [
                     OrderedDict([
                         ("URL", x.get("URL")),
-                        ("DefaultUnixUser", x.get("DefaultUnixUser"))
+                        ("DefaultUnixUser", x.get("DefaultUnixUser")),
+                        ("Description", x.get("Description")),
+                        ("Subject", x.get("Subject")),
                     ])
                     for x in token_issuers
                 ]

--- a/template-virtual-organization.yaml
+++ b/template-virtual-organization.yaml
@@ -48,8 +48,12 @@ Contacts:
 #   # TokenIssuers:
 #   ### URL is the https URL of your scitokens issuer, e.g. https://scitokens.org/<VO NAME>
 #   ### DefaultUnixUser is a username that jobs with tokens issued by this issuer should map to
+#   ### Description (optional) is human-readable text describing the mapping
+#   ### Subject (optional) is a token subject to restrict this mapping to
 #   # - URL: <URL>
 #   #   DefaultUnixUser: <USER>
+#   #   Description: <TEXT>
+#   #   Subject: <SUBJECT>
 
 FieldsOfScience:
 


### PR DESCRIPTION
Example input:
```
Credentials:
  TokenIssuers:
    - Description: production
      Subject: 7dee38a3-6ab8-4fe2-9e4c-58039c21d817
      URL: https://atlas-auth.web.cern.ch/
      DefaultUnixUser: usatlas1
    - Description: SAM/ETF
      Subject: 5c5d2a4d-9177-3efa-912f-1b4e5c9fb660
      URL: https://atlas-auth.web.cern.ch/
      DefaultUnixUser: usatlas2
    - Description: analysis
      Subject: 750e9609-485a-4ed4-bf16-d5cc46c71024
      URL: https://atlas-auth.web.cern.ch/
      DefaultUnixUser: usatlas3
```
will result in
```
## ATLAS ##
# production:
SCITOKENS /^https\:\/\/atlas\-auth\.web\.cern\.ch\/,7dee38a3\-6ab8\-4fe2\-9e4c\-58039c21d817$/ usatlas1
# SAM/ETF:
SCITOKENS /^https\:\/\/atlas\-auth\.web\.cern\.ch\/,5c5d2a4d\-9177\-3efa\-912f\-1b4e5c9fb660$/ usatlas2
# analysis:
SCITOKENS /^https\:\/\/atlas\-auth\.web\.cern\.ch\/,750e9609\-485a\-4ed4\-bf16\-d5cc46c71024$/ usatlas3
```
