### PR TITLE
Decommission AggieGrid Resource

### DIFF
--- a/topology/New Mexico State University/New Mexico State AggieGrid/NMSU_AGGIE_GRID.yaml
+++ b/topology/New Mexico State University/New Mexico State AggieGrid/NMSU_AGGIE_GRID.yaml
@@ -36,7 +36,7 @@ Resources:
         Details:
           hidden: false
   SLATE_US_NMSU_AGGIE_GRID:
-    Active: true
+    Active: false
     ID: 1097
     ContactLists:
       Administrative Contact:


### PR DESCRIPTION
The Aggie Grid cluster is being decommissioned so it needs to be removed, or disabled, in OSG.