### PR TITLE
Specify DirList in ET's public namespace

### DIFF
--- a/virtual-organizations/ET.yaml
+++ b/virtual-organizations/ET.yaml
@@ -50,3 +50,4 @@ DataFederations:
           - UCLouvain-ET-OSDF-Origin
         AllowedCaches:
           - ANY
+        DirList: http://et-origin.cism.ucl.ac.be:1094


### PR DESCRIPTION
I am adding the `DirList` option to the ET (public) namespace, because I was told (by @djw8605) that this is needed in order for the recursive copy (and listing) of a directory with `stashcp` to work.