### PR TITLE
Update PATh origin FQDN (INF-639)

### DIFF
--- a/topology/University of Wisconsin/CHTC/PATh_facility.yaml
+++ b/topology/University of Wisconsin/CHTC/PATh_facility.yaml
@@ -49,8 +49,8 @@ Resources:
         Tertiary:
           ID: OSG1000001
           Name: Brian Bockelman
-    FQDN: path-origin.chtc.wisc.edu
-    DN: /CN=path-origin.chtc.wisc.edu
+    FQDN: path-origin.facility.path-cc.io
+    DN: /CN=path-origin.facility.path-cc.io
     ID: 1409
     Services:
       XRootD origin server:


### PR DESCRIPTION
chtc.wisc.edu isn't Tiger managed so we can't automatically get certs for it