### PR TITLE
Create a public namespace for XENON to work around authfile generation failure

### DIFF
--- a/virtual-organizations/XENON.yaml
+++ b/virtual-organizations/XENON.yaml
@@ -49,6 +49,8 @@ ReportingGroups:
 DataFederations:
   StashCache:
     Namespaces:
+      /xenon/PUBLIC:
+        - PUBLIC
       /xenon/PROTECTED:
         - SciTokens:
             Issuer: https://scitokens.org/osg-connect


### PR DESCRIPTION
Generating a public origin authfile fails if the origin doesn't serve any public data; this prevents starting up both the auth and the unauth instances of the origin.