### PR TITLE
Add squid entries

### DIFF
--- a/topology/University of Arkansas at Little Rock/UA Little Rock ITS/UA-LR-ITS.yaml
+++ b/topology/University of Arkansas at Little Rock/UA Little Rock ITS/UA-LR-ITS.yaml
@@ -20,3 +20,26 @@ Resources:
     Services:
       Execution Endpoint:
         Description: UALR backfill containers
+  UA-LR-ITS-squid1:
+      Active: false
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          ID: 
+          Name: Timothy Stoddard
+        Secondary:
+          ID: 
+          Name: Timothy Stoddard
+      Security Contact:
+        Primary:
+          ID: 
+          Name: Timothy Stoddard
+        Secondary:
+          ID: 
+          Name: Timothy Stoddard
+    Description: The first squid server for UA Little Rock.
+    FQDN: frontier-cache.res.ualr.edu
+    ID: 
+    Services:
+      Squid:
+        Description: Generic squid service

--- a/topology/University of Arkansas at Little Rock/UA Little Rock ITS/UA-LR-ITS.yaml
+++ b/topology/University of Arkansas at Little Rock/UA Little Rock ITS/UA-LR-ITS.yaml
@@ -25,21 +25,21 @@ Resources:
     ContactLists:
       Administrative Contact:
         Primary:
-          ID: 
+          ID: 1d1de15f8d54ec20ce6da7c73420a3f721b819e4
           Name: Timothy Stoddard
         Secondary:
-          ID: 
+          ID: 1d1de15f8d54ec20ce6da7c73420a3f721b819e4
           Name: Timothy Stoddard
       Security Contact:
         Primary:
-          ID: 
+          ID: 1d1de15f8d54ec20ce6da7c73420a3f721b819e4
           Name: Timothy Stoddard
         Secondary:
-          ID: 
+          ID: 1d1de15f8d54ec20ce6da7c73420a3f721b819e4
           Name: Timothy Stoddard
     Description: The first squid server for UA Little Rock.
     FQDN: frontier-cache.res.ualr.edu
-    ID: 
+    ID: 1348
     Services:
       Squid:
         Description: Generic squid service

--- a/topology/University of Arkansas at Little Rock/UA Little Rock ITS/UA-LR-ITS.yaml
+++ b/topology/University of Arkansas at Little Rock/UA Little Rock ITS/UA-LR-ITS.yaml
@@ -26,21 +26,21 @@ Resources:
     ContactLists:
       Administrative Contact:
         Primary:
-          ID: 1d1de15f8d54ec20ce6da7c73420a3f721b819e4
+          ID: OSG1000251
           Name: Timothy Stoddard
         Secondary:
-          ID: 1d1de15f8d54ec20ce6da7c73420a3f721b819e4
+          ID: OSG1000251
           Name: Timothy Stoddard
       Security Contact:
         Primary:
-          ID: 1d1de15f8d54ec20ce6da7c73420a3f721b819e4
+          ID: OSG1000251
           Name: Timothy Stoddard
         Secondary:
-          ID: 1d1de15f8d54ec20ce6da7c73420a3f721b819e4
+          ID: OSG1000251
           Name: Timothy Stoddard
     Description: The first squid server for UA Little Rock.
     FQDN: frontier-cache.res.ualr.edu
-    ID: 1348
+    ID: 1442
     Services:
       Squid:
         Description: Generic squid service

--- a/topology/University of Arkansas at Little Rock/UA Little Rock ITS/UA-LR-ITS.yaml
+++ b/topology/University of Arkansas at Little Rock/UA Little Rock ITS/UA-LR-ITS.yaml
@@ -20,8 +20,9 @@ Resources:
     Services:
       Execution Endpoint:
         Description: UALR backfill containers
+        
   UA-LR-ITS-squid1:
-      Active: false
+    Active: false
     ContactLists:
       Administrative Contact:
         Primary:


### PR DESCRIPTION
This edit should add the entry for our squid servers. The FQDN is a round-robin which contains both squids.