### PR TITLE
perfsonar1.rc.ufl.edu replaces cmps1.rc.ufl.edu

### DIFF
--- a/topology/University of Florida/UF HPC/UFlorida-HPC.yaml
+++ b/topology/University of Florida/UF HPC/UFlorida-HPC.yaml
@@ -72,34 +72,6 @@ Resources:
           endpoint: perfsonar2.rc.ufl.edu
     VOOwnership:
       CMS: 100
-  T2_Florida_BW_IPv6:
-    Active: false
-    ContactLists:
-      Administrative Contact:
-        Primary:
-          ID: 8fe996dae2ee3abd17af9f8c0f57fa6d166be5ff
-          Name: University of Florida CMS Tier 2 Admins
-        Secondary:
-          ID: 2d9012f731159dd45a082164c6aac6577167e725
-          Name: Bockjoo Kim
-      Security Contact:
-        Primary:
-          ID: 8fe996dae2ee3abd17af9f8c0f57fa6d166be5ff
-          Name: University of Florida CMS Tier 2 Admins
-        Secondary:
-          ID: 2d9012f731159dd45a082164c6aac6577167e725
-          Name: Bockjoo Kim
-    Description: This is the perfSONAR-ps bandwidth instance at the University of
-      Florida CMS T2 site for IPv6
-    FQDN: cmsps1.rc.ufl.edu
-    ID: 1020
-    Services:
-      net.perfSONAR.Bandwidth:
-        Description: PerfSonar Bandwidth monitoring node
-        Details:
-          endpoint: cmsps1.rc.ufl.edu
-    VOOwnership:
-      CMS: 100
   UFlorida-CMS:
     Active: true
     ContactLists:


### PR DESCRIPTION
cmsps1.rc.ufl.edu was decommissioned.