### PR TITLE
Overhaul CHTC namespace and credential generation

### DIFF
--- a/virtual-organizations/GLOW.yaml
+++ b/virtual-organizations/GLOW.yaml
@@ -60,44 +60,6 @@ DataFederations:
         AllowedCaches:
           - ANY
 
-      - Path: /chtc/PROTECTED
-        Authorizations:
-          - FQAN: /GLOW
-          - DN: /DC=org/DC=cilogon/C=US/O=University of Wisconsin-Madison/CN=Matyas Selmeci A148276
-          - SciTokens:
-              Issuer: https://chtc.cs.wisc.edu
-              Base Path: /chtc/PROTECTED, /chtc/staging
-              Map Subject: True
-        AllowedOrigins:
-          - CHTC_STASHCACHE_ORIGIN_AUTH_2000
-        AllowedCaches:
-          - Stashcache-Chicago
-          - Stashcache-Kansas
-          - Stashcache-Houston
-          - Stashcache-Manhattan
-          - Stashcache-Sunnyvale
-          - CHTC_TIGER_CACHE
-          - CHTC_STASHCACHE_CACHE
-        Writeback: https://origin-auth2001.chtc.wisc.edu:1095
-        DirList: https://origin-auth2001.chtc.wisc.edu:1095
-        CredentialGeneration:
-          Strategy: OAuth2
-          Issuer: https://chtc.cs.wisc.edu
-          MaxScopeDepth: 2
-
-      - Path: /chtc/PROTECTED-TESTING
-        Authorizations:
-          - FQAN: /GLOW
-          - DN: /DC=org/DC=cilogon/C=US/O=University of Wisconsin-Madison/CN=Matyas Selmeci A148276
-          - SciTokens:
-              Issuer: https://chtc.cs.wisc.edu
-              Base Path: /chtc/PROTECTED, /chtc/staging
-              Map Subject: False
-        AllowedOrigins:
-          - CHTC_STASHCACHE_ORIGIN
-        AllowedCaches:
-          - ANY
-
       - Path: /chtc/itb/helm-origin/PUBLIC
         Authorizations:
           - PUBLIC
@@ -112,18 +74,18 @@ DataFederations:
           - DN: /DC=org/DC=cilogon/C=US/O=University of Wisconsin-Madison/CN=Matyas Selmeci A148276
           - SciTokens:
               Issuer: https://chtc.cs.wisc.edu
-              Base Path: /chtc/PROTECTED, /chtc/staging
+              Base Path: /chtc
               Map Subject: False
         AllowedOrigins:
           - CHTC-ITB-HELM-ORIGIN
         AllowedCaches:
           - ANY
 
-      - Path: /chtc/staging
+      - Path: /chtc
         Authorizations:
           - SciTokens:
               Issuer: https://chtc.cs.wisc.edu
-              Base Path: /chtc/PROTECTED, /chtc/staging
+              Base Path: /chtc
               Map Subject: True
         AllowedOrigins:
           - CHTC-STASHCACHE_ORIGIN_AUTH_2000
@@ -134,4 +96,4 @@ DataFederations:
         CredentialGeneration:
           Strategy: OAuth2
           Issuer: https://chtc.cs.wisc.edu
-          MaxScopeDepth: 2
+          MaxScopeDepth: 3

--- a/virtual-organizations/GLOW.yaml
+++ b/virtual-organizations/GLOW.yaml
@@ -80,6 +80,10 @@ DataFederations:
           - CHTC_STASHCACHE_CACHE
         Writeback: https://origin-auth2001.chtc.wisc.edu:1095
         DirList: https://origin-auth2001.chtc.wisc.edu:1095
+        CredentialGeneration:
+          Strategy: OAuth2
+          Issuer: https://chtc.cs.wisc.edu
+          MaxScopeDepth: 2
 
       - Path: /chtc/PROTECTED-TESTING
         Authorizations:
@@ -127,3 +131,7 @@ DataFederations:
           - ANY
         Writeback: https://origin-auth2000.chtc.wisc.edu:1095
         DirList: https://origin-auth2000.chtc.wisc.edu:1095
+        CredentialGeneration:
+          Strategy: OAuth2
+          Issuer: https://chtc.cs.wisc.edu
+          MaxScopeDepth: 2


### PR DESCRIPTION
This attempts to simplify the CHTC namespace so we simply have one issuer a single top-level base_path