### PR TITLE
* update the DN of the hosts in domain uconn.edu to drop the field

### DIFF
--- a/topology/University of Connecticut/UConn-HPC/UConn-HPC.yaml
+++ b/topology/University of Connecticut/UConn-HPC/UConn-HPC.yaml
@@ -19,7 +19,7 @@ Resources:
     FQDN: cn410.storrs.hpc.uconn.edu
     FQDNAliases:
     - osgce.storrs.hpc.uconn.edu
-    DN: /DC=org/DC=incommon/C=US/ST=Connecticut/L=Storrs/O=University of Connecticut/OU=Academic IT/CN=cn410.storrs.hpc.uconn.edu
+    DN: /DC=org/DC=incommon/C=US/ST=Connecticut/L=Storrs/O=University of Connecticut/CN=cn410.storrs.hpc.uconn.edu
     Services:
       Squid:
         Description: squid server for Storrs HPC cluster

--- a/topology/University of Connecticut/UConn-OSG/UConn-OSG.yaml
+++ b/topology/University of Connecticut/UConn-OSG/UConn-OSG.yaml
@@ -18,7 +18,7 @@ Resources:
     FQDN: gryphn.phys.uconn.edu
     FQDNAliases:
     - zeus.phys.uconn.edu
-    DN: /DC=org/DC=incommon/C=US/ST=Connecticut/L=Storrs/O=University of Connecticut/OU=Academic IT/CN=gryphn.phys.uconn.edu
+    DN: /DC=org/DC=incommon/C=US/ST=Connecticut/L=Storrs/O=University of Connecticut/CN=gryphn.phys.uconn.edu
     ID: 289
     Services:
       Squid:
@@ -150,7 +150,7 @@ Resources:
           Name: Richard T Jones
     Description: local UConn submit host to Gluex glideinWMS factory
     FQDN: gluex.phys.uconn.edu
-    DN: /DC=org/DC=incommon/C=US/ST=Connecticut/L=Storrs/O=University of Connecticut/OU=Academic IT/CN=gluex.phys.uconn.edu
+    DN: /DC=org/DC=incommon/C=US/ST=Connecticut/L=Storrs/O=University of Connecticut/CN=gluex.phys.uconn.edu
     FQDNAliases:
     - gluex.phys.uconn.edu
     ID: 998
@@ -185,7 +185,7 @@ Resources:
           Name: Richard T Jones
     Description: local UConn glideinWMS collector for Gluex
     FQDN: gremlin.phys.uconn.edu
-    DN: /DC=org/DC=incommon/C=US/ST=Connecticut/L=Storrs/O=University of Connecticut/OU=Academic IT/CN=gremlin.phys.uconn.edu
+    DN: /DC=org/DC=incommon/C=US/ST=Connecticut/L=Storrs/O=University of Connecticut/CN=gremlin.phys.uconn.edu
     FQDNAliases:
     - gremlin.phys.uconn.edu
     ID: 1268


### PR DESCRIPTION
  /OU=Academic IT, that no longer appears in the hostcert DN. [rtj]