### PR TITLE
Update Cardiff cache - only LIGO VO

### DIFF
--- a/topology/Cardiff University/Cardiff Computing Cluster/CardiffPRPCachingInfrastructure.yaml
+++ b/topology/Cardiff University/Cardiff Computing Cluster/CardiffPRPCachingInfrastructure.yaml
@@ -23,4 +23,4 @@ Resources:
       XRootD cache server:
         Description: Cardiff PRP Caching Service
     AllowedVOs:
-      - ANY
+      - LIGO


### PR DESCRIPTION
As requested, Cardiff only allows LIGO VO.