### PR TITLE
Ignore check_runs which do not validate data (SOFTWARE-5272)

### DIFF
--- a/.github/workflows/validate-data.yml
+++ b/.github/workflows/validate-data.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 
 jobs:
   validate-data:
+    # 'name' must match TARGET_CHECK_RUN_NAME as defined in webhook_app.py
     name: Validate Topology data
     runs-on: ubuntu-latest
     steps:

--- a/src/webapp/github.py
+++ b/src/webapp/github.py
@@ -94,6 +94,9 @@ class GitHubAuth:
         return self.github_api_call('PUT', url, data)
         # 200 OK / 405 (not mergeable) / 409 (sha mismatch)
 
+    def get_api_url(url):
+        return self.github_api_call('GET', url, None)
+
     def target_repo(self, owner, repo):
         return GitHubRepoAPI(self, owner, repo)
 


### PR DESCRIPTION
otherwise osg-bot gets jumpy and tries to merge a suitable PR for every check_suite that succeeds - and now there are two that run for each PR (data and src).  We only want it to care about the one for the data checks.

...

A bit more complicated than expected because the check_suite name does not appear in the payload for the check_suite hook, so we need to follow an api url to grab the name of each check run for each check suite.  Ah well.