### PR TITLE
Add downtime for USCMS-FNAL-WC1-CE3

### DIFF
--- a/topology/Fermi National Accelerator Laboratory/FNAL USCMS Tier1/USCMS-FNAL-WC1_downtime.yaml
+++ b/topology/Fermi National Accelerator Laboratory/FNAL USCMS Tier1/USCMS-FNAL-WC1_downtime.yaml
@@ -859,6 +859,16 @@
   Services:
   - SRMv2
 # ---------------------------------------------------------
-
+- Class: SCHEDULED
+  ID: 1456251254
+  Description: Replacing the CE hardware
+  Severity: Outage
+  StartTime: Apr 07, 2023 23:00 +0000
+  EndTime: Apr 12, 2023 20:00 +0000
+  CreatedTime: Apr 04, 2023 16:18 +0000
+  ResourceName: USCMS-FNAL-WC1-CE3
+  Services:
+  - CE
+# ---------------------------------------------------------
 
 


### PR DESCRIPTION
Hardware is being replaced on April 10. Two day buffer before April 10 to drain the CE properly and one day afterwards for unexpected suprises