### PR TITLE
Add HEPScore23Percentage to WLCGInformation

### DIFF
--- a/src/schema/rgsummary.xsd
+++ b/src/schema/rgsummary.xsd
@@ -151,6 +151,7 @@
                                 <xsd:element name="StorageCapacityMax" type="xsd:string"/>
                                 <xsd:element name="HEPSPEC" type="xsd:string" />
                                 <xsd:element minOccurs="0" name="APELNormalFactor" type="xsd:string" />
+                                <xsd:element minOccurs="0" name="HEPScore23Percentage" type="xsd:string" />
                                 <xsd:element name="TapeCapacity" type="xsd:string"/>
                               </xsd:sequence>
                             </xsd:complexType>

--- a/template-resourcegroup.yaml
+++ b/template-resourcegroup.yaml
@@ -122,6 +122,7 @@ Resources:
     ### WLCGInformation (optional) is only for resources that are part of the WLCG
     # WLCGInformation:
     #   APELNormalFactor: 0.0
+    #   HEPScore23Percentage: 0.0
     #   AccountingName: <name>
     #   HEPSPEC: 0
     #   InteropAccounting: true


### PR DESCRIPTION
HEPScore23Percentage is the percentage of the resource that has been benchmarked with HEPScore23 benchmark, the new benchmark for HEP.  Initially, it would be 0.  Sites will set this to the percent of their resources benchmarked with the new benchmark.   Since the old benchmark (HEPSPEC) and the new (HEPScore23) have a 1 to 1 normalization factor, no changes to the APELNormalFactor are required.

How the percentage of a resource is defined, it left as an exercise for the reader.  Percent of Cores?  Percent of job slots?  Percent of Memory?