### PR TITLE
Eliminate public s3 areas (SOFTWARE-5398)

### DIFF
--- a/virtual-organizations/OSG.yaml
+++ b/virtual-organizations/OSG.yaml
@@ -116,9 +116,9 @@ DataFederations:
       # for considerations.
 
       # NOTE: The SciTokens blocks for Issuer "https://osg-htc.org/ospool" must be the same
-      # between the paths /ospool/PROTECTED, /s3.amazonaws.com/us-east-1/PROTECTED, and
-      # /s3.amazonaws.com/us-west-1/PROTECTED below or we will see problems.  See
-      # c3524138ac8d46eee2a3c33cb75fac50acab41c4 for more information.
+      # between the paths /ospool/PROTECTED, /s3.amazonaws.com/us-east-1, and
+      # /s3.amazonaws.com/us-west-1 below or we will see problems.
+      # See c3524138ac8d46eee2a3c33cb75fac50acab41c4 for more information.
 
       - Path: /ospool/PROTECTED
         Authorizations:
@@ -133,7 +133,7 @@ DataFederations:
         Writeback: https://origin-auth2001.chtc.wisc.edu:1095
         DirList: https://origin-auth2001.chtc.wisc.edu:1095
 
-      - Path: /s3.amazonaws.com/us-east-1/PROTECTED
+      - Path: /s3.amazonaws.com/us-east-1
         Authorizations:
           - SciTokens:
               Issuer: https://osg-htc.org/ospool
@@ -146,7 +146,7 @@ DataFederations:
         Writeback: https://s3-us-east-1.osgdev.chtc.io:1095
         DirList: https://s3-us-east-1.osgdev.chtc.io:1095
 
-      - Path: /s3.amazonaws.com/us-west-1/PROTECTED
+      - Path: /s3.amazonaws.com/us-west-1
         Authorizations:
           - SciTokens:
               Issuer: https://osg-htc.org/ospool
@@ -164,21 +164,5 @@ DataFederations:
           - PUBLIC
         AllowedOrigins:
           - SDSC-test-Origin
-        AllowedCaches:
-          - ANY
-
-      - Path: /s3.amazonaws.com/us-east-1/PUBLIC
-        Authorizations:
-          - PUBLIC
-        AllowedOrigins:
-          - CHTC-ITB-S3-AWS-EAST-ORIGIN
-        AllowedCaches:
-          - ANY
-
-      - Path: /s3.amazonaws.com/us-west-1/PUBLIC
-        Authorizations:
-          - PUBLIC
-        AllowedOrigins:
-          - CHTC-ITB-S3-AWS-WEST-ORIGIN
         AllowedCaches:
           - ANY


### PR DESCRIPTION
The xrootd-s3 plugin expects:

/s3.amazonaws.com/<area>/<bucket>

So there's no way to separate public vs private data. Assume private data until we can get clarification from @bbockelm