### PR TITLE
Remove perfsonar1.ihepa.ufl.edu + cmsio.rc.ufl.edu

### DIFF
--- a/topology/University of Florida/UF HPC/UFlorida-HPC.yaml
+++ b/topology/University of Florida/UF HPC/UFlorida-HPC.yaml
@@ -72,48 +72,6 @@ Resources:
           endpoint: perfsonar2.rc.ufl.edu
     VOOwnership:
       CMS: 100
-  T2_Florida_LT:
-    Active: false
-    ContactLists:
-      Administrative Contact:
-        Primary:
-          ID: 8fe996dae2ee3abd17af9f8c0f57fa6d166be5ff
-          Name: University of Florida CMS Tier 2 Admins
-        Secondary:
-          ID: 2d9012f731159dd45a082164c6aac6577167e725
-          Name: Bockjoo Kim
-      Miscellaneous Contact:
-        Primary:
-          ID: 8fe996dae2ee3abd17af9f8c0f57fa6d166be5ff
-          Name: University of Florida CMS Tier 2 Admins
-        Secondary:
-          ID: 2d9012f731159dd45a082164c6aac6577167e725
-          Name: Bockjoo Kim
-      Resource Report Contact:
-        Primary:
-          ID: 8fe996dae2ee3abd17af9f8c0f57fa6d166be5ff
-          Name: University of Florida CMS Tier 2 Admins
-        Secondary:
-          ID: 2d9012f731159dd45a082164c6aac6577167e725
-          Name: Bockjoo Kim
-      Security Contact:
-        Primary:
-          ID: 8fe996dae2ee3abd17af9f8c0f57fa6d166be5ff
-          Name: University of Florida CMS Tier 2 Admins
-        Secondary:
-          ID: 2d9012f731159dd45a082164c6aac6577167e725
-          Name: Bockjoo Kim
-    Description: This is the perfSONAR-ps latency instance at the University of Florida
-      CMS T2 site.
-    FQDN: perfsonar1.ihepa.ufl.edu
-    ID: 606
-    Services:
-      net.perfSONAR.Latency:
-        Description: PerfSonar Latency monitoring node
-        Details:
-          endpoint: perfsonar1.ihepa.ufl.edu
-    VOOwnership:
-      CMS: 100
   T2_Florida_BW_IPv6:
     Active: false
     ContactLists:
@@ -260,46 +218,6 @@ Resources:
       KSI2KMax: 15600000
       KSI2KMin: 4800000
       StorageCapacityMax: 0
-      StorageCapacityMin: 0
-      TapeCapacity: 0
-  UFlorida-SLB-GridFTP:
-    Active: true
-    ContactLists:
-      Administrative Contact:
-        Primary:
-          ID: 8fe996dae2ee3abd17af9f8c0f57fa6d166be5ff
-          Name: University of Florida CMS Tier 2 Admins
-        Secondary:
-          ID: 2d9012f731159dd45a082164c6aac6577167e725
-          Name: Bockjoo Kim
-      Security Contact:
-        Primary:
-          ID: 8fe996dae2ee3abd17af9f8c0f57fa6d166be5ff
-          Name: University of Florida CMS Tier 2 Admins
-        Secondary:
-          ID: 2d9012f731159dd45a082164c6aac6577167e725
-          Name: Bockjoo Kim
-    Description: Simple Load Balance GridFTP server.
-    FQDN: cmsio.rc.ufl.edu
-    ID: 888
-    Services:
-      GridFtp:
-        Description: GridFtp Storage Element
-        Details:
-          hidden: false
-          uri_override: cmsio.rc.ufl.edu:2811
-    VOOwnership:
-      CMS: 100
-    WLCGInformation:
-      APELNormalFactor: 1
-      AccountingName: T2_US_Florida
-      HEPSPEC: 1
-      InteropAccounting: true
-      InteropBDII: true
-      InteropMonitoring: true
-      KSI2KMax: 1
-      KSI2KMin: 1
-      StorageCapacityMax: 616
       StorageCapacityMin: 0
       TapeCapacity: 0
   UFlorida-XRD:

--- a/topology/University of Florida/UF HPC/UFlorida-HPC_downtime.yaml
+++ b/topology/University of Florida/UF HPC/UFlorida-HPC_downtime.yaml
@@ -113,27 +113,6 @@
   StartTime: Nov 2, 2017 13:00 +0000
 # ----------------------------------------------------------
 - Class: UNSCHEDULED
