### PR TITLE
Adding scheduled downtime for GLOW-OSG for update

### DIFF
--- a/topology/University of Wisconsin/GLOW/GLOW_downtime.yaml
+++ b/topology/University of Wisconsin/GLOW/GLOW_downtime.yaml
@@ -3017,3 +3017,14 @@
   Services:
   - CE
 # ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 1322473108
+  Description: Updating to OSG 3.6
+  Severity: Intermittent Outage
+  StartTime: Nov 01, 2022 20:30 +0000
+  EndTime: Nov 02, 2022 22:00 +0000
+  CreatedTime: Oct 31, 2022 20:15 +0000
+  ResourceName: GLOW-OSG
+  Services:
+  - CE
+# ---------------------------------------------------------


### PR DESCRIPTION
Adding scheduled downtime for GLOW-OSG for updating to OSG 3.6. Update is taking longer than expected.