### PR TITLE
Update BU_ATLAS_Tier2.yaml

### DIFF
--- a/topology/Boston University/Boston University ATLAS Tier2/BU_ATLAS_Tier2.yaml
+++ b/topology/Boston University/Boston University ATLAS Tier2/BU_ATLAS_Tier2.yaml
@@ -47,6 +47,51 @@ Resources:
       StorageCapacityMax: 5500
       StorageCapacityMin: 2300
       TapeCapacity: 0
+  NET2v6:
+    Active: true
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          ID: 4407ce51850137cf80f8e2f95829669b90fdba12
+          Name: Augustine Abaris
+        Secondary:
+          ID: 82375e645bdcae71e863c8a7aa7eb7f8cf553768
+          Name: Saul Youssef
+      Security Contact:
+        Primary:
+          ID: 4407ce51850137cf80f8e2f95829669b90fdba12
+          Name: Augustine Abaris
+        Secondary:
+          ID: 82375e645bdcae71e863c8a7aa7eb7f8cf553768
+          Name: Saul Youssef
+    Description: 'U.S. ATLAS Northeast Tier 2 Center: Boston University and Harvard
+      University'
+    FQDN: ne4.bu.edu
+    ID: 1308
+    Services:
+      CE:
+        Description: Compute Element
+        Details:
+          hidden: false
+      GridFtp:
+        Description: Gridftp Storage Element
+        Details:
+          hidden: false
+          uri_override: atlas.bu.edu:8443
+    VOOwnership:
+      ATLAS: 100
+    WLCGInformation:
+      APELNormalFactor: 14.00
+      AccountingName: US-NET2
+      HEPSPEC: 121754
+      InteropAccounting: true
+      InteropBDII: true
+      InteropMonitoring: true
+      KSI2KMax: 1
+      KSI2KMin: 1
+      StorageCapacityMax: 5500
+      StorageCapacityMin: 2300
+      TapeCapacity: 0
   net2.bu.edu-squid:
     Active: true
     ContactLists:


### PR DESCRIPTION
As suggested by Matyas Selmeci, I have copied the NET2 resource into "NET2v6", changing the FQDN and ID, but keeping everything else the same.  This is is meant to reflect adding a new ipv6 gatekeeper.  - Saul