### PR TITLE
Update DataFederations/StashCache data to use the new schema added in SOFTWARE-5179

### DIFF
--- a/virtual-organizations/CMS.yaml
+++ b/virtual-organizations/CMS.yaml
@@ -77,25 +77,12 @@ SupportURL: http://helpdesk.fnal.gov
 DataFederations:
   StashCache:
     Namespaces:
-      /store:
-        - FQAN:/cms
-        - SciTokens:
-            Issuer: https://scitokens.org/cms
-            Base Path: /
-            Restricted Path: /store
-    AllowedOrigins: []    # FIXME - Contact StashCache operations to find the resource(s) that should be allowed to serve data under /store
-    AllowedCaches: []    # Deny by default
-
-## SOFTWARE-5179 schema
-# DataFederations:
-#   StashCache:
-#     Namespaces:
-#       - Path: /store
-#         Authorizations:
-#           - FQAN: /cms
-#           - SciTokens:
-#               Issuer: https://scitokens.org/cms
-#               Base Path: /
-#               Restricted Path: /store
-#         AllowedOrigins: []    # FIXME - Contact StashCache operations to find the resource(s) that should be allowed to serve data under /store
-#         AllowedCaches: []    # Deny by default
+      - Path: /store
+        Authorizations:
+          - FQAN: /cms
+          - SciTokens:
+              Issuer: https://scitokens.org/cms
+              Base Path: /
+              Restricted Path: /store
+        AllowedOrigins: []    # FIXME - Contact StashCache operations to find the resource(s) that should be allowed to serve data under /store
+        AllowedCaches: []    # Deny by default

--- a/virtual-organizations/Fermilab.yaml
+++ b/virtual-organizations/Fermilab.yaml
@@ -84,19 +84,9 @@ SupportURL: http://fermigrid.fnal.gov/
 DataFederations:
   StashCache:
     Namespaces:
-      /pnfs/fnal.gov:
-        - PUBLIC
-    AllowedOrigins: []    # FIXME - Contact StashCache operations to find the resource(s) that should be allowed to serve data under /pnfs/fnal.gov
-    AllowedCaches:
-      - ANY
-
-## SOFTWARE-5179 schema
-# DataFederations:
-#   StashCache:
-#     Namespaces:
-#       - Path: /pnfs/fnal.gov
-#         Authorizations:
-#           - PUBLIC
-#         AllowedOrigins: []    # FIXME - Contact StashCache operations to find the resource(s) that should be allowed to serve data under /pnfs/fnal.gov
-#         AllowedCaches:
-#           - ANY
+      - Path: /pnfs/fnal.gov
+        Authorizations:
+          - PUBLIC
+        AllowedOrigins: []    # FIXME - Contact StashCache operations to find the resource(s) that should be allowed to serve data under /pnfs/fnal.gov
+        AllowedCaches:
+          - ANY

--- a/virtual-organizations/GLOW.yaml
+++ b/virtual-organizations/GLOW.yaml
@@ -47,48 +47,30 @@ PurposeURL: https://chtc.cs.wisc.edu/approach.shtml
 ReportingGroups:
 - glow
 SupportURL: https://chtc.cs.wisc.edu
-DataFederations:
-  StashCache:
-    Namespaces:
-      /chtc/PUBLIC:
-        - PUBLIC
-      /chtc/PROTECTED:
-        - FQAN:/GLOW
-        - DN:/DC=org/DC=cilogon/C=US/O=University of Wisconsin-Madison/CN=Matyas Selmeci A148276
-        - SciTokens:
-            Issuer: https://chtc.cs.wisc.edu
-            Base Path: /chtc
-    AllowedOrigins:
-      - CHTC_STASHCACHE_ORIGIN
-      - CHTC_STASHCACHE_ORIGIN_2000
-      - CHTC_STASHCACHE_ORIGIN_AUTH_2000
-    AllowedCaches:
-      - ANY
+ DataFederations:
+   StashCache:
+     Namespaces:
+       - Path: /chtc/PUBLIC
+         Authorizations:
+           - PUBLIC
+         AllowedOrigins:
+           - CHTC_STASHCACHE_ORIGIN
+           - CHTC_STASHCACHE_ORIGIN_2000
+         AllowedCaches:
+           - ANY
 
