### PR TITLE
Update UFlorida-HPC_downtime.yaml

### DIFF
--- a/topology/University of Florida/UF HPC/UFlorida-HPC_downtime.yaml
+++ b/topology/University of Florida/UF HPC/UFlorida-HPC_downtime.yaml
@@ -810,7 +810,7 @@
   Description: RHEL8 upgrade
   Severity: Outage
   StartTime: Jan 09, 2023 18:05 +0000
-  EndTime: Jul 05, 2023 18:06 +0000
+  EndTime: Jun 22, 2023 16:00 +0000
   CreatedTime: Jan 09, 2023 18:06 +0000
   ResourceName: UFlorida-HPC
   Services:


### PR DESCRIPTION
RHEL8 upgrade for the CE is complete. 
The downtime will end at Thu Jun 22 16:00:00 UTC 2023