### PR TITLE
Update MWT2.yaml to have current CPU power info.

### DIFF
--- a/topology/University of Chicago/MWT2 ATLAS UC/MWT2.yaml
+++ b/topology/University of Chicago/MWT2 ATLAS UC/MWT2.yaml
@@ -36,14 +36,14 @@ Resources:
     VOOwnership:
       ATLAS: 100
     WLCGInformation:
-      APELNormalFactor: 12.53
+      APELNormalFactor: 14.11
       AccountingName: US-MWT2
-      HEPSPEC: 308968
+      HEPSPEC: 589592
       InteropAccounting: false
       InteropBDII: false
       InteropMonitoring: false
-      KSI2KMax: 77242
-      KSI2KMin: 77242
+      KSI2KMax: 147398
+      KSI2KMin: 147398
       StorageCapacityMax: 0
       StorageCapacityMin: 0
       TapeCapacity: 0
@@ -115,14 +115,14 @@ Resources:
     VOOwnership:
       ATLAS: 100
     WLCGInformation:
-      APELNormalFactor: 12.53
+      APELNormalFactor: 14.11
       AccountingName: US-MWT2
-      HEPSPEC: 308968
+      HEPSPEC: 589592
       InteropAccounting: true
       InteropBDII: true
       InteropMonitoring: true
-      KSI2KMax: 77242
-      KSI2KMin: 77242
+      KSI2KMax: 147398
+      KSI2KMin: 147398
       StorageCapacityMax: 0
       StorageCapacityMin: 0
       TapeCapacity: 0
@@ -160,14 +160,14 @@ Resources:
     VOOwnership:
       ATLAS: 100
     WLCGInformation:
-      APELNormalFactor: 12.53
+      APELNormalFactor: 14.11
       AccountingName: US-MWT2
-      HEPSPEC: 308968
+      HEPSPEC: 589592
       InteropAccounting: true
       InteropBDII: true
       InteropMonitoring: true
-      KSI2KMax: 77242
-      KSI2KMin: 77242
+      KSI2KMax: 147398
+      KSI2KMin: 147398
       StorageCapacityMax: 0
       StorageCapacityMin: 0
       TapeCapacity: 0
@@ -205,14 +205,14 @@ Resources:
     VOOwnership:
       ATLAS: 100
     WLCGInformation:
-      APELNormalFactor: 12.53
+      APELNormalFactor: 14.11
       AccountingName: US-MWT2
-      HEPSPEC: 308968
+      HEPSPEC: 589592
       InteropAccounting: true
       InteropBDII: true
       InteropMonitoring: true
-      KSI2KMax: 77242
-      KSI2KMin: 77242
+      KSI2KMax: 147398
+      KSI2KMin: 147398
       StorageCapacityMax: 0
       StorageCapacityMin: 0
       TapeCapacity: 0
@@ -250,14 +250,14 @@ Resources:
     VOOwnership:
       ATLAS: 100
     WLCGInformation:
-      APELNormalFactor: 12.53
+      APELNormalFactor: 14.11
       AccountingName: US-MWT2
-      HEPSPEC: 308968
+      HEPSPEC: 589592
       InteropAccounting: true
       InteropBDII: true
       InteropMonitoring: true
-      KSI2KMax: 77242
-      KSI2KMin: 77242
+      KSI2KMax: 147398
+      KSI2KMin: 147398
       StorageCapacityMax: 0
       StorageCapacityMin: 0
       TapeCapacity: 0
@@ -296,14 +296,14 @@ Resources:
     VOOwnership:
       ATLAS: 100
     WLCGInformation:
-      APELNormalFactor: 12.53
+      APELNormalFactor: 14.11
       AccountingName: US-MWT2
-      HEPSPEC: 308968
+      HEPSPEC: 589592
       InteropAccounting: true
       InteropBDII: true
       InteropMonitoring: true
-      KSI2KMax: 77242
-      KSI2KMin: 77242
+      KSI2KMax: 147398
+      KSI2KMin: 147398
       StorageCapacityMax: 0
       StorageCapacityMin: 0
       TapeCapacity: 0


### PR DESCRIPTION
Updated APELNormalFactor, HEPSPEC, KSI2KMax, and KSI2KMin.  Changed for MWT2_CE, MWT2_CE_IU, MWT2_CE_IU2,MWT2_CE_UC, MWT2_CE_UC2, and MW2_CE_UIUC. NB: MW2_CE_UIUC is NOT in service so Active is set to false for MWT2_CE_UIUC.