-## SOFTWARE-5179 schema
-# DataFederations:
-#   StashCache:
-#     Namespaces:
-#       - Path: /chtc/PUBLIC
-#         Authorizations:
-#           - PUBLIC
-#         AllowedOrigins:
-#           - CHTC_STASHCACHE_ORIGIN
-#           - CHTC_STASHCACHE_ORIGIN_2000
-#         AllowedCaches:
-#           - ANY
-#
-#       - Path: /chtc/PROTECTED
-#         Authorizations:
-#           - FQAN:/GLOW
-#           - DN:/DC=org/DC=cilogon/C=US/O=University of Wisconsin-Madison/CN=Matyas Selmeci A148276
-#           - SciTokens:
-#               Issuer: https://chtc.cs.wisc.edu
-#               Base Path: /chtc
-#               Map Subject: True
-#         AllowedOrigins:
-#           - CHTC_STASHCACHE_ORIGIN_AUTH_2000
-#         AllowedCaches:
-#           - CHTC_TIGER_CACHE
-#           - CHTC_STASHCACHE_CACHE
+       - Path: /chtc/PROTECTED
+         Authorizations:
+           - FQAN:/GLOW
+           - DN:/DC=org/DC=cilogon/C=US/O=University of Wisconsin-Madison/CN=Matyas Selmeci A148276
+           - SciTokens:
+               Issuer: https://chtc.cs.wisc.edu
+               Base Path: /chtc
+               Map Subject: True
+         AllowedOrigins:
+           - CHTC_STASHCACHE_ORIGIN_AUTH_2000
+         AllowedCaches:
+           # TODO: only allowing CHTC caches defeats the purpose of OSDF; allow PRP caches too?
+           - CHTC_TIGER_CACHE
+           - CHTC_STASHCACHE_CACHE
 

--- a/virtual-organizations/GLOW.yaml
+++ b/virtual-organizations/GLOW.yaml
@@ -47,30 +47,31 @@ PurposeURL: https://chtc.cs.wisc.edu/approach.shtml
 ReportingGroups:
 - glow
 SupportURL: https://chtc.cs.wisc.edu
- DataFederations:
-   StashCache:
-     Namespaces:
-       - Path: /chtc/PUBLIC
-         Authorizations:
-           - PUBLIC
-         AllowedOrigins:
-           - CHTC_STASHCACHE_ORIGIN
-           - CHTC_STASHCACHE_ORIGIN_2000
-         AllowedCaches:
-           - ANY
 
-       - Path: /chtc/PROTECTED
-         Authorizations:
-           - FQAN:/GLOW
-           - DN:/DC=org/DC=cilogon/C=US/O=University of Wisconsin-Madison/CN=Matyas Selmeci A148276
-           - SciTokens:
-               Issuer: https://chtc.cs.wisc.edu
-               Base Path: /chtc
-               Map Subject: True
-         AllowedOrigins:
-           - CHTC_STASHCACHE_ORIGIN_AUTH_2000
-         AllowedCaches:
-           # TODO: only allowing CHTC caches defeats the purpose of OSDF; allow PRP caches too?
-           - CHTC_TIGER_CACHE
-           - CHTC_STASHCACHE_CACHE
+DataFederations:
+ StashCache:
+   Namespaces:
+     - Path: /chtc/PUBLIC
+       Authorizations:
+         - PUBLIC
+       AllowedOrigins:
+         - CHTC_STASHCACHE_ORIGIN
+         - CHTC_STASHCACHE_ORIGIN_2000
+       AllowedCaches:
+         - ANY
+
+     - Path: /chtc/PROTECTED
+       Authorizations:
+         - FQAN:/GLOW
+         - DN:/DC=org/DC=cilogon/C=US/O=University of Wisconsin-Madison/CN=Matyas Selmeci A148276
+         - SciTokens:
+             Issuer: https://chtc.cs.wisc.edu
+             Base Path: /chtc
+             Map Subject: True
+       AllowedOrigins:
+         - CHTC_STASHCACHE_ORIGIN_AUTH_2000
+       AllowedCaches:
+         # TODO: only allowing CHTC caches defeats the purpose of OSDF; allow PRP caches too?
+         - CHTC_TIGER_CACHE
+         - CHTC_STASHCACHE_CACHE
 

