### PR TITLE
Add missing AllowedVOs list to the Georgia_Tech_PACE-GridFTP resource…

### DIFF
--- a/topology/Georgia Institute of Technology/Georgia Tech/Georgia Tech PACE.yaml
+++ b/topology/Georgia Institute of Technology/Georgia Tech/Georgia Tech PACE.yaml
@@ -84,6 +84,8 @@ Resources:
           hidden: false
       XRootD cache server:
         Description: Georgia Tech Caching Server
+    AllowedVOs:
+      - LIGO
     VOOwnership:
       LIGO: 100
   Georgia_Tech_LIGO_Submit_1:


### PR DESCRIPTION
… (which is both a gridftp resource and a cache)

Spotted by Carl's code in #2557