### PR TITLE
Add /virgo/virgo namespace to LIGO VO

### DIFF
--- a/virtual-organizations/LIGO.yaml
+++ b/virtual-organizations/LIGO.yaml
@@ -84,6 +84,8 @@ DataFederations:
         - SciTokens:
             Issuer: https://cilogon.org/ligo
             Base Path: /user/ligo
+      /user/virgo:
+        - "FQAN:/virgo"
       /gwdata:
         - PUBLIC
     AllowedOrigins:


### PR DESCRIPTION
If I understand correctly, this should add the "virgo:/virgo/virgo" VOMS subgroup to `cvmfs-x509-helper`.