### PR TITLE
add new /igwn/virgo namespace in LIGO VO

### DIFF
--- a/virtual-organizations/LIGO.yaml
+++ b/virtual-organizations/LIGO.yaml
@@ -87,6 +87,41 @@ DataFederations:
         AllowedOrigins:
           - CIT_LIGO_ORIGIN
           - LIGO-StashCache-Origin
+        AllowedCaches:
+          - SUT-STASHCACHE
+          - Georgia_Tech_PACE_GridFTP2
+          - Stashcache-UCSD
+          - Stashcache-UofA
+          - Stashcache-KISTI
+          - Stashcache-Houston
+          - Stashcache-Manhattan
+          - Stashcache-Sunnyvale
+          - Stashcache-Chicago
+          - Stashcache-Kansas
+          - PIC_STASHCACHE_CACHE
+          - SU_STASHCACHE_CACHE
+          - PSU-LIGO-CACHE
+          - MGHPCC_NRP_OSDF_CACHE
+          - SDSC_NRP_OSDF_CACHE
+          - NEBRASKA_NRP_OSDF_CACHE
+          - CINCINNATI_INTERNET2_OSDF_CACHE
+          - BOISE_INTERNET2_OSDF_CACHE
+          - T1_STASHCACHE_CACHE
+          - CARDIFF_UK_OSDF_CACHE
+          - ComputeCanada-Cedar-Cache
+          - JACKSONVILLE_INTERNET2_OSDF_CACHE
+      - Path: /igwn/virgo
+        Authorizations:
+          - FQAN: /osg/ligo
+          - FQAN: /virgo
+          - FQAN: /virgo/virgo
+          - SciTokens:
+              Issuer: https://cilogon.org/igwn
+              Base Path: /igwn
+          - SciTokens:
+              Issuer: https://test.cilogon.org/igwn
+              Base Path: /igwn
+        AllowedOrigins:
           - UCL-Virgo-StashCache-Origin
         AllowedCaches:
           - SUT-STASHCACHE


### PR DESCRIPTION
Reference: https://support.opensciencegrid.org/support/tickets/public/66335a5ae2d5e7b24d21b9aa28fdcb8b6a0d3a5872de5e385cdf5dbfb4d91297#reply-to-ticket-public

I already stopped the services in the origin and moved the data that we want to keep to the new /igwn/virgo path. Once this merge request is accepted, I will reconfigure the origin and start the services. 