### PR TITLE
Update uconn HPC fqdn alias

### DIFF
--- a/topology/University of Connecticut/UConn-HPC/UConn-HPC.yaml
+++ b/topology/University of Connecticut/UConn-HPC/UConn-HPC.yaml
@@ -16,9 +16,10 @@ Resources:
         Primary:
           ID: 650bf84a5cf49caf504fed22ce07b98580c6fa12
           Name: Richard T. Jones
-    FQDN: cn410.storrs.hpc.uconn.edu
+    FQDN: osgce.storrs.hpc.uconn.edu
     FQDNAliases:
-    - osgce.storrs.hpc.uconn.edu
+    - 
+    - cn410.storrs.hpc.uconn.edu
     DN: /DC=org/DC=incommon/C=US/ST=Connecticut/L=Storrs/O=University of Connecticut/OU=Academic IT/CN=cn410.storrs.hpc.uconn.edu
     Services:
       Squid:
@@ -40,9 +41,9 @@ Resources:
           ID: 650bf84a5cf49caf504fed22ce07b98580c6fa12
           Name: Richard T. Jones
     Description: HTcondor-CE server for the UConn-HPC compute resources
-    FQDN: cn410.storrs.hpc.uconn.edu
+    FQDN: osgce.storrs.hpc.uconn.edu
     FQDNAliases:
-    - osgce.storrs.hpc.uconn.edu
+    - cn410.storrs.hpc.uconn.edu
     ID: 1094
     Services:
       CE:

--- a/topology/University of Connecticut/UConn-HPC/UConn-HPC.yaml
+++ b/topology/University of Connecticut/UConn-HPC/UConn-HPC.yaml
@@ -16,10 +16,9 @@ Resources:
         Primary:
           ID: 650bf84a5cf49caf504fed22ce07b98580c6fa12
           Name: Richard T. Jones
-    FQDN: osgce.storrs.hpc.uconn.edu
+    FQDN: cn410.storrs.hpc.uconn.edu
     FQDNAliases:
-    - 
-    - cn410.storrs.hpc.uconn.edu
+    - osgce.storrs.hpc.uconn.edu
     DN: /DC=org/DC=incommon/C=US/ST=Connecticut/L=Storrs/O=University of Connecticut/OU=Academic IT/CN=cn410.storrs.hpc.uconn.edu
     Services:
       Squid:


### PR DESCRIPTION
GRACC isn't able to map osgce.storrs.hpc.uconn.edu to a facility because it is only in the FQDN alias.  Swap the fqdn alias and FQDN so GRACC can map it correctly.  The gratia probe ProbeName is set to "htcondor-ce:osgce.storrs.hpc.uconn.edu"