### PR TITLE
BNL ATLAS GridFTP has been replaced by a WebDAV endpoint

### DIFF
--- a/topology/Brookhaven National Laboratory/BNL ATLAS Tier1/BNL-ATLAS.yaml
+++ b/topology/Brookhaven National Laboratory/BNL ATLAS Tier1/BNL-ATLAS.yaml
@@ -358,8 +358,8 @@ Resources:
     FQDN: dcgftp.usatlas.bnl.gov
     ID: 1089
     Services:
-      GridFtp:
-        Description: GridFtp service endpoint
+      WebDAV:
+        Description: WebDAV service endpoint
         Details:
           hidden: false
     VOOwnership:


### PR DESCRIPTION
Verified by @dougbenjamin 