### PR TITLE
Use an available version of Python for GHA workflows

### DIFF
--- a/.github/workflows/validate-caches.yml
+++ b/.github/workflows/validate-caches.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6.15
+          python-version: 3.9.15
       - name: Compare StashCache config lists
         run: |
           ./src/tests/diff_cache_configs.py

--- a/.github/workflows/validate-caches.yml
+++ b/.github/workflows/validate-caches.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.6.15
       - name: Compare StashCache config lists
         run: |
           ./src/tests/diff_cache_configs.py

--- a/.github/workflows/validate-code.yml
+++ b/.github/workflows/validate-code.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6.15
+          python-version: 3.9.15
       - name: Install packages
         run: |
           sudo apt-get update

--- a/.github/workflows/validate-code.yml
+++ b/.github/workflows/validate-code.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.6.15
       - name: Install packages
         run: |
           sudo apt-get update

--- a/.github/workflows/validate-data.yml
+++ b/.github/workflows/validate-data.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.6.15
       - name: Install packages
         run: |
           sudo apt-get update

--- a/.github/workflows/validate-data.yml
+++ b/.github/workflows/validate-data.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6.15
+          python-version: 3.9.15
       - name: Install packages
         run: |
           sudo apt-get update


### PR DESCRIPTION
Apparently the generic "3.6" was removed.