### PR TITLE
downtime tweak for automerge test (SOFTWARE-5216)

### DIFF
--- a/topology/University of Wisconsin/CHTC/CHTC-ITB_downtime.yaml
+++ b/topology/University of Wisconsin/CHTC/CHTC-ITB_downtime.yaml
@@ -1,6 +1,6 @@
 - Class: SCHEDULED
   ID: 1172965569
-  Description: SLURM upgrade.
+  Description: SLURM upgrade
   Severity: Outage
   StartTime: May 17, 2022 11:00 +0000
   EndTime: May 17, 2022 17:00 +0000


### PR DESCRIPTION
in particular, my contact IDs are now my CILogonID, but if everything is
working as we expect, osg-bot should accept and merge my downtime tweak
PR automatically.

This reverts commit 0107a25b86e646a0a40604477a348b25f11446aa.