### PR TITLE
Adding scheduled downtime for GLOW CE cmsgrid01

### DIFF
--- a/topology/University of Wisconsin/GLOW/GLOW_downtime.yaml
+++ b/topology/University of Wisconsin/GLOW/GLOW_downtime.yaml
@@ -3039,3 +3039,14 @@
   Services:
   - CE
 # ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 1328450191
+  Description: Updating to OSG 3.6
+  Severity: Intermittent Outage
+  StartTime: Nov 08, 2022 19:00 +0000
+  EndTime: Nov 08, 2022 23:00 +0000
+  CreatedTime: Nov 07, 2022 18:16 +0000
+  ResourceName: GLOW
+  Services:
+  - CE
+# ---------------------------------------------------------


### PR DESCRIPTION
Adding scheduled downtime for GLOW CE cmsgrid01 for OSG 3.6 update.