### PR TITLE
Updating downtime for Georgia Tech for the upcoming quarterly maintenance period - February 9 - 11, 2022

### DIFF
--- a/topology/Georgia Institute of Technology/Georgia Tech/Georgia Tech PACE OSG 2_downtime.yaml
+++ b/topology/Georgia Institute of Technology/Georgia Tech/Georgia Tech PACE OSG 2_downtime.yaml
@@ -218,7 +218,7 @@
   - net.perfSONAR.Bandwidth
 # ---------------------------------------------------------
 - Class: SCHEDULED
-  ID: 997651549
+  ID: 997651569
   Description: 'Quarterly Maintenance '
   Severity: Outage
   StartTime: Feb 09, 2022 10:00 +0000
@@ -229,7 +229,7 @@
   - Submit Node
 # ---------------------------------------------------------
 - Class: SCHEDULED
-  ID: 997651550
+  ID: 997651570
   Description: 'Quarterly Maintenance '
   Severity: Outage
   StartTime: Feb 09, 2022 10:00 +0000
@@ -241,7 +241,7 @@
   - Squid
 # ---------------------------------------------------------
 - Class: SCHEDULED
-  ID: 997651551
+  ID: 997651571
   Description: 'Quarterly Maintenance '
   Severity: Outage
   StartTime: Feb 09, 2022 10:00 +0000
@@ -253,7 +253,7 @@
   - XRootD cache server
 # ---------------------------------------------------------
 - Class: SCHEDULED
-  ID: 997651552
+  ID: 997651572
   Description: 'Quarterly Maintenance '
   Severity: Outage
   StartTime: Feb 09, 2022 10:00 +0000

--- a/topology/Georgia Institute of Technology/Georgia Tech/Georgia Tech PACE OSG 2_downtime.yaml
+++ b/topology/Georgia Institute of Technology/Georgia Tech/Georgia Tech PACE OSG 2_downtime.yaml
@@ -217,3 +217,49 @@
   Services:
   - net.perfSONAR.Bandwidth
 # ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 997651549
+  Description: 'Quarterly Maintenance '
+  Severity: Outage
+  StartTime: Feb 09, 2022 10:00 +0000
+  EndTime: Feb 12, 2022 04:00 +0000
+  CreatedTime: Feb 07, 2022 13:04 +0000
+  ResourceName: Georgia_Tech_LIGO_Submit_2
+  Services:
+  - Submit Node
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 997651550
+  Description: 'Quarterly Maintenance '
+  Severity: Outage
+  StartTime: Feb 09, 2022 10:00 +0000
+  EndTime: Feb 12, 2022 04:00 +0000
+  CreatedTime: Feb 07, 2022 13:04 +0000
+  ResourceName: Georgia_Tech_PACE_CE_2
+  Services:
+  - CE
+  - Squid
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 997651551
+  Description: 'Quarterly Maintenance '
+  Severity: Outage
+  StartTime: Feb 09, 2022 10:00 +0000
+  EndTime: Feb 12, 2022 04:00 +0000
+  CreatedTime: Feb 07, 2022 13:04 +0000
+  ResourceName: Georgia_Tech_PACE_GridFTP2
+  Services:
+  - GridFtp
+  - XRootD cache server
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 997651552
+  Description: 'Quarterly Maintenance '
+  Severity: Outage
+  StartTime: Feb 09, 2022 10:00 +0000
+  EndTime: Feb 12, 2022 04:00 +0000
+  CreatedTime: Feb 07, 2022 13:04 +0000
+  ResourceName: Georgia_Tech_PACE_perfSONAR_BW
+  Services:
+  - net.perfSONAR.Bandwidth
+# ---------------------------------------------------------


### PR DESCRIPTION
Updating downtime for Georgia Tech for the upcoming quarterly maintenance period - February 9 - 11, 2022