### PR TITLE
Supplement comanage data with contact db info (SOFTWARE-4734)

### DIFF
--- a/src/webapp/cilogon_ldap.py
+++ b/src/webapp/cilogon_ldap.py
@@ -66,10 +66,65 @@ def cilogon_id_map_to_yaml_data(m):
     return data
 
 
+def get_osgid_lookup(yaml_data):
+    osgid_lookup = {}
+    for id_, contact in yaml_data.items():
+        if 'CILogonID' in contact:
+            osgid_lookup[contact['CILogonID']] = contact
+    return osgid_lookup
+
+
+def get_email_lookup(yaml_data):
+    email_lookup = {}
+    for id_, contact in yaml_data.items():
+        ci = contact.get('ContactInformation')
+        if not ci:
+            continue
+        for Email in ('PrimaryEmail', 'SecondaryEmail'):
+            if Email in ci:
+                email_lookup[ci[Email]] = contact
+    return email_lookup
+
+
+def get_sup_contact(contact, osgid_lookup, email_lookup):
+    id_ = contact.get('CILogonID')
+    if id_ in osgid_lookup:
+        return osgid_lookup[id_]
+    ci = contact.get('ContactInformation')
+    if not ci:
+        return None
+    for Email in ('PrimaryEmail', 'SecondaryEmail'):
+        if Email in ci:
+            addr = ci[Email]
+            if addr in email_lookup:
+                return email_lookup[addr]
+    return None
+
+
+def supplement_contact_info(contact, sup_contact):
+    for k,v in sup_contact.items():
+        if k not in contact:
+            contact[k] = sup_contact
+        elif isinstance(k, dict):
+            for k2,v2 in v.items():
+                if k2 not in contact[k]:
+                    contact[k][k2] = v2
+
+
 def merge_yaml_data(yaml_data_main, yaml_data_secondary):
+    # main is comanage (cilogon), secondary is contact db
     yd = dict(yaml_data_main)
+    osgid_lookup = get_osgid_lookup(yaml_data_secondary)
+    email_lookup = get_email_lookup(yaml_data_secondary)
+
+    for contact in yd.values():
+        sup_contact = get_sup_contact(contact, osgid_lookup, email_lookup)
+        if sup_contact:
+            supplement_contact_info(contact, sup_contact)
+
     for id_, contact in yaml_data_secondary.items():
         if id_ not in yd:
             yd[id_] = contact
+
     return yd
 


### PR DESCRIPTION
`merge_yaml_data` used just to add the contact db items to the comanage contact data, as separate contacts; but we actually want to add the missing info to the comanage contacts themselves.

Per SOFTWARE-4734, we want to match on CILogonID, if possible, otherwise match on email address.  Primary or Secondary email from either source can match against either one in the other source.  (Sanity checks of the contact db data confirm for me that this is a safe thing to do.)

I've broken the work for this into a handful of smaller functions in order to help keep my sanity, though there is a growing feeling that all of these, essentially dict manipulation functions could cozily find themselves in a separate module, rather than with the proper cilogon ldap functions.  I'm open to suggestions if anyone has a strong feeling on that.