### PR TITLE
Revert "Add simple Prometheus update metrics"

### DIFF
--- a/requirements-apache.txt
+++ b/requirements-apache.txt
@@ -17,7 +17,6 @@ Jinja2>=2.11.3,<2.12
 ldap3>=2.6.1
 MarkupSafe<2.1
 # ^^ MarkupSafe stuck on 2.0.x due to removal of "soft_unicode" symbol
-prometheus-client>=0.15.0,<0.16
 python-dateutil>=2.7.3,<2.8
 python-gnupg
 PyYAML>=5.4.1,<5.5

--- a/requirements-rootless.txt
+++ b/requirements-rootless.txt
@@ -17,7 +17,6 @@ Jinja2>=2.11.3,<2.12
 ldap3>=2.6.1
 MarkupSafe<2.1
 # ^^ MarkupSafe stuck on 2.0.x due to removal of "soft_unicode" symbol
-prometheus-client>=0.15.0,<0.16
 python-dateutil>=2.7.3,<2.8
 python-gnupg
 PyYAML>=5.4.1,<5.5

--- a/src/app.py
+++ b/src/app.py
@@ -5,8 +5,6 @@ import csv
 import flask
 import flask.logging
 from flask import Flask, Response, make_response, request, render_template
-from werkzeug.middleware.dispatcher import DispatcherMiddleware
-from prometheus_client import make_wsgi_app
 from io import StringIO
 import logging
 import os
@@ -831,12 +829,6 @@ def _get_authorized():
 
     # If it gets here, then it is not authorized
     return default_authorized
-
-
-# Enable prometheus integration with the topology webapp
-app.wsgi_app = DispatcherMiddleware(app.wsgi_app, {
-    '/metrics': make_wsgi_app()
-})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Reverts opensciencegrid/topology#2899

We can't have a dependency on prometheus-client in models.py because models.py is also used by scripts that don't pip install stuff.