### PR TITLE
Remove "ligo" token issuers from /user/ligo OSDF

### DIFF
--- a/virtual-organizations/LIGO.yaml
+++ b/virtual-organizations/LIGO.yaml
@@ -84,15 +84,6 @@ DataFederations:
           - SciTokens:
               Issuer: https://test.cilogon.org/igwn
               Base Path: /user/ligo
-          - SciTokens:
-              Issuer: https://scitokens.org/ligo
-              Base Path: /user/ligo
-          - SciTokens:
-              Issuer: https://test.cilogon.org/ligo
-              Base Path: /user/ligo
-          - SciTokens:
-              Issuer: https://cilogon.org/ligo
-              Base Path: /user/ligo
         AllowedOrigins:
           - CIT_LIGO_ORIGIN
           - LIGO-StashCache-Origin


### PR DESCRIPTION
As of yesterday, both https:/test.cilogon.org/ligo and https://cilogon.org/ligo have been retired as issuers for tokens for our users, in favor of the "igwn" issuer only. This PR therefore removes those.  In addition, we are removing the scitokens.org issuer because we do not believe it is needed for accessing files via OSDF or CVMFS.  However we do still need to keep it in the Credentials section of this file, as our pilots use that issuer.