### PR TITLE
INF-1139: update topology for chtc hosts

### DIFF
--- a/topology/University of Wisconsin/CHTC/CHTC.yaml
+++ b/topology/University of Wisconsin/CHTC/CHTC.yaml
@@ -511,7 +511,7 @@ Resources:
   CHTC-ap40:
     Active: true
     Description: The ap40.chtc.wisc.edu login node for the OSG Open Pool
-    ID: 1303
+    ID: 1468
     ContactLists:
       Administrative Contact:
         Primary:

--- a/topology/University of Wisconsin/CHTC/CHTC.yaml
+++ b/topology/University of Wisconsin/CHTC/CHTC.yaml
@@ -510,7 +510,7 @@ Resources:
 
   CHTC-ap40:
     Active: true
-    Description: The ap40.chtc.wisc.edu login node for the OSG Open Pool
+    Description: The ap40.uw.osg-htc.org access point for the Open Science Pool
     ID: 1468
     ContactLists:
       Administrative Contact:
@@ -522,6 +522,9 @@ Resources:
           Name: Aaron Moate
           ID: OSG1000015
     FQDN: ap40.chtc.wisc.edu
+    FQDNAliases:
+      - ap2007.chtc.wisc.edu 
+      - ospool-ap2040.chtc.wisc.edu
     Services:
       Submit Node:
         Description: OS Pool access point
@@ -530,7 +533,7 @@ Resources:
     Tags:
       - OSPool
     VOOwnership:
-      GLOW: 100
+      OSG: 100
 
   CHTC-ospool-eht:
     Active: true

--- a/topology/University of Wisconsin/CHTC/CHTC.yaml
+++ b/topology/University of Wisconsin/CHTC/CHTC.yaml
@@ -63,6 +63,8 @@ Resources:
         Description: OSG Submission Node
         Details:
           hidden: false
+    Tags:
+      - OSPool
     VOOwnership:
       GLOW: 100
   CHTC-submit2:
@@ -84,6 +86,8 @@ Resources:
         Description: OSG Submission Node
         Details:
           hidden: false
+    Tags:
+      - OSPool
     VOOwnership:
       GLOW: 100
 
@@ -106,6 +110,8 @@ Resources:
         Description: OSG Submission Node
         Details:
           hidden: false
+    Tags:
+      - OSPool
     VOOwnership:
       GLOW: 100
 
@@ -477,7 +483,7 @@ Resources:
         Description: OSG VO backfill containers on the Tiger cluster
 
   CHTC-ap7:
-    Active: true
+    Active: false
     Description: The ap7.chtc.wisc.edu login node for the OSG Open Pool
     ID: 1303
     ContactLists:
@@ -492,6 +498,30 @@ Resources:
     FQDN: ap7.chtc.wisc.edu
     FQDNAliases:
       - ap2007.chtc.wisc.edu
+    Services:
+      Submit Node:
+        Description: OS Pool access point
+        Details:
+          hidden: false
+    Tags:
+      - OSPool
+    VOOwnership:
+      GLOW: 100
+
+  CHTC-ap40:
+    Active: true
+    Description: The ap40.chtc.wisc.edu login node for the OSG Open Pool
+    ID: 1303
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          Name: Aaron Moate
+          ID: OSG1000015
+      Security Contact:
+        Primary:
+          Name: Aaron Moate
+          ID: OSG1000015
+    FQDN: ap40.chtc.wisc.edu
     Services:
       Submit Node:
         Description: OS Pool access point


### PR DESCRIPTION
Per https://opensciencegrid.atlassian.net/browse/INF-1139:
- Add new `ap40.chtc.wisc.edu` host to replace ap7
- Mark ap7 as inactive
- Tag submit-1, submit2, and submit3 as OSPool resources