-  Description: One of the Lustre OSSes requires a maintenance.
-  EndTime: Jan 4, 2018 17:00 +0000
-  ID: 1005549
-  ResourceName: UFlorida-SLB-GridFTP
-  Services:
-  - GridFtp
-  Severity: Outage
-  StartTime: Jan 4, 2018 14:00 +0000
-# ----------------------------------------------------------
-- Class: UNSCHEDULED
-  Description: One of lustre oss (cmsoss3) is not responsive. This causes a stall
-    in the entire site.
-  EndTime: Mar 9, 2018 16:00 +0000
-  ID: 1005620
-  ResourceName: UFlorida-SLB-GridFTP
-  Services:
-  - GridFtp
-  Severity: Outage
-  StartTime: Mar 9, 2018 14:00 +0000
-# ----------------------------------------------------------
-- Class: UNSCHEDULED
   Description: One of lustre oss (cmsoss3) is not responsive. This causes a stall
     in the entire site.
   EndTime: Mar 9, 2018 16:00 +0000
@@ -255,49 +234,6 @@
   - CE
   Severity: Outage
   StartTime: Sep 3, 2018 05:00 +0000
-# ----------------------------------------------------------
-- Class: UNSCHEDULED
-  Description: Network issue due to a switch that went bad.
-  EndTime: Sep 3, 2018 07:15 +0000
-  ID: 1005709
-  ResourceName: UFlorida-SLB-GridFTP
-  Services:
-  - GridFtp
-  Severity: Outage
-  StartTime: Sep 3, 2018 05:00 +0000
-# ----------------------------------------------------------
-- Class: UNSCHEDULED
-  ID: 53539069
-  Description: lustre hardware issue
-  Severity: Severe
-  StartTime: Oct 23, 2018 13:00 +0000
-  EndTime: Oct 23, 2018 21:00 +0000
-  CreatedTime: Oct 23, 2018 23:05 +0000
-  ResourceName: UFlorida-SLB-GridFTP
-  Services:
-  - GridFtp
-# ---------------------------------------------------------
-- Class: UNSCHEDULED
-  ID: 95610993
-  Description: lustre hardware issue
-  Severity: Outage
-  StartTime: Dec 12, 2018 15:00 +0000
-  EndTime: Dec 12, 2018 21:00 +0000
-  CreatedTime: Dec 11, 2018 14:44 +0000
-  ResourceName: UFlorida-SLB-GridFTP
-  Services:
-  - GridFtp
-# ---------------------------------------------------------
-- Class: UNSCHEDULED
-  ID: 144880518
-  Description: lustre CMSOSS3 issue
-  Severity: Outage
-  StartTime: Feb 06, 2019 15:00 +0000
-  EndTime: Feb 06, 2019 22:00 +0000
-  CreatedTime: Feb 06, 2019 15:20 +0000
-  ResourceName: UFlorida-SLB-GridFTP
-  Services:
-  - GridFtp
 # ---------------------------------------------------------
 - Class: SCHEDULED
   ID: 200132800
@@ -348,22 +284,6 @@
   - CE
 # ---------------------------------------------------------
 - Class: SCHEDULED
-  ID: 200134564
-  Description: "UFRC will carry out a major maintenance on 5/6 \u2013 5/9. As a result,\
-    \ HiPerGator cluster, home area, /ufrc, /orange as well as /apps will be out of\
-    \ service during this maintenance. User login servers will be down as well.    \
-    \ Though CMS servers including /cms will not be touched in this maintenance, other\
-    \ resources that CMS jobs may rely on will be unavailable therefore CMS jobs will\
-    \ not be able to run at the time. "
-  Severity: Outage
-  StartTime: May 06, 2019 13:00 +0000
-  EndTime: May 10, 2019 06:00 +0000
-  CreatedTime: Apr 11, 2019 15:10 +0000
-  ResourceName: UFlorida-SLB-GridFTP
-  Services:
-  - GridFtp
-# ---------------------------------------------------------
-- Class: SCHEDULED
   ID: 221825172
   Description: "UFRC will carry out a major maintenance on 5/6 \u2013 5/9. As a result,\
     \ HiPerGator cluster, home area, /ufrc, /orange as well as /apps will be out of\
@@ -378,17 +298,6 @@
   ResourceName: UFlorida-XRD
   Services:
   - XRootD component
