### PR TITLE
Remove PATh Facility access to OSPool namespaces (INF-406)

### DIFF
--- a/virtual-organizations/OSG.yaml
+++ b/virtual-organizations/OSG.yaml
@@ -127,10 +127,6 @@ DataFederations:
               Issuer: https://osg-htc.org/ospool
               Base Path: /ospool/PROTECTED,/s3.amazonaws.com/us-east-1,/s3.amazonaws.com/us-west-1
               Map Subject: True
-          - SciTokens:
-              Issuer: https://path-cc.io
-              Base Path: /ospool/PROTECTED,/path-facility/data,/path-facility/projects
-              Map Subject: True
         AllowedOrigins:
           - CHTC_OSPOOL_ORIGIN
         AllowedCaches:


### PR DESCRIPTION
@rynge this will revoke access to `/ospool/PROTECTED` from AP1 users. I know that we have some users that need to move data between the two namespaces so we should probably hold off on merging this until that's done.