--- a/virtual-organizations/Gluex.yaml
+++ b/virtual-organizations/Gluex.yaml
@@ -49,39 +49,23 @@ SupportURL: http://gryphn.phys.uconn.edu/UConn-OSG/support.html
 DataFederations:
   StashCache:
     Namespaces:
-      /Gluex:
-        - PUBLIC
-      /gluex:
-        - PUBLIC
-    AllowedOrigins:
-        # UConn-OSG_StashCache_origin serves /gluex/uconn0 (FD #68279)
-        - UConn-OSG_StashCache_origin
-        # UConn-HPC_StashCache_origin serves /gluex/uconn1 (FD #68279)
-        - UConn-HPC_StashCache_origin
-    AllowedCaches:
-        - ANY
-
-## SOFTWARE-5179 schema
-# DataFederations:
-#   StashCache:
-#     Namespaces:
-#       - Path: /Gluex
-#         Authorizations:
-#           - PUBLIC
-#         AllowedOrigins:
-#             # UConn-OSG_StashCache_origin serves /gluex/uconn0 (FD #68279)
-#             - UConn-OSG_StashCache_origin
-#             # UConn-HPC_StashCache_origin serves /gluex/uconn1 (FD #68279)
-#             - UConn-HPC_StashCache_origin
-#         AllowedCaches:
-#             - ANY
-#       - Path: /gluex
-#         Authorizations:
-#           - PUBLIC
-#         AllowedOrigins:
-#             # UConn-OSG_StashCache_origin serves /gluex/uconn0 (FD #68279)
-#             - UConn-OSG_StashCache_origin
-#             # UConn-HPC_StashCache_origin serves /gluex/uconn1 (FD #68279)
-#             - UConn-HPC_StashCache_origin
-#         AllowedCaches:
-#             - ANY
+      - Path: /Gluex
+        Authorizations:
+          - PUBLIC
+        AllowedOrigins:
+            # UConn-OSG_StashCache_origin serves /gluex/uconn0 (FD #68279)
+            - UConn-OSG_StashCache_origin
+            # UConn-HPC_StashCache_origin serves /gluex/uconn1 (FD #68279)
+            - UConn-HPC_StashCache_origin
+        AllowedCaches:
+            - ANY
+      - Path: /gluex
+        Authorizations:
+          - PUBLIC
+        AllowedOrigins:
+            # UConn-OSG_StashCache_origin serves /gluex/uconn0 (FD #68279)
+            - UConn-OSG_StashCache_origin
+            # UConn-HPC_StashCache_origin serves /gluex/uconn1 (FD #68279)
+            - UConn-HPC_StashCache_origin
+        AllowedCaches:
+            - ANY

--- a/virtual-organizations/HCC.yaml
+++ b/virtual-organizations/HCC.yaml
@@ -61,50 +61,31 @@ ReportingGroups:
 SupportURL: http://hcc.unl.edu/contact
 DataFederations:
   StashCache:
-    AllowedCaches:
-    - ANY
-    AllowedOrigins:
-    - HCC-Origin
-    - HCC-StashCache-Origin
     Namespaces:
-      /hcc/focusday:
-      - FQAN:/hcc
-      - DN:/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=bbockelm/CN=659869/CN=Brian Paul Bockelman
-      /hcc/PUBLIC:
-        - PUBLIC
-      /hcc/PROTECTED:
-        - SciTokens:
-            Issuer: https://scitokens.org/hcc
-            Base Path: /hcc
-
-## SOFTWARE-5179 schema
-# DataFederations:
-#   StashCache:
-#     Namespaces:
-#       - Path: /hcc/focusday
-#         Authorizations:
-#           - FQAN: /hcc
-#           - DN: /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=bbockelm/CN=659869/CN=Brian Paul Bockelman
-#         AllowedCaches:
-#         - ANY
-#         AllowedOrigins:
-#         - HCC-Origin
-#         - HCC-StashCache-Origin
-#       - Path: /hcc/PUBLIC
-#         Authorizations:
-#           - PUBLIC
-#         AllowedCaches:
-#         - ANY
-#         AllowedOrigins:
-#         - HCC-Origin
-#         - HCC-StashCache-Origin
-#       - Path: /hcc/PROTECTED
-#         Authorizations:
-#           - SciTokens:
-#               Issuer: https://scitokens.org/hcc
-#               Base Path: /hcc
-#         AllowedCaches:
-#         - ANY
-#         AllowedOrigins:
-#         - HCC-Origin
-#         - HCC-StashCache-Origin
+      - Path: /hcc/focusday
+        Authorizations:
+          - FQAN: /hcc
+          - DN: /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=bbockelm/CN=659869/CN=Brian Paul Bockelman
+        AllowedCaches:
+        - ANY
+        AllowedOrigins:
+        - HCC-Origin
+        - HCC-StashCache-Origin
+      - Path: /hcc/PUBLIC
+        Authorizations:
+          - PUBLIC
+        AllowedCaches:
+        - ANY
+        AllowedOrigins:
+        - HCC-Origin
+        - HCC-StashCache-Origin
+      - Path: /hcc/PROTECTED
+        Authorizations:
+          - SciTokens:
+              Issuer: https://scitokens.org/hcc
+              Base Path: /hcc
+        AllowedCaches:
+        - ANY
+        AllowedOrigins:
+        - HCC-Origin
+        - HCC-StashCache-Origin

--- a/virtual-organizations/IceCube.yaml
+++ b/virtual-organizations/IceCube.yaml
@@ -50,27 +50,10 @@ ReportingGroups:
 DataFederations:
   StashCache:
     Namespaces:
-      /icecube/PUBLIC:
-        - PUBLIC
-      # This path doesn't exist (nor does the issuer) but we need it to generate an acceptable scitokens.conf until SOFTWARE-4223 and/or SOFTWARE-4389 are done.
-      /icecube/PROTECTED:
-        - SciTokens:
-            Issuer: https://scitokens.org/icecube
-            Base Path: /icecube
-    AllowedCaches:
-      - ANY
-    AllowedOrigins:
-      - IceCube_StashCache_origin
-
-
-## SOFTWARE-5179 schema
-# DataFederations:
-#   StashCache:
-#     Namespaces:
-#       - Path: /icecube/PUBLIC
-#         Authorizations:
-#           - PUBLIC
-#         AllowedCaches:
-#           - ANY
-#         AllowedOrigins:
-#           - IceCube_StashCache_origin
+      - Path: /icecube/PUBLIC
+        Authorizations:
+          - PUBLIC
+        AllowedCaches:
+          - ANY
+        AllowedOrigins:
+          - IceCube_StashCache_origin

--- a/virtual-organizations/LIGO.yaml
+++ b/virtual-organizations/LIGO.yaml
@@ -72,88 +72,47 @@ ReportingGroups:
 DataFederations:
   StashCache:
     Namespaces:
-      /user/ligo:
-        - "FQAN:/osg/ligo"
-        - "FQAN:/virgo"
-        - "FQAN:/virgo/virgo"
-        - SciTokens:
-            Issuer: https://scitokens.org/ligo
-            Base Path: /user/ligo
-        - SciTokens:
-            Issuer: https://test.cilogon.org/ligo
-            Base Path: /user/ligo
-        - SciTokens:
-            Issuer: https://cilogon.org/ligo
-            Base Path: /user/ligo
-      /gwdata:
-        - PUBLIC
-    AllowedOrigins:
-      - CIT_LIGO_ORIGIN
-      - LIGO-StashCache-Origin
-      - UCL-Virgo-StashCache-Origin
-    AllowedCaches:
-      - SUT-STASHCACHE
-      - HCC-Stash
-      - Georgia_Tech_PACE_GridFTP2
-      - Stashcache-UCSD
-      - Stashcache-UofA
-      - Stashcache-Cardiff
-      - Stashcache-KISTI
-      - Stashcache-Houston
-      - Stashcache-Manhattan
-      - Stashcache-Sunnyvale
-      - Stashcache-Chicago
-      - Stashcache-Kansas
-      - T1_STASHCACHE_CACHE
-      - PIC_STASHCACHE_CACHE
-      - SU_STASHCACHE_CACHE
-      - PSU-LIGO-CACHE
-
-## SOFTWARE-5179 schema
-# DataFederations:
-#   StashCache:
-#     Namespaces:
-#       - Path: /user/ligo
-#         Authorizations:
-#           - FQAN: /osg/ligo
-#           - FQAN: /virgo
-#           - FQAN: /virgo/virgo
-#           - SciTokens:
-#               Issuer: https://scitokens.org/ligo
-#               Base Path: /user/ligo
-#           - SciTokens:
-#               Issuer: https://test.cilogon.org/ligo
-#               Base Path: /user/ligo
-#           - SciTokens:
-#               Issuer: https://cilogon.org/ligo
-#               Base Path: /user/ligo
-#         AllowedOrigins:
-#           - CIT_LIGO_ORIGIN
-#           - LIGO-StashCache-Origin
-#           - UCL-Virgo-StashCache-Origin
-#         AllowedCaches:
-#           - SUT-STASHCACHE
-#           - HCC-Stash
-#           - Georgia_Tech_PACE_GridFTP2
-#           - Stashcache-UCSD
-#           - Stashcache-UofA
-#           - Stashcache-Cardiff
-#           - Stashcache-KISTI
-#           - Stashcache-Houston
-#           - Stashcache-Manhattan
-#           - Stashcache-Sunnyvale
-#           - Stashcache-Chicago
-#           - Stashcache-Kansas
-#           - T1_STASHCACHE_CACHE
-#           - PIC_STASHCACHE_CACHE
-#           - SU_STASHCACHE_CACHE
-#           - PSU-LIGO-CACHE
-#       - Path: /gwdata
-#         Authorizations:
-#           - PUBLIC
-#         AllowedOrigins:
-#           - CIT_LIGO_ORIGIN
-#           - LIGO-StashCache-Origin
-#           - UCL-Virgo-StashCache-Origin
-#         AllowedCaches:
-#           - ANY
+      - Path: /user/ligo
+        Authorizations:
+          - FQAN: /osg/ligo
+          - FQAN: /virgo
+          - FQAN: /virgo/virgo
+          - SciTokens:
+              Issuer: https://scitokens.org/ligo
+              Base Path: /user/ligo
+          - SciTokens:
+              Issuer: https://test.cilogon.org/ligo
+              Base Path: /user/ligo
+          - SciTokens:
+              Issuer: https://cilogon.org/ligo
+              Base Path: /user/ligo
+        AllowedOrigins:
+          - CIT_LIGO_ORIGIN
+          - LIGO-StashCache-Origin
+          - UCL-Virgo-StashCache-Origin
+        AllowedCaches:
+          - SUT-STASHCACHE
+          - HCC-Stash
+          - Georgia_Tech_PACE_GridFTP2
+          - Stashcache-UCSD
+          - Stashcache-UofA
+          - Stashcache-Cardiff
+          - Stashcache-KISTI
+          - Stashcache-Houston
+          - Stashcache-Manhattan
+          - Stashcache-Sunnyvale
+          - Stashcache-Chicago
+          - Stashcache-Kansas
+          - T1_STASHCACHE_CACHE
+          - PIC_STASHCACHE_CACHE
+          - SU_STASHCACHE_CACHE
+          - PSU-LIGO-CACHE
+      - Path: /gwdata
+        Authorizations:
+          - PUBLIC
+        AllowedOrigins:
+          - CIT_LIGO_ORIGIN
+          - LIGO-StashCache-Origin
+          - UCL-Virgo-StashCache-Origin
+        AllowedCaches:
+          - ANY

