### PR TITLE
Remove the SWT2 gk10

### DIFF
--- a/topology/University of Texas Arlington/SWT2 ATLAS UTA/SWT2_CPB.yaml
+++ b/topology/University of Texas Arlington/SWT2 ATLAS UTA/SWT2_CPB.yaml
@@ -46,7 +46,7 @@ Resources:
       StorageCapacityMin: 5000
       TapeCapacity: 0
   SWT2_CPB_CE_2:
-    Active: true
+    Active: false
     ContactLists:
       Administrative Contact:
         Primary:
@@ -76,9 +76,9 @@ Resources:
       APELNormalFactor: 10.43
       AccountingName: US-SWT2
       HEPSPEC: 102816
-      InteropAccounting: true
-      InteropBDII: true
-      InteropMonitoring: true
+      InteropAccounting: false
+      InteropBDII: false
+      InteropMonitoring: false
       KSI2KMax: 2086
       KSI2KMin: 2086
       StorageCapacityMax: 5000


### PR DESCRIPTION
GK10 is inactive, and marked as such in CRIC.  I was informed by Frederick Luehring that it is a backup gk and not expected to generate usage records.  Turning off the usage record monitoring in that case.