### PR TITLE
Add new OSDF Origin resource for ET VO to UCL-INGRID.

### DIFF
--- a/topology/Universite catholique de Louvain/UCL-INGRID/UCL-INGRID.yaml
+++ b/topology/Universite catholique de Louvain/UCL-INGRID/UCL-INGRID.yaml
@@ -1,11 +1,11 @@
 Production: true
 SupportCenter: Self Supported
-GroupDescription: StashCache Origin in Louvain
+GroupDescription: OSDF Origins in Louvain
 GroupID: 1097
 Resources:
   UCL-Virgo-StashCache-Origin:
     Active: true
-    Description: Virgo StashCache Origin
+    Description: Virgo OSDF Origin
     ID: 1108
     ContactLists:
       Administrative Contact:
@@ -23,6 +23,28 @@ Resources:
     DN: /DC=org/DC=terena/DC=tcs/C=BE/ST=Brabant wallon/L=Louvain-la-Neuve/O=Universite catholique de Louvain/CN=ingrid-se09.cism.ucl.ac.be
     Services:
       XRootD origin server:
-        Description: Virgo StashCache Origin Server
+        Description: Virgo OSDF Origin Server
+    AllowedVOs:
+      - ANY
+  UCLouvain-ET-OSDF-Origin:
+    Active: true
+    Description: ET OSDF Origin
+    ID: 1359
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          Name: Andres Tanasijczuk
+          ID: 7142b387956966f21dfcedf7fa4eef637c15837c 
+        Secondary:
+          Name: Pavel Demin
+          ID: a1697df7d81a4fe12d6f156922ef6c7b82bd3479
+      Security Contact:
+        Primary:
+          Name: Pavel Demin
+          ID: a1697df7d81a4fe12d6f156922ef6c7b82bd3479 
+    FQDN: et-origin.cism.ucl.ac.be
+    Services:
+      XRootD origin server:
+        Description: ET OSDF Origin Server
     AllowedVOs:
       - ANY


### PR DESCRIPTION
This is to register a new origin server for the newly created ET VO. The origin will be a public one. My plan is to run it in a container on the same host machine that is currently running the private origin `UCL-Virgo-StashCache-Origin`. Therefore this new origin has the same DN and FQDN as the `UCL-Virgo-StashCache-Origin`  origin. I discussed this with @djw8605 who said this configuration should be ok and there should be no problem in having two origin resources with same DN and FQDN in topology.