### PR TITLE
Enabling T1_STASHCACHE_CACHE to LIGO

### DIFF
--- a/virtual-organizations/LIGO.yaml
+++ b/virtual-organizations/LIGO.yaml
@@ -116,6 +116,7 @@ DataFederations:
           - NEBRASKA_NRP_OSDF_CACHE
           - CINCINNATI_INTERNET2_OSDF_CACHE
           - BOISE_INTERNET2_OSDF_CACHE
+          - T1_STASHCACHE_CACHE
       - Path: /gwdata
         Authorizations:
           - PUBLIC


### PR DESCRIPTION
The cache T1_STASHCACHE_CACHE is updated to OSG 3.6. Now we need to test it. 