### PR TITLE
Use James Hongs' COManage ID (FD#70290)

### DIFF
--- a/topology/University of Southern California/Center for Advanced Research Computing/USC-CARC-Artemis.yaml
+++ b/topology/University of Southern California/Center for Advanced Research Computing/USC-CARC-Artemis.yaml
@@ -14,11 +14,11 @@ Resources:
       Administrative Contact:
         Primary:
           Name: James Hong
-          ID: fd858d68a68b33617c327004061152291c9e42eb
+          ID: OSG1000133
       Security Contact:
         Primary:
           Name: James Hong
-          ID: fd858d68a68b33617c327004061152291c9e42eb
+          ID: OSG1000133
     FQDN: artemis-squid.carc.usc.edu
     Services:
       Squid:

--- a/topology/University of Southern California/Center for Advanced Research Computing/USC-CARC-Carina.yaml
+++ b/topology/University of Southern California/Center for Advanced Research Computing/USC-CARC-Carina.yaml
@@ -14,11 +14,11 @@ Resources:
       Administrative Contact:
         Primary:
           Name: James Hong
-          ID: fd858d68a68b33617c327004061152291c9e42eb
+          ID: OSG1000133
       Security Contact:
         Primary:
           Name: James Hong
-          ID: fd858d68a68b33617c327004061152291c9e42eb
+          ID: OSG1000133
     FQDN: ospool-backfill.carc.usc.edu
     Services:
       Execution Endpoint:
@@ -34,11 +34,11 @@ Resources:
       Administrative Contact:
         Primary:
           Name: James Hong
-          ID: fd858d68a68b33617c327004061152291c9e42eb
+          ID: OSG1000133
       Security Contact:
         Primary:
           Name: James Hong
-          ID: fd858d68a68b33617c327004061152291c9e42eb
+          ID: OSG1000133
     FQDN: carina-68-181-208-3.usc.edu
     Services:
       Squid:


### PR DESCRIPTION
If someone has a COManage ID, we should always prefer it since we have
services (e.g., OS Registry) that do lookups against COManage

@edquist I thought that this would "just work" with your merging COManage and Topology IDs work