### PR TITLE
Remove hadoop-osg.rcac.purdue.edu CE

### DIFF
--- a/topology/Purdue University/Purdue CMS/Purdue.yaml
+++ b/topology/Purdue University/Purdue CMS/Purdue.yaml
@@ -38,9 +38,9 @@ Resources:
       APELNormalFactor: 15.07
       AccountingName: T2_US_Purdue
       HEPSPEC: 3929
-      InteropAccounting: true
-      InteropBDII: true
-      InteropMonitoring: true
+      InteropAccounting: false
+      InteropBDII: false
+      InteropMonitoring: false
       KSI2KMax: 500
       KSI2KMin: 100
       StorageCapacityMax: 0


### PR DESCRIPTION
decommissioned, per FD 69928

@goughes can you confirm that hadoop-osg should be "retired".