### PR TITLE
Revert "(Temporarily) deactivate old CHTC Stash Cache server"

### DIFF
--- a/topology/University of Wisconsin/CHTC/CHTC.yaml
+++ b/topology/University of Wisconsin/CHTC/CHTC.yaml
@@ -176,7 +176,7 @@ Resources:
       GLOW: 100
 
   CHTC_STASHCACHE_CACHE:
-    Active: false
+    Active: true
     Description: This is a StashCache cache server at UW.
     ID: 958
     ContactLists:


### PR DESCRIPTION
It's fixed now.

This reverts commit 4923fdaa73040008e9ac0ec42cdeb1decb25ef37.