### PR TITLE
Fix Downtime Forms

### DIFF
--- a/src/templates/generate_downtime_form.html.j2
+++ b/src/templates/generate_downtime_form.html.j2
@@ -51,10 +51,8 @@ Resource Downtime YAML Generator
       {%- endif %}
 
       <form method=post>
-        <!-- NOTE: we are not using CSRF because none of the POST data is actually
-        used to change anything.  If that ever changes, see
-        https://flask-wtf.readthedocs.io/en/stable/csrf.html
-        -->
+        {{ form.csrf_token }}
+
         {{ M.render_field(form.facility) }}
         {{ M.render_button(form.change_facility) }}
 

--- a/src/templates/generate_resource_group_downtime_form.html.j2
+++ b/src/templates/generate_resource_group_downtime_form.html.j2
@@ -57,10 +57,8 @@ Resource Group Downtime YAML Generator
       {%- endif %}
 
       <form method=post>
-        <!-- NOTE: we are not using CSRF because none of the POST data is actually
-        used to change anything.  If that ever changes, see
-        https://flask-wtf.readthedocs.io/en/stable/csrf.html
-        -->
+        {{ form.csrf_token }}
+
         {{ M.render_field(form.facility) }}
         {{ M.render_button(form.change_facility) }}
 

--- a/src/webapp/forms.py
+++ b/src/webapp/forms.py
@@ -154,7 +154,7 @@ class GenerateResourceGroupDowntimeForm(FlaskForm):
                                                 "rows": "10"})
 
     class Meta:
-        csrf = False  # CSRF not needed because no data gets modified
+        csrf = True
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -249,7 +249,7 @@ class GenerateDowntimeForm(FlaskForm):
                                                 "rows": "10"})
 
     class Meta:
-        csrf = False  # CSRF not needed because no data gets modified
+        csrf = True
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -324,7 +324,7 @@ class GenerateProjectForm(FlaskForm):
     manual_submit = SubmitField("Submit Manually")
 
     class Meta:
-        csrf = True  # CSRF not needed because no data gets modified
+        csrf = True
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
This adds CSRF Tokens to the two existing forms that do not have them. After commit PR #2836 was merged all wtforms are required to either have CSRF Tokens or explicitly exempt themselves. 

https://flask-wtf.readthedocs.io/en/0.15.x/csrf/