### PR TITLE
Add PyYaml module and function that reads services.yaml.

### DIFF
--- a/src/topology_utils.py
+++ b/src/topology_utils.py
@@ -8,6 +8,7 @@ import sys
 import urllib
 import fnmatch
 import urllib.parse as urlparse
+import yaml
 
 import xml.etree.ElementTree as ET
 
@@ -172,6 +173,13 @@ def get_vo_map(args, session=None):
 
     return vo_map
 
+def get_contact_filter_service_ids():
+    """"
+    Reads and parse filters from services.yaml
+    """
+    with open("../topology/services.yaml", "r") as file:
+        service_ids = yaml.safe_load(file)
+        return(service_ids)
 
 SERVICE_IDS = {'ce': 1,
                'srmv2': 3,


### PR DESCRIPTION
This commit includes a new function that reads and parses services.yaml within the topology directory and returns the dictionary. It is intended to replace the hardcoded list of SERVICE_IDS filters and will be used with osg-notify.