### PR TITLE
LIGO: add new cilogon/igwn user token issuers

### DIFF
--- a/virtual-organizations/LIGO.yaml
+++ b/virtual-organizations/LIGO.yaml
@@ -79,6 +79,12 @@ DataFederations:
           - FQAN: /virgo
           - FQAN: /virgo/virgo
           - SciTokens:
+              Issuer: https://cilogon.org/igwn
+              Base Path: /user/ligo
+          - SciTokens:
+              Issuer: https://test.cilogon.org/igwn
+              Base Path: /user/ligo
+          - SciTokens:
               Issuer: https://scitokens.org/ligo
               Base Path: /user/ligo
           - SciTokens:


### PR DESCRIPTION
This PR closes #2747 by adding references to the new cilogon.org/igwn token issuers for the LIGO VO. These are used for user tokens, not pilot tokens.