### PR TITLE
* correct the spelling of the stashcache origin, old name UConn-HPC_SE

### DIFF
--- a/virtual-organizations/Gluex.yaml
+++ b/virtual-organizations/Gluex.yaml
@@ -56,7 +56,7 @@ DataFederations:
     AllowedOrigins:
         # UConn-OSG_StashCache_origin serves /gluex/uconn0 (FD #68279)
         - UConn-OSG_StashCache_origin
-        # UConn-HPC_SE serves /gluex/uconn1 (FD #68279)
-        - UConn-HPC_SE
+        # UConn-HPC_StashCache_origin serves /gluex/uconn1 (FD #68279)
+        - UConn-HPC_StashCache_origin
     AllowedCaches:
         - ANY


### PR DESCRIPTION
  to new name UConn-HPC_StashCache_origin [rtj]