### PR TITLE
rename CHTC-EHT-EP -> CHTC-GPU-EP (SOFTWARE-5283)

### DIFF
--- a/topology/University of Wisconsin/CHTC/CHTC_OSPOOL.yaml
+++ b/topology/University of Wisconsin/CHTC/CHTC_OSPOOL.yaml
@@ -64,7 +64,7 @@ Resources:
         Description: OSPool Access Point
     Tags:
       - OSPool
-  CHTC-EHT-EP:
+  CHTC-GPU-EP:
     Active: true
     ContactLists:
       Administrative Contact:
@@ -84,8 +84,8 @@ Resources:
         Secondary:
           ID: OSG1000002
           Name: Matyas Selmeci
-    Description: OSPool A100 for EHT
-    FQDN: eht-ep.chtc.wisc.edu
+    Description: OSPool GPU A100 for EHT
+    FQDN: gpu-ep.chtc.wisc.edu
     ID: 1325
     Services:
       Execution Endpoint:


### PR DESCRIPTION
@bbockelm, updating per your comment [here](https://github.com/opensciencegrid/tiger-osg-config/pull/492#pullrequestreview-1063487723)

>2. In the topology registration, let's call it something non-EHT related. "Tiger-GPU-EP" or "CHTC-GPU-EP" would be good starters.

Is it correct that i am also updating the FQDN here?