### PR TITLE
Increase WSGI processes to 5 for topology

### DIFF
--- a/docker/apache.conf
+++ b/docker/apache.conf
@@ -5,7 +5,7 @@ LoadModule wsgi_module /usr/local/lib64/python3.9/site-packages/mod_wsgi/server/
 WSGIPythonPath /app
 
 # Run apps in separate processes to stop yaml.CSafeLoader import-time error
-WSGIDaemonProcess topology  home=/app
+WSGIDaemonProcess topology  home=/app processes=5
 WSGIDaemonProcess topomerge home=/app
 
 # vhost for topology, SSL terminated here (for gridsite auth)


### PR DESCRIPTION
In local testing, this seems to allow it to use CPU on multiple httpd processes, rather than being limited to 100% on a single process