### PR TITLE
Allow PATh issuer access to /ospool/PROTECTED (INF-406)

### DIFF
--- a/virtual-organizations/OSG.yaml
+++ b/virtual-organizations/OSG.yaml
@@ -129,7 +129,7 @@ DataFederations:
               Map Subject: True
           - SciTokens:
               Issuer: https://path-cc.io/
-              Base Path: /ospool/PROTECTED
+              Base Path: /ospool/PROTECTED,/path-facility/data
               Map Subject: True
         AllowedOrigins:
           - CHTC_OSPOOL_ORIGIN

--- a/virtual-organizations/OSG.yaml
+++ b/virtual-organizations/OSG.yaml
@@ -127,6 +127,10 @@ DataFederations:
               Issuer: https://osg-htc.org/ospool
               Base Path: /ospool/PROTECTED,/s3.amazonaws.com/us-east-1,/s3.amazonaws.com/us-west-1
               Map Subject: True
+          - SciTokens:
+              Issuer: https://path-cc.io/
+              Base Path: /ospool/PROTECTED
+              Map Subject: True
         AllowedOrigins:
           - CHTC_OSPOOL_ORIGIN
         AllowedCaches:

--- a/virtual-organizations/PATh.yaml
+++ b/virtual-organizations/PATh.yaml
@@ -67,7 +67,7 @@ DataFederations:
         Authorizations:
           - SciTokens:
               Issuer: https://path-cc.io/
-              Base Path: /path-facility/data
+              Base Path: /ospool/PROTECTED,/path-facility/data
               Map Subject: True
         AllowedOrigins:
           - CHTC-PATH-ORIGIN


### PR DESCRIPTION
This is required to provide a smooth transition to users on AP1, which is currently improperly configured with the OSPool issuer. With this change, we can do the following:

1.  Create a PATh issuer (INF-406)
2.  Update the AP1 local credmon scopes with both the relevant ospool and PATh....paths
3.  Replace the AP1 OSPool local issuer with the PATh issuer
4.  Coordinate with users to transition to the new PATh namespace
5.  Remove any OSPool bits from AP1 and revert this commit

I think this should be safe to add for `scitokens.conf` generation, even with the "enormous hack" bits that we have in for the demo