### PR TITLE
Added scheduled downtime for OSG 3.6 update to CE cnsgrid03

### DIFF
--- a/topology/University of Wisconsin/GLOW/GLOW_downtime.yaml
+++ b/topology/University of Wisconsin/GLOW/GLOW_downtime.yaml
@@ -3028,3 +3028,14 @@
   Services:
   - CE
 # ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 1324905254
+  Description: Updating to OSG 3.6
+  Severity: Intermittent Outage
+  StartTime: Nov 04, 2022 16:00 +0000
+  EndTime: Nov 04, 2022 21:00 +0000
+  CreatedTime: Nov 03, 2022 15:48 +0000
+  ResourceName: GLOW-CONDOR-CE
+  Services:
+  - CE
+# ---------------------------------------------------------


### PR DESCRIPTION
Added scheduled downtime for OSG 3.6 update to CE cmsgrid03 on Friday, Nov. 4.