### PR TITLE
Add VO for Einstein Telescope

### DIFF
--- a/virtual-organizations/ET.yaml
+++ b/virtual-organizations/ET.yaml
@@ -1,0 +1,52 @@
+Name: ET
+LongName: Einstein Telescope
+AppDescription: The Einstein Telescope is a proposed underground infrastructure to host a third-generation, gravitational-wave observatory in Europe.
+Community: The Einstein Telescope Scientific Collaboration
+CertificateOnly: false
+ID: 228
+Contacts:
+  Administrative Contact:
+  - ID: f63b159d0c057f82bfe4929353ea943bc0792059
+    Name: Stefano Bagnasco
+  - ID: 7142b387956966f21dfcedf7fa4eef637c15837c
+    Name: Andres Tanasijczuk
+  Security Contact:
+  - ID: f63b159d0c057f82bfe4929353ea943bc0792059
+    Name: Stefano Bagnasco
+  - ID: 7142b387956966f21dfcedf7fa4eef637c15837c
+    Name: Andres Tanasijczuk
+  Registration Authority:
+  - ID: f63b159d0c057f82bfe4929353ea943bc0792059
+    Name: Stefano Bagnasco
+  - ID: 7142b387956966f21dfcedf7fa4eef637c15837c
+    Name: Andres Tanasijczuk
+  VO Manager:
+  - ID: f63b159d0c057f82bfe4929353ea943bc0792059
+    Name: Stefano Bagnasco
+  - ID: 7142b387956966f21dfcedf7fa4eef637c15837c
+    Name: Andres Tanasijczuk
+Disable: false
+FieldsOfScience:
+  PrimaryFields:
+  - Gravitational Physics
+  SecondaryFields:
+  - Astrophysics
+  - Physics
+  - Physics and astronomy
+PrimaryURL: http://www.et-gw.eu
+PurposeURL: http://www.et-gw.eu
+SupportURL: http://www.et-gw.eu
+OASIS:
+  UseOASIS: true
+  OASISRepoURLs:
+  - http://hcc-cvmfs-repo.unl.edu:8000/cvmfs/et-gw.osgstorage.org
+DataFederations:
+  StashCache:
+    Namespaces:
+      - Path: /et-gw/PUBLIC
+        Authorizations:
+          - PUBLIC
+        AllowedOrigins:
+          - UCLouvain-ET-OSDF-Origin
+        AllowedCaches:
+          - ANY


### PR DESCRIPTION
This pull request is to add a new VO for Einstein Telescope. The reason is, we would like to use OSDF + CVMFS to distribute simulated data for a Mock Data Challenge to computing centres in Europe. 

Einstein Telescope is a proposed third-generation gravitational waves interferometer in Europe. It is the counterpart of Cosmic Explorer in US. We got the green light from OSG director Frank Wuerthwein to use OSG's OSDF + CVMFS infrastructure. 

On the technical side, I discussed with @djw8605 and @ppaschos who agreed that adding a new CVMFS repository "et-gw.osgstorage.org" to the CVMFS server in Nebraska (the same server that is used to publish data in `ligo.osgstorage.org`) is not a problem, therefore I am adding the entry:
```
  OASISRepoURLs:
  - http://hcc-cvmfs-repo.unl.edu:8000/cvmfs/et-gw.osgstorage.org
```

I will install in the next days a public origin server in my university, which I anticipate it will be named `UCLouvain-ET-OSDF-Origin`.

Neither the origin server nor the CVMFS repository exist yet. I am adding them to this file in advance. If that is not ok, I can remove that information and add them latter.