### PR TITLE
Change end Date for Georgia Tech PACE OSG 2 CE Downtime

### DIFF
--- a/topology/Georgia Institute of Technology/Georgia Tech/Georgia Tech PACE OSG 2_downtime.yaml
+++ b/topology/Georgia Institute of Technology/Georgia Tech/Georgia Tech PACE OSG 2_downtime.yaml
@@ -498,7 +498,7 @@
   Description: Slate CE Outage
   Severity: Severe
   StartTime: May 12, 2023 10:00 +0000
-  EndTime: May 26, 2023 21:00 +0000
+  EndTime: May 17, 2023 20:00 +0000
   CreatedTime: May 15, 2023 17:29 +0000
   ResourceName: Georgia_Tech_PACE_CE_2
   Services:


### PR DESCRIPTION
Access to SlateCI was restored after a firewall change; the CE service is up and running again.