### PR TITLE
Allow and prefer spaceless versions of the SciTokens auth type keys

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -279,9 +279,11 @@ There are three kinds of authorization types:
 
       - SciTokens:
           Issuer: https://chtc.cs.wisc.edu
-          Base Path: /chtc
-          Restricted Path: /PROTECTED/matyas,/PROTECTED/bbockelm
-          Map Subject: True
+          BasePath: /chtc
+          RestrictedPath: /PROTECTED/matyas,/PROTECTED/bbockelm
+          MapSubject: True
+
+  (for backwards compat, `Base Path`, `Restricted Path`, and `Map Subject` are also accepted)
 
   This results in an issuer block that looks like
 
@@ -293,8 +295,8 @@ There are three kinds of authorization types:
 
   See [the XrdSciTokens readme](https://github.com/xrootd/xrootd/tree/master/src/XrdSciTokens#readme) for a reference of what these mean.
  
-  `Restricted Path` is optional (and rarely set); it is omitted if not specified. 
-  `Map Subject` is optional and defaults to `false` if not specified.
+  `RestrictedPath` is optional (and rarely set); it is omitted if not specified. 
+  `MapSubject` is optional and defaults to `false` if not specified.
   It is only used in scitokens.cfg for the origin.
 
 ```yaml

--- a/src/webapp/data_federation.py
+++ b/src/webapp/data_federation.py
@@ -130,15 +130,15 @@ def _parse_authz_scitokens(attributes: Dict, authz: Dict) -> Tuple[AuthMethod, O
     issuer = attributes.get("Issuer")
     if not issuer:
         errors += "'Issuer' missing or empty; "
-    base_path = attributes.get("Base Path")
+    base_path = attributes.get("BasePath", attributes.get("Base Path"))
     if not base_path:
-        errors += "'Base Path' missing or empty; "
-    restricted_path = attributes.get("Restricted Path", None)
+        errors += "'BasePath' missing or empty; "
+    restricted_path = attributes.get("RestrictedPath", attributes.get("Restricted Path", None))
     if restricted_path and not isinstance(restricted_path, str):
-        errors += "'Restricted Path' not a string; "
-    map_subject = attributes.get("Map Subject", False)
+        errors += "'RestrictedPath' not a string; "
+    map_subject = attributes.get("MapSubject", attributes.get("Map Subject", False))
     if not isinstance(map_subject, bool):
-        errors += "'Map Subject' not a boolean; "
+        errors += "'MapSubject' not a boolean; "
     if errors:
         errors = errors[:-2]  # chop off last '; '
         return NullAuth(), f"Invalid SciTokens auth {authz}: {errors}"


### PR DESCRIPTION
"BasePath" instead of "Base Path", "RestrictedPath" instead of "Restricted Path", "MapSubject" instead of "Map Subject" This makes those attributes more consistent with the attribute names everywhere else in the file. The old names are still supported.