### PR TITLE
Update cache_config_whitelist.txt

### DIFF
--- a/src/tests/cache_config_whitelist.txt
+++ b/src/tests/cache_config_whitelist.txt
@@ -1,1 +1,2 @@
 # one item per line FQDN:port
+xrootd-local.unl.edu:1094


### PR DESCRIPTION
The xrootd-local.unl.edu:1094 is a origin used on CVMFS config. 