### PR TITLE
Fix Apache CacheEnable config

### DIFF
--- a/docker/apache.conf
+++ b/docker/apache.conf
@@ -41,7 +41,7 @@ WSGIDaemonProcess topomerge home=/app
   # Enable memory caching
   CacheSocache shmcb
   CacheSocacheMaxSize 102400
-  CacheEnable socache
+  CacheEnable socache /
 
 </VirtualHost>
 


### PR DESCRIPTION
This was intended to be included in PR #3133

Error without it:
```
AH00526: Syntax error on line 44 of /etc/httpd/conf.d/topology.conf:
CacheEnable provider (socache) is missing an URL.
```
