### PR TITLE
Add scheduled downtime for GLOW-OSG CE

### DIFF
--- a/topology/University of Wisconsin/GLOW/GLOW_downtime.yaml
+++ b/topology/University of Wisconsin/GLOW/GLOW_downtime.yaml
@@ -3006,4 +3006,14 @@
   Services:
   - net.perfSONAR.Latency
 # ---------------------------------------------------------
-
+- Class: SCHEDULED
+  ID: 1319973971
+  Description: Updating to OSG 3.6
+  Severity: Severe
+  StartTime: Oct 31, 2022 16:00 +0000
+  EndTime: Oct 31, 2022 22:00 +0000
+  CreatedTime: Oct 28, 2022 22:49 +0000
+  ResourceName: GLOW-OSG
+  Services:
+  - CE
+# ---------------------------------------------------------


### PR DESCRIPTION
Adding a scheduled downtime for the GLOW-OSG CE for the update to OSG 3.6 on Oct 31.