### PR TITLE
update SUT-OzStar.yaml with new host cert DN

### DIFF
--- a/topology/Swinburne University of Technology/SUT - OzStar/SUT-OzStar.yaml
+++ b/topology/Swinburne University of Technology/SUT - OzStar/SUT-OzStar.yaml
@@ -140,4 +140,4 @@ Resources:
         Description: StashCache cache server
     AllowedVOs:
       - LIGO
-    DN: /DC=com/DC=quovadisglobal/DC=grid/DC=auscert/DC=hosts/C=AU/ST=Victoria/L=Hawthorn/O=Swinburne University of Technology/OU=Information Technology Services/CN=ligo.hpc.swin.edu.au
+    DN: /CN=ligo.hpc.swin.edu.au


### PR DESCRIPTION
Swinburne's certificate issuer (quovadis) can no longer renew our grid cert, so we have switched to using Let's Encrypt, which does not include all the DN fields.

This is a possible cause of an authentication error with xrootd-local.unl.edu, so the stashcache cannot access files to serve.

The new subject line is:

 openssl x509 -in xrdcert.pem -noout -subject
subject= /CN=ligo.hpc.swin.edu.au