### PR TITLE
Remove datetime input type ( SOFTWARE-5145 )

### DIFF
--- a/src/templates/generate_downtime_form.html.j2
+++ b/src/templates/generate_downtime_form.html.j2
@@ -68,8 +68,10 @@ Resource Downtime YAML Generator
         {{ render_dtfield(form.severity) }}
 
         {{ render_dtfield(form.utc_offset) }}
-        {{ render_dtfield(form.start_datetime) }}
-        {{ render_dtfield(form.end_datetime) }}
+        {{ render_dtfield(form.start_date) }}
+        {{ render_dtfield(form.start_time) }}
+        {{ render_dtfield(form.end_date) }}
+        {{ render_dtfield(form.end_time) }}
 
         {{ render_dtbutton(form.generate) }}
       </form>

--- a/src/templates/generate_resource_group_downtime_form.html.j2
+++ b/src/templates/generate_resource_group_downtime_form.html.j2
@@ -75,8 +75,10 @@ Resource Group Downtime YAML Generator
         {{ render_dtfield(form.severity) }}
 
         {{ render_dtfield(form.utc_offset) }}
-        {{ render_dtfield(form.start_datetime) }}
-        {{ render_dtfield(form.end_datetime) }}
+        {{ render_dtfield(form.start_date) }}
+        {{ render_dtfield(form.start_time) }}
+        {{ render_dtfield(form.end_date) }}
+        {{ render_dtfield(form.end_time) }}
 
         {{ render_dtbutton(form.generate) }}
       </form>

--- a/src/webapp/forms.py
+++ b/src/webapp/forms.py
@@ -1,7 +1,7 @@
 import datetime
 
 from flask_wtf import FlaskForm
-from wtforms.fields import SelectField, SelectMultipleField, StringField, \
+from wtforms import SelectField, SelectMultipleField, StringField, \
     TextAreaField, SubmitField
 from wtforms.fields.html5 import TimeField, DateField
 from wtforms.validators import InputRequired

--- a/src/webapp/forms.py
+++ b/src/webapp/forms.py
@@ -1,9 +1,9 @@
 import datetime
 
 from flask_wtf import FlaskForm
-from wtforms import SelectField, SelectMultipleField, StringField, \
-    TimeField, TextAreaField, SubmitField
-from wtforms.fields.html5 import DateTimeLocalField
+from wtforms.fields import SelectField, SelectMultipleField, StringField, \
+    TextAreaField, SubmitField
+from wtforms.fields.html5 import TimeField, DateField
 from wtforms.validators import InputRequired
 
 from . import models
@@ -132,8 +132,11 @@ class GenerateResourceGroupDowntimeForm(FlaskForm):
     ])
     description = StringField("Description (the reason and/or impact of the outage)", [InputRequired()])
 
-    start_datetime = DateTimeLocalField("Local Start Datetime", format='%Y-%m-%dT%H:%M', validators=[InputRequired()])
-    end_datetime = DateTimeLocalField("Local End Datetime", format='%Y-%m-%dT%H:%M', validators=[InputRequired()])
+    start_date = DateField("Local Start Date", validators=[InputRequired()])
+    start_time = TimeField("Local Start Time", validators=[InputRequired()])
+    end_date = DateField("Local End Date", validators=[InputRequired()])
+    end_time = TimeField("Local End Time", validators=[InputRequired()])
+
     utc_offset = SelectField("UTC Offset", choices=UTCOFFSET_CHOICES)
 
     facility = SelectField("Facility", choices=[], default="")
@@ -162,8 +165,8 @@ class GenerateResourceGroupDowntimeForm(FlaskForm):
 
         if not super().validate():
             return False
-        if self.start_datetime.data > self.end_datetime.data:
-            self.end_datetime.errors.append("End date/time must be after start date/time")
+        if self.get_start_datetime() > self.get_end_datetime():
+            self.end_date.errors.append("End date/time must be after start date/time")
             return False
 
         days_in_future = (self.get_start_datetime() - datetime.datetime.utcnow()).days
@@ -177,10 +180,14 @@ class GenerateResourceGroupDowntimeForm(FlaskForm):
         return True
 
     def get_start_datetime(self):
-        return self.start_datetime.data + datetime.timedelta(minutes=int(self.utc_offset.data))
+        return datetime.datetime.combine(
+            self.start_date.data, self.start_time.data
+        ) + datetime.timedelta(minutes=int(self.utc_offset.data))
 
     def get_end_datetime(self):
-        return self.end_datetime.data + datetime.timedelta(minutes=int(self.utc_offset.data))
+        return datetime.datetime.combine(
+            self.end_date.data, self.end_time.data
+        ) + datetime.timedelta(minutes=int(self.utc_offset.data))
 
     def get_yaml(self, resources, service_names_by_resource) -> str:
 
@@ -221,8 +228,11 @@ class GenerateDowntimeForm(FlaskForm):
     ])
     description = StringField("Description (the reason and/or impact of the outage)", [InputRequired()])
 
-    start_datetime = DateTimeLocalField("Local Start Datetime", format='%Y-%m-%dT%H:%M', validators=[InputRequired()])
-    end_datetime = DateTimeLocalField("Local End Datetime", format='%Y-%m-%dT%H:%M', validators=[InputRequired()])
+    start_date = DateField("Local Start Date", validators=[InputRequired()])
+    start_time = TimeField("Local Start Time", validators=[InputRequired()])
+    end_date = DateField("Local End Date", validators=[InputRequired()])
+    end_time = TimeField("Local End Time", validators=[InputRequired()])
+
     utc_offset = SelectField("UTC Offset", choices=UTCOFFSET_CHOICES)
 
     services = SelectMultipleField("Known OSG Services (select one or more)", [InputRequired()], choices=[])
@@ -251,8 +261,8 @@ class GenerateDowntimeForm(FlaskForm):
 
         if not super().validate():
             return False
-        if self.start_datetime.data > self.end_datetime.data:
-            self.end_datetime.errors.append("End date/time must be after start date/time")
+        if self.get_start_datetime() > self.get_end_datetime():
+            self.end_date.errors.append("End date/time must be after start date/time")
             return False
 
         days_in_future = (self.get_start_datetime() - datetime.datetime.utcnow()).days
@@ -266,10 +276,14 @@ class GenerateDowntimeForm(FlaskForm):
         return True
 
     def get_start_datetime(self):
-        return self.start_datetime.data + datetime.timedelta(minutes=int(self.utc_offset.data))
+        return datetime.datetime.combine(
+            self.start_date.data, self.start_time.data
+        ) + datetime.timedelta(minutes=int(self.utc_offset.data))
 
     def get_end_datetime(self):
-        return self.end_datetime.data + datetime.timedelta(minutes=int(self.utc_offset.data))
+        return datetime.datetime.combine(
+            self.end_date.data, self.end_time.data
+        ) + datetime.timedelta(minutes=int(self.utc_offset.data))
 
     def get_yaml(self) -> str:
 


### PR DESCRIPTION
Converted the datetime input into date and time inputs which are more broadly supported

I manually plugged in inputs into Chrome, Firefox, and Safari to test. 

Also confirmed wider support here -> https://caniuse.com/input-datetime