### PR TITLE
Updating the DN for the stashcache node in Georgia Tech PACE 2

### DIFF
--- a/topology/Georgia Institute of Technology/Georgia Tech/Georgia Tech PACE OSG 2.yaml
+++ b/topology/Georgia Institute of Technology/Georgia Tech/Georgia Tech PACE OSG 2.yaml
@@ -73,7 +73,7 @@ Resources:
           Name: Semir Sarajlic
     Description: Second GridFTP server, initially for incoming LIGO, Icecube, CTA, OSG-Connect.
     FQDN: osg-gftp2.pace.gatech.edu
-    DN:  /DC=org/DC=incommon/C=US/ST=Georgia/L=Atlanta/O=Georgia Institute of Technology/OU=Office of Information Technology/CN=osg-gftp2.pace.gatech.edu
+    DN:  /DC=org/DC=incommon/C=US/ST=Georgia/O=Georgia Institute of Technology/OU=Office of Information Technology/CN=osg-gftp2.pace.gatech.edu
     ID: 1058
     Services:
       GridFtp:


### PR DESCRIPTION
The DN for osg-login2 did *not* change, this time around...