### PR TITLE
Update Cori artificial reporting FQDNs

### DIFF
--- a/topology/National Energy Research Scientific Computing Center/NERSC/NERSC-Cori.yaml
+++ b/topology/National Energy Research Scientific Computing Center/NERSC/NERSC-Cori.yaml
@@ -19,7 +19,9 @@ Resources:
         Primary:
           Name: Steve Timm
           ID: 2ab71c21032fd77a73523c3b65af0510ac30d4e3
-    FQDN: cori.nersc.gov
+    FQDN: cori-haswell.hepcloud.fnal.gov
+    FQDNAliases:
+       - cori.nersc.gov
     Services:
       CE:
         Description: Bosco SSH direct submit only
@@ -49,7 +51,9 @@ Resources:
         Primary:
           Name: Steve Timm
           ID: 2ab71c21032fd77a73523c3b65af0510ac30d4e3
-    FQDN: cori.hepcloud.fnal.gov
+    FQDN: cori-knl.hepcloud.fnal.gov
+    FQDNAliases:
+       - cori.nersc.gov
     Services:
       CE:
         Description: Bosco SSH direct submit only


### PR DESCRIPTION
Similar to what's being done for Perlmutter in #2213, this allows Haswell and KNL resources to be accounted separately.