### PR TITLE
adding an outage for USCMS-FNAL-WC1-CE3

### DIFF
--- a/topology/Fermi National Accelerator Laboratory/FNAL USCMS Tier1/USCMS-FNAL-WC1_downtime.yaml
+++ b/topology/Fermi National Accelerator Laboratory/FNAL USCMS Tier1/USCMS-FNAL-WC1_downtime.yaml
@@ -871,4 +871,14 @@
   - CE
 # ---------------------------------------------------------
 
-
+- Class: UNSCHEDULED
+  ID: 1463377996
+  Description: CE failing pilots, need a downtime to investigate
+  Severity: Severe
+  StartTime: Apr 12, 2023 22:00 +0000
+  EndTime: Apr 14, 2023 16:00 +0000
+  CreatedTime: Apr 12, 2023 22:16 +0000
+  ResourceName: USCMS-FNAL-WC1-CE3
+  Services:
+  - CE
+# ---------------------------------------------------------


### PR DESCRIPTION
CE came out of the downtime and started failing pilots immediately. Need some time to debug the cause.