### PR TITLE
Fix Base Path in the /ospool/PROTECTED namespace and add explanatory comment

### DIFF
--- a/virtual-organizations/OSG.yaml
+++ b/virtual-organizations/OSG.yaml
@@ -83,7 +83,8 @@ DataFederations:
       /ospool/PROTECTED:
         - SciTokens:
             Issuer: https://osg-htc.org/ospool
-            Base Path: /ospool/PROTECTED
+            # Base Path gets prepended to token scopes
+            Base Path: /
     AllowedOrigins:
       - OSGCONNECT_ORIGIN
       - CHTC_OSPOOL_ORIGIN


### PR DESCRIPTION
The token scopes already include "/ospool/PROTECTED"