--- a/virtual-organizations/OSG.yaml
+++ b/virtual-organizations/OSG.yaml
@@ -74,72 +74,48 @@ SupportURL: http://www.opensciencegrid.org
 DataFederations:
   StashCache:
     Namespaces:
-      /osdftest:
-        - PUBLIC
-      /user:
-        - PUBLIC
-      /osgconnect/public:
-        - PUBLIC
-      /osgconnect/collab:
-        - PUBLIC
-      /ospool/PROTECTED:
-        - SciTokens:
-            Issuer: https://osg-htc.org/ospool
-            # Base Path gets prepended to token scopes
-            Base Path: /ospool/PROTECTED
-    AllowedOrigins:
-      - OSGCONNECT_ORIGIN
-      - CHTC_OSPOOL_ORIGIN
-      - SDSC-test-Origin
-    AllowedCaches:
-      - ANY
-
-## SOFTWARE-5179 schema
-# DataFederations:
-#   StashCache:
-#     Namespaces:
-#       - Path: /user
-#         Authorizations:
-#           - PUBLIC
-#         AllowedOrigins:
-#           - OSGCONNECT_ORIGIN
-#           - CHTC_OSPOOL_ORIGIN
-#         AllowedCaches:
-#           - ANY
-#       - Path: /osgconnect/public
-#         Authorizations:
-#           - PUBLIC
-#         AllowedOrigins:
-#           - OSGCONNECT_ORIGIN
-#           - CHTC_OSPOOL_ORIGIN
-#         AllowedCaches:
-#           - ANY
-#         Writeback: https://stash-xrd.osgconnect.net:1094
-#       - Path: /osgconnect/collab
-#         Authorizations:
-#           - PUBLIC
-#         AllowedOrigins:
-#           - OSGCONNECT_ORIGIN
-#           - CHTC_OSPOOL_ORIGIN
-#         AllowedCaches:
-#           - ANY
-#       - Path: /ospool/PROTECTED
-#         Authorizations:
-#           - SciTokens:
-#               Issuer: https://osg-htc.org/ospool
-#               Base Path: /ospool/PROTECTED
-#               Map Subject: True
-#         AllowedOrigins:
-#           - OSGCONNECT_ORIGIN
-#           - CHTC_OSPOOL_ORIGIN
-#         AllowedCaches:
-#           - ANY
-#         Writeback: https://origin-auth2001.chtc.wisc.edu:1095
-#         DirList: https://origin-auth2001.chtc.wisc.edu:1095
-#       - Path: /osdftest
-#         Authorizations:
-#           - PUBLIC
-#         AllowedOrigins:
-#           - SDSC-test-Origin
-#         AllowedCaches:
-#           - ANY
+      - Path: /user
+        Authorizations:
+          - PUBLIC
+        AllowedOrigins:
+          - OSGCONNECT_ORIGIN
+          - CHTC_OSPOOL_ORIGIN
+        AllowedCaches:
+          - ANY
+      - Path: /osgconnect/public
+        Authorizations:
+          - PUBLIC
+        AllowedOrigins:
+          - OSGCONNECT_ORIGIN
+          - CHTC_OSPOOL_ORIGIN
+        AllowedCaches:
+          - ANY
+        Writeback: https://stash-xrd.osgconnect.net:1094
+      - Path: /osgconnect/collab
+        Authorizations:
+          - PUBLIC
+        AllowedOrigins:
+          - OSGCONNECT_ORIGIN
+          - CHTC_OSPOOL_ORIGIN
+        AllowedCaches:
+          - ANY
+      - Path: /ospool/PROTECTED
+        Authorizations:
+          - SciTokens:
+              Issuer: https://osg-htc.org/ospool
+              Base Path: /ospool/PROTECTED
+              Map Subject: True
+        AllowedOrigins:
+          - OSGCONNECT_ORIGIN
+          - CHTC_OSPOOL_ORIGIN
+        AllowedCaches:
+          - ANY
+        Writeback: https://origin-auth2001.chtc.wisc.edu:1095
+        DirList: https://origin-auth2001.chtc.wisc.edu:1095
+      - Path: /osdftest
+        Authorizations:
+          - PUBLIC
+        AllowedOrigins:
+          - SDSC-test-Origin
+        AllowedCaches:
+          - ANY

