### PR TITLE
retire TIGER-OSG-BACKFILL; add TIGER-OSG-BACKFILL-ITB

### DIFF
--- a/topology/University of Wisconsin/CHTC/CHTC-ITB.yaml
+++ b/topology/University of Wisconsin/CHTC/CHTC-ITB.yaml
@@ -332,3 +332,30 @@ Resources:
     AllowedVOs:
       - GLOW
       - OSG
+
+  TIGER-OSG-BACKFILL-ITB:
+    Active: true
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          ID: OSG1000003
+          Name: Brian Lin
+        Secondary:
+          ID: OSG1000002
+          Name: Matyas Selmeci
+        Tertiary:
+          ID: OSG1000007
+          Name: Carl Edquist
+      Security Contact:
+        Primary:
+          ID: OSG1000003
+          Name: Brian Lin
+        Secondary:
+          ID: OSG1000002
+          Name: Matyas Selmeci
+    Description: OSG VO backfill containers on the Tiger cluster
+    FQDN: tiger-osg-backfill-itb.osgdev.chtc.io
+    ID: 1342
+    Services:
+      Execution Endpoint:
+        Description: OSG VO backfill containers on the Tiger cluster

--- a/topology/University of Wisconsin/CHTC/CHTC-ITB.yaml
+++ b/topology/University of Wisconsin/CHTC/CHTC-ITB.yaml
@@ -334,7 +334,7 @@ Resources:
       - OSG
 
   TIGER-OSG-BACKFILL-ITB:
-    Active: true
+    Active: false
     ContactLists:
       Administrative Contact:
         Primary:
@@ -353,9 +353,9 @@ Resources:
         Secondary:
           ID: OSG1000002
           Name: Matyas Selmeci
-    Description: OSG VO backfill containers on the Tiger cluster
+    Description: OSG VO backfill containers on the Tiger cluster, serving the ITB pool
     FQDN: tiger-osg-backfill-itb.osgdev.chtc.io
     ID: 1342
     Services:
       Execution Endpoint:
-        Description: OSG VO backfill containers on the Tiger cluster
+        Description: OSG VO backfill containers on the Tiger cluster, serving the ITB pool

--- a/topology/University of Wisconsin/CHTC/CHTC.yaml
+++ b/topology/University of Wisconsin/CHTC/CHTC.yaml
@@ -606,7 +606,7 @@ Resources:
         Description: OSG VO backfill containers on the Tiger cluster, in the production namespace
 
   TIGER-OSG-BACKFILL:
-    Active: true
+    Active: false
     ContactLists:
       Administrative Contact:
         Primary:


### PR DESCRIPTION
The old TIGER-OSG-BACKFILL was originally set up for ITB but was serving prod jobs.

Per discussion in https://support.opensciencegrid.org/a/tickets/69078 we are going to retire than one and make a new one named more explicitly for ITB.