### PR TITLE
Add IGWN CILogon issuer to scitokens mapfile

### DIFF
--- a/virtual-organizations/LIGO.yaml
+++ b/virtual-organizations/LIGO.yaml
@@ -41,6 +41,8 @@ Credentials:
   TokenIssuers:
     - URL: https://scitokens.org/ligo
       DefaultUnixUser: ligo
+    - URL: https://cilogon.org/igwn
+      DefaultUnixUser: ligo
 Disable: false
 FieldsOfScience:
   PrimaryFields:


### PR DESCRIPTION
Attn @astroclark... we can change this to map to the `igwn` user, but that would require sites that are using the default OSG scitokens mapfile to create a `igwn` service account on their cluster(s). Either way, sites not using the default mapfile will have to update their custom mapfiles with the new issuer (should be added rather than replacing the old mapping).