### PR TITLE
Create SingARENSingaporeInfrastructure_downtime.yaml

### DIFF
--- a/topology/SingAREN/SingARENSingapore/SingARENSingaporeInfrastructure_downtime.yaml
+++ b/topology/SingAREN/SingARENSingapore/SingARENSingaporeInfrastructure_downtime.yaml
@@ -1,0 +1,11 @@
+- Class: UNSCHEDULED
+  ID: 1560891865
+  Description: going to DC
+  Severity: Outage
+  StartTime: Aug 03, 2023 19:30 +0000
+  EndTime: Aug 31, 2023 19:39 +0000
+  CreatedTime: Aug 03, 2023 18:59 +0000
+  ResourceName: SINGAPORE_INTERNET2_OSDF_CACHE
+  Services:
+  - XRootD cache server
+# ---------------------------------------------------------


### PR DESCRIPTION
Add downtime for SINGAPORE_INTERNET2_OSDF_CACHE due to the node being processed to be sent to DC.