### PR TITLE
crane-gw1.unl.edu: Set inactive

### DIFF
--- a/topology/University of Nebraska/Nebraska-Omaha/Crane.yaml
+++ b/topology/University of Nebraska/Nebraska-Omaha/Crane.yaml
@@ -3,7 +3,7 @@ GroupID: 388
 Production: true
 Resources:
   Crane-CE1:
-    Active: true
+    Active: false
     ContactLists:
       Administrative Contact:
         Primary:

--- a/topology/University of Nebraska/Nebraska-Omaha/Crane.yaml
+++ b/topology/University of Nebraska/Nebraska-Omaha/Crane.yaml
@@ -47,29 +47,4 @@ Resources:
       KSI2KMin: 0
       StorageCapacityMax: 0
       StorageCapacityMin: 0
-  HCC-PKI-Proxy:
-    Active: true
-    ContactLists:
-      Administrative Contact:
-        Primary:
-          ID: e86d60dc841731aebfd879d5883d66ebab20cbd2
-          Name: Garhan Attebury
-        Secondary:
-          ID: a2d43374cb67fd2f248f56d7819b77726dfeaa2b
-          Name: Carl Lundstedt
-      Security Contact:
-        Primary:
-          ID: e86d60dc841731aebfd879d5883d66ebab20cbd2
-          Name: Garhan Attebury
-        Secondary:
-          ID: a2d43374cb67fd2f248f56d7819b77726dfeaa2b
-          Name: Carl Lundstedt
-    Description: Round robin DNS alias for HCC Squids in Omaha
-    FQDN: hcc-pki-proxy.unl.edu
-    ID: 1004
-    Services:
-      Squid:
-        Description: Generic squid service
-    VOOwnership:
-      HCC: 100
 SupportCenter: Community Support Center

--- a/topology/University of Nebraska/Nebraska-Omaha/Swan.yaml
+++ b/topology/University of Nebraska/Nebraska-Omaha/Swan.yaml
@@ -47,4 +47,29 @@ Resources:
       KSI2KMin: 0
       StorageCapacityMax: 0
       StorageCapacityMin: 0
+  HCC-PKI-Proxy:
+    Active: true
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          ID: e86d60dc841731aebfd879d5883d66ebab20cbd2
+          Name: Garhan Attebury
+        Secondary:
+          ID: a2d43374cb67fd2f248f56d7819b77726dfeaa2b
+          Name: Carl Lundstedt
+      Security Contact:
+        Primary:
+          ID: e86d60dc841731aebfd879d5883d66ebab20cbd2
+          Name: Garhan Attebury
+        Secondary:
+          ID: a2d43374cb67fd2f248f56d7819b77726dfeaa2b
+          Name: Carl Lundstedt
+    Description: Round robin DNS alias for HCC Squids in Omaha
+    FQDN: hcc-pki-proxy.unl.edu
+    ID: 1004
+    Services:
+      Squid:
+        Description: Generic squid service
+    VOOwnership:
+      HCC: 100
 SupportCenter: Community Support Center


### PR DESCRIPTION
Cluster is being retired June 23, 2023. Also move hcc-pki-proxy.unl.edu resource to the active cluster.