### PR TITLE
Need to extend the downtime

### DIFF
--- a/topology/University of Florida/UF HPC/UFlorida-HPC_downtime.yaml
+++ b/topology/University of Florida/UF HPC/UFlorida-HPC_downtime.yaml
@@ -810,7 +810,7 @@
   Description: RHEL8 upgrade
   Severity: Outage
   StartTime: Jan 09, 2023 18:05 +0000
-  EndTime: Apr 05, 2023 18:06 +0000
+  EndTime: Jul 05, 2023 18:06 +0000
   CreatedTime: Jan 09, 2023 18:06 +0000
   ResourceName: UFlorida-HPC
   Services:


### PR DESCRIPTION
Per Florida Research Computing, the downtime needs to be extended to allow their automation scheme.