### PR TITLE
Update BU_ATLAS_Tier2_downtime.yaml

### DIFF
--- a/topology/Boston University/Boston University ATLAS Tier2/BU_ATLAS_Tier2_downtime.yaml
+++ b/topology/Boston University/Boston University ATLAS Tier2/BU_ATLAS_Tier2_downtime.yaml
@@ -167,3 +167,15 @@
   - CE
   - GridFtp
 # ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 1063514739
+  Description: Kernel upgrade of NFS servers and retirement of 3TB GPFS pool
+  Severity: Severe
+  StartTime: Jan 11, 2022 11:00 +0000
+  EndTime: Jan 11, 2022 14:00 +0000
+  CreatedTime: Jan 05, 2022 02:57 +0000
+  ResourceName: NET2
+  Services:
+  - CE
+  - GridFtp
+# ---------------------------------------------------------


### PR DESCRIPTION
Scheduled downtime to retire 3TB GPFS pool and do NFS server kernel upgrades