### PR TITLE
Adding scheduled downtime for CE cmsgrid02

### DIFF
--- a/topology/University of Wisconsin/GLOW/GLOW_downtime.yaml
+++ b/topology/University of Wisconsin/GLOW/GLOW_downtime.yaml
@@ -3050,3 +3050,14 @@
   Services:
   - CE
 # ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 1329428399
+  Description: Updating to OSG 3.6
+  Severity: Intermittent Outage
+  StartTime: Nov 09, 2022 21:30 +0000
+  EndTime: Nov 10, 2022 00:00 +0000
+  CreatedTime: Nov 08, 2022 21:27 +0000
+  ResourceName: GLOW-CMS
+  Services:
+  - CE
+# ---------------------------------------------------------


### PR DESCRIPTION
Adding scheduled downtime for GLOW-CMS CE cmsgrid02 to update to OSG 3.6.