### PR TITLE
Add new LIGO OSDF Origins to CIT_LIGO.yaml

### DIFF
--- a/topology/California Institute of Technology/Caltech LIGO/CIT_LIGO.yaml
+++ b/topology/California Institute of Technology/Caltech LIGO/CIT_LIGO.yaml
@@ -19,6 +19,44 @@ Resources:
         Description: StashCache Origin server
     AllowedVOs:
       - LIGO
+  CIT_LIGO_ORIGIN_IFO:
+    Active: false
+    Description: This serves proprietary gravitational-wave data from the LIGO interferometers
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          Name: Stuart Anderson
+          ID: c50e7cc9d0086272ef995fb76461612d40c70435
+      Security Contact:
+        Primary:
+          Name: Stuart Anderson
+          ID: c50e7cc9d0086272ef995fb76461612d40c70435
+    FQDN: origin-ifo.ligo.caltech.edu
+    DN: /DC=org/DC=incommon/C=US/ST=California/O=California Institute of Technology/CN=origin-ifo.ligo.caltech.edu
+    Services:
+      XRootD origin server:
+        Description: StashCache Origin server
+    AllowedVOs:
+      - LIGO
+  CIT_LIGO_ORIGIN_SHARED:
+    Active: false
+    Description: This serves proprietary data shared among LIGO, Virgo, and KAGRA
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          Name: Stuart Anderson
+          ID: c50e7cc9d0086272ef995fb76461612d40c70435
+      Security Contact:
+        Primary:
+          Name: Stuart Anderson
+          ID: c50e7cc9d0086272ef995fb76461612d40c70435
+    FQDN: origin-shared.ligo.caltech.edu
+    DN: /DC=org/DC=incommon/C=US/ST=California/O=California Institute of Technology/CN=origin-shared.ligo.caltech.edu
+    Services:
+      XRootD origin server:
+        Description: StashCache Origin server
+    AllowedVOs:
+      - LIGO
   CIT_LIGO_SQUID1:
     ContactLists:
       Administrative Contact:

--- a/topology/California Institute of Technology/Caltech LIGO/CIT_LIGO.yaml
+++ b/topology/California Institute of Technology/Caltech LIGO/CIT_LIGO.yaml
@@ -33,6 +33,7 @@ Resources:
           ID: c50e7cc9d0086272ef995fb76461612d40c70435
     FQDN: origin-ifo.ligo.caltech.edu
     DN: /DC=org/DC=incommon/C=US/ST=California/O=California Institute of Technology/CN=origin-ifo.ligo.caltech.edu
+    ID: 1457
     Services:
       XRootD origin server:
         Description: StashCache Origin server
@@ -52,6 +53,7 @@ Resources:
           ID: c50e7cc9d0086272ef995fb76461612d40c70435
     FQDN: origin-shared.ligo.caltech.edu
     DN: /DC=org/DC=incommon/C=US/ST=California/O=California Institute of Technology/CN=origin-shared.ligo.caltech.edu
+    ID: 1458
     Services:
       XRootD origin server:
         Description: StashCache Origin server


### PR DESCRIPTION
This PR adds two new OSDF origin servers to the Caltech LIGO resource group. I have marked them as inactive because while the servers are up and should respond to ping, we have not finished configuring XRootD on them.  However, if they need to be marked active in order for [this test](https://osg-htc.org/docs/data/stashcache/install-origin/#testing-file-access-authenticated-origin) to work, then please when considering this PR also change those to active. I have not added ID lines for the servers themselves as my understanding is that those will be assigned to them as part of the PR approval.