### PR TITLE
Add SciToken issuer to Gluex VO

### DIFF
--- a/virtual-organizations/Gluex.yaml
+++ b/virtual-organizations/Gluex.yaml
@@ -15,6 +15,10 @@ Contacts:
   VO Manager:
   - ID: 650bf84a5cf49caf504fed22ce07b98580c6fa12
     Name: Richard T. Jones
+Credentials:
+  TokenIssuers:
+    - URL: https://zeus.phys.uconn.edu
+      DefaultUnixUser: gluex
 Disable: false
 FieldsOfScience:
   PrimaryFields:


### PR DESCRIPTION
Will use https://zeus.phys.uconn.edu as the issuer. Do not merge until https://zeus.phys.uconn.edu/.well-known/openid-configuration exists.