### PR TITLE
Add downtime for SLATE_US_NMSU_DISCOVERY

### DIFF
--- a/topology/New Mexico State University/New Mexico State Discovery/NMSU_DISCOVERY_downtime.yaml
+++ b/topology/New Mexico State University/New Mexico State Discovery/NMSU_DISCOVERY_downtime.yaml
@@ -38,4 +38,14 @@
   ResourceName: SLATE_US_NMSU_DISCOVERY
   Services:
   - CE
+- Class: SCHEDULED
+  ID: 1243386217
+  Description: Standard Biannual Cluster Downtime
+  Severity: Outage
+  StartTime: Aug 01, 2022 14:00 +0000
+  EndTime: Aug 19, 2022 23:00 +0000
+  CreatedTime: Aug 01, 2022 07:23 +0000
+  ResourceName: SLATE_US_NMSU_DISCOVERY
+  Services:
+  - CE
 # ---------------------------------------------------------


### PR DESCRIPTION
Service will be down due to the backing Slurm cluster having it's biannual maintenance.  OSG downtime is extended an extra few days on top in case of complications.