### PR TITLE
Turn off production monitoring for gridgk08

### DIFF
--- a/topology/Brookhaven National Laboratory/BNL ATLAS Tier1/BNL-ATLAS.yaml
+++ b/topology/Brookhaven National Laboratory/BNL ATLAS Tier1/BNL-ATLAS.yaml
@@ -275,9 +275,9 @@ Resources:
       APELNormalFactor: 12.69
       AccountingName: BNL_ATLAS_1
       HEPSPEC: 0
-      InteropAccounting: true
-      InteropBDII: true
-      InteropMonitoring: true
+      InteropAccounting: false
+      InteropBDII: false
+      InteropMonitoring: false
       KSI2KMax: 0
       KSI2KMin: 0
       StorageCapacityMax: 0


### PR DESCRIPTION
As confirmed in FD 71291:
> gridgk08 is not being used in production, certainly not for ATLAS.  Back in April,... told me it had been used to serve jobs for BNL-LAKE queues in the past, but we were now keeping it in reserve for testing upgrades, etc.