### PR TITLE
Avert various crashes in Xrootd DN checker CI

### DIFF
--- a/src/tests/verify_resources.py
+++ b/src/tests/verify_resources.py
@@ -686,7 +686,9 @@ def test_16_Xrootd_DNs(rgs, rgfns):
 
     for rg, rgfn in zip(rgs, rgfns):
         for rname, rdict in sorted(rg['Resources'].items()):
-            if 'XRootD cache server' in rdict['Services'] and rdict['Active'] and 'DN' not in rdict:
+            if ('XRootD cache server' in rdict.get('Services', {})
+                    and rdict.get('Active', True)
+                    and not rdict.get('DN', "")):
                 print_emsg_once('XrootdWithoutDN')
                 print("ERROR: In '%s', Xrootd cache server Resource '%s' has no DN" %
                       (rgfn, rname))


### PR DESCRIPTION
- Don't crash when checking for the DN of a cache server that doesn't have 'Active' set 'Active' defaults to True in the Topology webapp, so it should default to True in the CI as well.
- Don't crash if there's no 'Services' section
- Deal with a DN field being present but empty