### PR TITLE
Add CMB_Petravick symlink

### DIFF
--- a/projects/CMB_Petravick.yaml
+++ b/projects/CMB_Petravick.yaml
@@ -1,0 +1,1 @@
+Illinois_Petravick.yaml


### PR DESCRIPTION
Jobs have already been submitted with this project name so the GRACC needs to be able to find CMB_Petravick for payload record details