### PR TITLE
authorize /virgo/ligo FQAN to access /user/ligo and /igwn/virgo namespaces

### DIFF
--- a/virtual-organizations/LIGO.yaml
+++ b/virtual-organizations/LIGO.yaml
@@ -78,6 +78,7 @@ DataFederations:
           - FQAN: /osg/ligo
           - FQAN: /virgo
           - FQAN: /virgo/virgo
+          - FQAN: /virgo/ligo
           - SciTokens:
               Issuer: https://cilogon.org/igwn
               Base Path: /user/ligo
@@ -115,6 +116,7 @@ DataFederations:
           - FQAN: /osg/ligo
           - FQAN: /virgo
           - FQAN: /virgo/virgo
+          - FQAN: /virgo/ligo
           - SciTokens:
               Issuer: https://cilogon.org/igwn
               Base Path: /igwn


### PR DESCRIPTION
I do not know why the `/virgo/ligo` FQAN is not included in the `Authorizations` list. If there is a reason, please ignore this pull request.

I would think that it should be included. It is included in the list of authorized VOMS groups for the CVMFS  repository `ligo.osgstorage.org`:

```
osg:/osg/ligo
LIGO:/ligo
virgo:/virgo/ligo
virgo:/virgo/virgo
```

So why not to add it here in topology. The `Authorizations` list here is for accessing the OSDF caches, right?