-# ---------------------------------------------------------
-- Class: SCHEDULED
-  ID: 279906262
-  Description: Rack Rearrangement
-  Severity: Outage
-  StartTime: Jul 19, 2019 13:00 +0000
-  EndTime: Jul 19, 2019 21:00 +0000
-  CreatedTime: Jul 12, 2019 23:03 +0000
-  ResourceName: UFlorida-SLB-GridFTP
-  Services:
-  - GridFtp
 # ---------------------------------------------------------
 - Class: SCHEDULED
   ID: 279906848
@@ -488,28 +397,6 @@
   ResourceName: UFlorida-HPC
   Services:
   - CE
-# ---------------------------------------------------------
-- Class: UNSCHEDULED
-  ID: 409186425
-  Description: Hardware issue
-  Severity: Intermittent Outage
-  StartTime: Dec 09, 2019 13:00 +0000
-  EndTime: Dec 09, 2019 21:00 +0000
-  CreatedTime: Dec 10, 2019 04:00 +0000
-  ResourceName: UFlorida-SLB-GridFTP
-  Services:
-  - GridFtp
-# ---------------------------------------------------------
-- Class: UNSCHEDULED
-  ID: 431706818
-  Description: lustre hardware issue (Controller)
-  Severity: Outage
-  StartTime: Jan 04, 2020 13:00 +0000
-  EndTime: Jan 13, 2020 19:00 +0000
-  CreatedTime: Jan 04, 2020 14:44 +0000
-  ResourceName: UFlorida-SLB-GridFTP
-  Services:
-  - GridFtp
 # ---------------------------------------------------------
 - Class: UNSCHEDULED
   ID: 431707356
@@ -622,17 +509,6 @@
   - CE
 # ---------------------------------------------------------
 - Class: UNSCHEDULED
-  ID: 653881553
-  Description: Power outage
-  Severity: Outage
-  StartTime: Sep 17, 2020 15:00 +0000
-  EndTime: Sep 20, 2020 05:00 +0000
-  CreatedTime: Sep 17, 2020 19:15 +0000
-  ResourceName: UFlorida-SLB-GridFTP
-  Services:
-  - GridFtp
-# ---------------------------------------------------------
-- Class: UNSCHEDULED
   ID: 653881703
   Description: Power outage
   Severity: Outage
@@ -721,17 +597,6 @@
   - CE
 # ---------------------------------------------------------
 - Class: SCHEDULED
-  ID: 706481529
-  Description: Power work for the HPC upgrade
-  Severity: Outage
-  StartTime: Nov 18, 2020 23:00 +0000
-  EndTime: Nov 23, 2020 14:00 +0000
-  CreatedTime: Nov 17, 2020 15:22 +0000
-  ResourceName: UFlorida-SLB-GridFTP
-  Services:
-  - GridFtp
-# ---------------------------------------------------------
-- Class: SCHEDULED
   ID: 706481685
   Description: Power work for the HPC upgrade
   Severity: Outage
@@ -774,17 +639,6 @@
   ResourceName: UFlorida-HPG2
   Services:
   - CE
-# ---------------------------------------------------------
-- Class: SCHEDULED
-  ID: 718705534
-  Description: The major power construction work in the Data Center
-  Severity: Outage
-  StartTime: Dec 23, 2020 14:00 +0000
-  EndTime: Jan 11, 2021 04:00 +0000
-  CreatedTime: Dec 01, 2020 18:55 +0000
-  ResourceName: UFlorida-SLB-GridFTP
-  Services:
-  - GridFtp
 # ---------------------------------------------------------
 - Class: SCHEDULED
   ID: 718705707
@@ -851,17 +705,6 @@
   ResourceName: UFlorida-HPG2
   Services:
   - CE
-# ---------------------------------------------------------
-- Class: UNSCHEDULED
-  ID: 839686703
-  Description: Host certficate is expired
-  Severity: Outage
-  StartTime: Apr 20, 2021 23:00 +0000
-  EndTime: Apr 21, 2021 16:00 +0000
-  CreatedTime: Apr 21, 2021 01:31 +0000
-  ResourceName: UFlorida-SLB-GridFTP
-  Services:
-  - GridFtp
 # ---------------------------------------------------------
 - Class: UNSCHEDULED
   ID: 839686858


### PR DESCRIPTION
perfsonar1.rc.ufl.edu replaces perfsonar1.ihepa.ufl.edu and cmsio.rc.ufl.edu is decommissioned.