### PR TITLE
Deactivated Kent St. until ready

### DIFF
--- a/topology/Kent State University/Kent State Research/Kent_State_Research.yaml
+++ b/topology/Kent State University/Kent State Research/Kent_State_Research.yaml
@@ -5,7 +5,7 @@ Production: true
 SupportCenter: Self Supported
 Resources:
   KENT-STATE-RESEARCH-EP:
-    Active: true
+    Active: false
     ContactLists:
       Administrative Contact:
         Primary:


### PR DESCRIPTION
Kent State University is in the process of integrating their compute capacity into the OSPool, but are not there yet.[1] By our own instructions in the commented-up Topology template, a Resource should be marked as `Active: false` until it is actually ready.[2] So, this commit sets Kent State to inactive for now. This change is in part driven by Miron looking at the map of CC* sites, which is based on Topology entries; thus, we should not be showing Kent State quite yet.

[1] https://support.opensciencegrid.org/a/tickets/71868
[2] https://github.com/opensciencegrid/topology/blob/99f0abde2e759e58c8e246b97c96b2f6877b6361/template-resourcegroup.yaml#L22