### PR TITLE
Move end of GT OSG PACE 2 downtime earlier

### DIFF
--- a/topology/Georgia Institute of Technology/Georgia Tech/Georgia Tech PACE OSG 2_downtime.yaml
+++ b/topology/Georgia Institute of Technology/Georgia Tech/Georgia Tech PACE OSG 2_downtime.yaml
@@ -406,7 +406,7 @@
   Description: Quarterly Maintenance
   Severity: Outage
   StartTime: Jan 31, 2023 11:00 +0000
-  EndTime: Feb 07, 2023 17:00 +0000
+  EndTime: Feb 02, 2023 16:00 +0000
   CreatedTime: Jan 23, 2023 20:40 +0000
   ResourceName: Georgia_Tech_LIGO_Submit_2
   Services:
@@ -417,7 +417,7 @@
   Description: Quarterly Maintenance
   Severity: Outage
   StartTime: Jan 31, 2023 11:00 +0000
-  EndTime: Feb 07, 2023 17:00 +0000
+  EndTime: Feb 02, 2023 16:00 +0000
   CreatedTime: Jan 23, 2023 20:40 +0000
   ResourceName: Georgia_Tech_PACE_CE_2
   Services:
@@ -429,7 +429,7 @@
   Description: Quarterly Maintenance
   Severity: Outage
   StartTime: Jan 31, 2023 11:00 +0000
-  EndTime: Feb 07, 2023 17:00 +0000
+  EndTime: Feb 02, 2023 16:00 +0000
   CreatedTime: Jan 23, 2023 20:40 +0000
   ResourceName: Georgia_Tech_PACE_GridFTP2
   Services:
@@ -441,7 +441,7 @@
   Description: Quarterly Maintenance
   Severity: Outage
   StartTime: Jan 31, 2023 11:00 +0000
-  EndTime: Feb 07, 2023 17:00 +0000
+  EndTime: Feb 02, 2023 16:00 +0000
   CreatedTime: Jan 23, 2023 20:40 +0000
   ResourceName: Georgia_Tech_PACE_perfSONAR_BW
   Services:


### PR DESCRIPTION
Maintenance activities on the Buzzard cluster finished earlier than we originally thought, move the end of downtime forward to Feb 02, 11am EST.