### PR TITLE
Move webapp.common.generate_dn_hash() to a new file, x509.py

### DIFF
--- a/src/webapp/common.py
+++ b/src/webapp/common.py
@@ -4,13 +4,10 @@ import hashlib
 import json
 import os
 import re
-import shlex
 import subprocess
 import sys
 from typing import Any, Dict, List, Union, AnyStr, NewType, TypeVar
 from functools import wraps
-
-import asn1
 
 log = getLogger(__name__)
 
@@ -336,62 +333,6 @@ def support_cors(f):
         return response
 
     return wrapped
-
-
-__oid_map = {
-   "DC": "0.9.2342.19200300.100.1.25",
-   "OU": "2.5.4.11",
-   "CN": "2.5.4.3",
-   "O": "2.5.4.10",
-   "ST": "2.5.4.8",
-   "C": "2.5.4.6",
-   "L": "2.5.4.7",
-   "postalCode": "2.5.4.17",
-   "street": "2.5.4.9",
-   "emailAddress": "1.2.840.113549.1.9.1",
-   }
-
-
-def generate_dn_hash(dn: str) -> str:
-    """
-    Given a DN one-liner as commonly encoded in the grid world
-    (e.g., output of `openssl x509 -in $FILE -noout -subject`), run
-    the OpenSSL subject hash generation algorithm.
-
-    This is done by calculating the SHA-1 sum of the canonical form of the
-    X509 certificate's subject.  Formatting is a bit like this:
-
-    SEQUENCE:
-       SET:
-         SEQUENCE:
-           OID
-           UTF8String
-
-    All the UTF-8 values should be converted to lower-case and multiple
-    spaces should be replaced with a single space.  That is, "Foo  Bar"
-    should be substituted with "foo bar" for the canonical form.
-    """
-    dn_split_re = re.compile("/([A-Za-z]+)=")
-
-    encoder = asn1.Encoder()
-    encoder.start()
-    info = dn_split_re.split(dn)[1:]
-    for attr, val in zip(info[0::2], info[1::2]):
-        oid = __oid_map.get(attr)
-        if not oid:
-            raise ValueError("OID for attribute {} is not known.".format(attr))
-        encoder.enter(0x11)
-        encoder.enter(0x10)
-        encoder.write(oid, 0x06)
-        encoder.write(val.lower().encode("utf-8"), 0x0c)
-        encoder.leave()
-        encoder.leave()
-    output = encoder.output()
-    hash_obj = hashlib.sha1()
-    hash_obj.update(output)
-    digest = hash_obj.digest()
-    int_summary = digest[0] | digest[1] << 8 | digest[2] << 16 | digest[3] << 24
-    return "%08lx.0" % int_summary
 
 
 XROOTD_CACHE_SERVER = "XRootD cache server"

--- a/src/webapp/vos_data.py
+++ b/src/webapp/vos_data.py
@@ -5,7 +5,8 @@ from logging import getLogger
 from typing import Dict, List, Optional, Set, Tuple, Union
 
 from .common import Filters, ParsedYaml, VOSUMMARY_SCHEMA_URL, is_null, expand_attr_list, order_dict, escape, \
-    generate_dn_hash, XROOTD_CACHE_SERVER, XROOTD_ORIGIN_SERVER
+    XROOTD_CACHE_SERVER, XROOTD_ORIGIN_SERVER
+from .x509 import generate_dn_hash
 from .contacts_reader import ContactsData
 
 

--- a/src/webapp/x509.py
+++ b/src/webapp/x509.py
@@ -1,0 +1,59 @@
+import hashlib
+import re
+
+import asn1
+
+__oid_map = {
+   "DC": "0.9.2342.19200300.100.1.25",
+   "OU": "2.5.4.11",
+   "CN": "2.5.4.3",
+   "O": "2.5.4.10",
+   "ST": "2.5.4.8",
+   "C": "2.5.4.6",
+   "L": "2.5.4.7",
+   "postalCode": "2.5.4.17",
+   "street": "2.5.4.9",
+   "emailAddress": "1.2.840.113549.1.9.1",
+   }
+
+
+def generate_dn_hash(dn: str) -> str:
+    """
+    Given a DN one-liner as commonly encoded in the grid world
+    (e.g., output of `openssl x509 -in $FILE -noout -subject`), run
+    the OpenSSL subject hash generation algorithm.
+
+    This is done by calculating the SHA-1 sum of the canonical form of the
+    X509 certificate's subject.  Formatting is a bit like this:
+
+    SEQUENCE:
+       SET:
+         SEQUENCE:
+           OID
+           UTF8String
+
+    All the UTF-8 values should be converted to lower-case and multiple
+    spaces should be replaced with a single space.  That is, "Foo  Bar"
+    should be substituted with "foo bar" for the canonical form.
+    """
+    dn_split_re = re.compile("/([A-Za-z]+)=")
+
+    encoder = asn1.Encoder()
+    encoder.start()
+    info = dn_split_re.split(dn)[1:]
+    for attr, val in zip(info[0::2], info[1::2]):
+        oid = __oid_map.get(attr)
+        if not oid:
+            raise ValueError("OID for attribute {} is not known.".format(attr))
+        encoder.enter(0x11)
+        encoder.enter(0x10)
+        encoder.write(oid, 0x06)
+        encoder.write(val.lower().encode("utf-8"), 0x0c)
+        encoder.leave()
+        encoder.leave()
+    output = encoder.output()
+    hash_obj = hashlib.sha1()
+    hash_obj.update(output)
+    digest = hash_obj.digest()
+    int_summary = digest[0] | digest[1] << 8 | digest[2] << 16 | digest[3] << 24
+    return "%08lx.0" % int_summary


### PR DESCRIPTION
This lets you import webapp.common without having "asn1" installed, which is good because get-scitokens-mapfile uses webapp.common and asn1 isn't available as an RPM on EL7.