### PR TITLE
Add Cache-Control headers and enable Apache in-memory caching of topology output, along with compression

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN alternatives --set python3 /usr/bin/python3.9
 WORKDIR /app
 
 # Install application dependencies
-COPY requirements-apache.txt src/ ./
+COPY requirements-apache.txt ./
 RUN pip3 install --no-cache-dir -r requirements-apache.txt
 
 # Create data directory, and gather SSH keys for git
@@ -38,6 +38,8 @@ RUN echo "45 */6 * * * root /usr/sbin/fetch-crl -q -r 21600 -p 10" >  /etc/cron.
     echo "@reboot      root /usr/sbin/fetch-crl -q          -p 10" >> /etc/cron.d/fetch-crl && \
     echo "0 0 * * *    root /usr/bin/pkill -USR1 httpd"            >  /etc/cron.d/httpd
 
+# Install application
+COPY src/ ./
 
 # Set up Apache configuration
 # Remove default SSL config: default certs don't exist on EL8 so the

--- a/docker/apache.conf
+++ b/docker/apache.conf
@@ -38,6 +38,11 @@ WSGIDaemonProcess topomerge home=/app
   # Enable compression for text files
   AddOutputFilterByType DEFLATE text/html text/plain text/xml text/css text/javascript application/javascript application/json
 
+  # Enable memory caching
+  CacheSocache shmcb
+  CacheSocacheMaxSize 102400
+  CacheEnable socache
+
 </VirtualHost>
 
 # Separate vhost for map, no SSL required (terminated in traefik)

--- a/docker/apache.conf
+++ b/docker/apache.conf
@@ -35,6 +35,9 @@ WSGIDaemonProcess topomerge home=/app
 
   WSGIScriptAlias /        /app/topology.wsgi         process-group=topology application-group=topology
 
+  # Enable compression for text files
+  AddOutputFilterByType DEFLATE text/html text/plain text/xml text/css text/javascript application/javascript application/json
+
 </VirtualHost>
 
 # Separate vhost for map, no SSL required (terminated in traefik)

--- a/src/app.py
+++ b/src/app.py
@@ -14,7 +14,7 @@ import traceback
 import urllib.parse
 
 from webapp import default_config
-from webapp.common import readfile, to_xml_bytes, to_json_bytes, Filters, support_cors, simplify_attr_list, is_null, escape
+from webapp.common import readfile, to_xml_bytes, to_json_bytes, Filters, support_cors, simplify_attr_list, is_null, escape, cache_control_private
 from webapp.exceptions import DataError, ResourceNotRegistered, ResourceMissingService
 from webapp.forms import GenerateDowntimeForm, GenerateResourceGroupDowntimeForm
 from webapp.models import GlobalData
@@ -90,6 +90,14 @@ def _fix_unicode(text):
     """Convert a partial unicode string to full unicode"""
     return text.encode('utf-8', 'surrogateescape').decode('utf-8')
 
+@app.after_request
+def set_cache_control(response):
+    if response.status_code == 200:
+        # Cache results for 300s
+        response.cache_control.max_age = 300
+        # Serve an expired entry for up to 100s while refreshing in the background
+        response.headers['Cache-Control'] += ', stale-while-revalidate=100'
+    return response
 
 @app.route('/')
 def homepage():
@@ -120,6 +128,7 @@ def schema(xsdfile):
 
 
 @app.route('/miscuser/xml')
+@cache_control_private
 def miscuser_xml():
     return Response(to_xml_bytes(global_data.get_contacts_data().get_tree(_get_authorized())),
                     mimetype='text/xml')
@@ -214,12 +223,13 @@ def collaborations_scitoken_text():
 
 
 @app.route('/contacts')
+@cache_control_private
 def contacts():
     try:
         authorized = _get_authorized()
         contacts_data = global_data.get_contacts_data().without_duplicates()
         users_list = contacts_data.get_tree(_get_authorized())["Users"]["User"]
-        return _fix_unicode(render_template('contacts.html.j2', users=users_list, authorized=authorized))
+        return Response(_fix_unicode(render_template('contacts.html.j2', users=users_list, authorized=authorized)))
     except (KeyError, AttributeError):
         app.log_exception(sys.exc_info())
         return Response("Error getting users", status=503)  # well, it's better than crashing
@@ -469,6 +479,7 @@ def stashcache_namespaces_json():
 
 
 @app.route("/oasis-managers/json")
+@cache_control_private
 def oasis_managers():
     if not _get_authorized():
         return Response("Not authorized", status=403)

--- a/src/webapp/common.py
+++ b/src/webapp/common.py
@@ -335,5 +335,15 @@ def support_cors(f):
     return wrapped
 
 
+def cache_control_private(f):
+    """Decorator to set `Cache-Control: private` on response"""
+    @wraps(f)
+    def wrapped():
+        response = f()
+        response.cache_control.private = True
+        return response
+    return wrapped
+
+
 XROOTD_CACHE_SERVER = "XRootD cache server"
 XROOTD_ORIGIN_SERVER = "XRootD origin server"


### PR DESCRIPTION
This takes a neglected work-in-progress to use Varnish, and simplifies it. This builds on the ideas started in #3132.

Varnish would be a better choice for caching, but adds more complexity to keep gridsite authentication working. Unfortunately, Apache doesn't support `Cache-Control: stale-while-revalidate=...`. Some clients will still get slow responses as content is refreshed, but it's slightly better.