### PR TITLE
Remove perfsonar1.ihep.ufl.edu as it is not used

### DIFF
--- a/topology/University of Florida/UF HPC/UFlorida-HPC.yaml
+++ b/topology/University of Florida/UF HPC/UFlorida-HPC.yaml
@@ -72,48 +72,6 @@ Resources:
           endpoint: perfsonar2.rc.ufl.edu
     VOOwnership:
       CMS: 100
-  T2_Florida_LT:
-    Active: false
-    ContactLists:
-      Administrative Contact:
-        Primary:
-          ID: 8fe996dae2ee3abd17af9f8c0f57fa6d166be5ff
-          Name: University of Florida CMS Tier 2 Admins
-        Secondary:
-          ID: 2d9012f731159dd45a082164c6aac6577167e725
-          Name: Bockjoo Kim
-      Miscellaneous Contact:
-        Primary:
-          ID: 8fe996dae2ee3abd17af9f8c0f57fa6d166be5ff
-          Name: University of Florida CMS Tier 2 Admins
-        Secondary:
-          ID: 2d9012f731159dd45a082164c6aac6577167e725
-          Name: Bockjoo Kim
-      Resource Report Contact:
-        Primary:
-          ID: 8fe996dae2ee3abd17af9f8c0f57fa6d166be5ff
-          Name: University of Florida CMS Tier 2 Admins
-        Secondary:
-          ID: 2d9012f731159dd45a082164c6aac6577167e725
-          Name: Bockjoo Kim
-      Security Contact:
-        Primary:
-          ID: 8fe996dae2ee3abd17af9f8c0f57fa6d166be5ff
-          Name: University of Florida CMS Tier 2 Admins
-        Secondary:
-          ID: 2d9012f731159dd45a082164c6aac6577167e725
-          Name: Bockjoo Kim
-    Description: This is the perfSONAR-ps latency instance at the University of Florida
-      CMS T2 site.
-    FQDN: perfsonar1.ihepa.ufl.edu
-    ID: 606
-    Services:
-      net.perfSONAR.Latency:
-        Description: PerfSonar Latency monitoring node
-        Details:
-          endpoint: perfsonar1.ihepa.ufl.edu
-    VOOwnership:
-      CMS: 100
   T2_Florida_BW_IPv6:
     Active: false
     ContactLists:


### PR DESCRIPTION
The perfsonar is not used any more with its replacement perfsonar1.rc.ufl.edu.