--- a/virtual-organizations/XENON.yaml
+++ b/virtual-organizations/XENON.yaml
@@ -49,34 +49,19 @@ ReportingGroups:
 DataFederations:
   StashCache:
     Namespaces:
-      /xenon/PUBLIC:
-        - PUBLIC
-      /xenon/PROTECTED:
-        - FQAN: /xenon.biggrid.nl
-        - DN: /DC=org/DC=cilogon/C=US/O=University of California-San Diego/CN=Kevin Coakley A183421
-        - DN: /DC=org/DC=cilogon/C=US/O=University of California-San Diego/CN=Danny Saba T51578603
-    AllowedCaches:
-      - RDS_AUTH_OSDF_CACHE
-    AllowedOrigins:
-      - RDS_OSDF_ORIGIN
-
-## SOFTWARE-5179 schema
-# DataFederations:
-#   StashCache:
-#     Namespaces:
-#       - Path: /xenon/PROTECTED
-#         Authorizations:
-#           - FQAN: /xenon.biggrid.nl
-#           - DN: /DC=org/DC=cilogon/C=US/O=University of California-San Diego/CN=Kevin Coakley A183421
-#           - DN: /DC=org/DC=cilogon/C=US/O=University of California-San Diego/CN=Danny Saba T51578603
-#         AllowedCaches:
-#           - RDS_AUTH_OSDF_CACHE
-#         AllowedOrigins:
-#           - RDS_OSDF_ORIGIN
-#       - Path: /xenon/PUBLIC
-#         Authorizations:
-#           - PUBLIC
-#         AllowedCaches:
-#           - ANY
-#         AllowedOrigins:
-#           - RDS_OSDF_ORIGIN
+      - Path: /xenon/PROTECTED
+        Authorizations:
+          - FQAN: /xenon.biggrid.nl
+          - DN: /DC=org/DC=cilogon/C=US/O=University of California-San Diego/CN=Kevin Coakley A183421
+          - DN: /DC=org/DC=cilogon/C=US/O=University of California-San Diego/CN=Danny Saba T51578603
+        AllowedCaches:
+          - RDS_AUTH_OSDF_CACHE
+        AllowedOrigins:
+          - RDS_OSDF_ORIGIN
+      - Path: /xenon/PUBLIC
+        Authorizations:
+          - PUBLIC
+        AllowedCaches:
+          - ANY
+        AllowedOrigins:
+          - RDS_OSDF_ORIGIN


### PR DESCRIPTION
This _does_ result in some output differences:

- Authfiles for caches not in the AllowedCaches list of a Namespace no longer allow access to data from that Namespace
  (instead of just not being able to obtain it from the origin)

- Authfiles for authenticated origin instances no longer allow access to public data they may have