### PR TITLE
Origins need to support a specific VO (FD#71771)

### DIFF
--- a/topology/University of Utah/Utah-SCI-VDC/Utah-SCI-VDC-ITB.yaml
+++ b/topology/University of Utah/Utah-SCI-VDC/Utah-SCI-VDC-ITB.yaml
@@ -23,4 +23,4 @@ Resources:
       XRootD origin server:
         Description: SCI VDC OSDF Origin Server
     AllowedVOs:
-      - ANY
+      - VDC


### PR DESCRIPTION
Otherwise they get the following from the Topology endpoint


> https://topology.opensciencegrid.org/origin/Authfile?fqdn=osg-sci1.datacollaboratory.org
>
> Error generating authfile for this FQDN: Origin does not support any namespaces Please check configuration in OSG topology or contact help@opensciencegrid.org