### PR TITLE
Add APEL normalization factors to MIT CEs that were set to 0

### DIFF
--- a/topology/Massachusetts Institute of Technology/MIT CMS/MIT_CMS.yaml
+++ b/topology/Massachusetts Institute of Technology/MIT CMS/MIT_CMS.yaml
@@ -118,7 +118,7 @@ Resources:
       CDF: 10
       CMS: 90
     WLCGInformation:
-      APELNormalFactor: 0
+      APELNormalFactor: 11.72
       AccountingName: T2_US_MIT
       HEPSPEC: 0
       InteropAccounting: true
@@ -155,7 +155,7 @@ Resources:
     VOOwnership:
       CMS: 100
     WLCGInformation:
-      APELNormalFactor: 0
+      APELNormalFactor: 11.72
       AccountingName: T2_US_MIT
       HEPSPEC: 0
       InteropAccounting: true


### PR DESCRIPTION
Keep the APEL normalization number the same as the first CE.