### PR TITLE
Allow all new UC OSPool APs to access /ospool/uc-shared

### DIFF
--- a/virtual-organizations/OSG.yaml
+++ b/virtual-organizations/OSG.yaml
@@ -180,7 +180,7 @@ DataFederations:
         Authorizations:
           - SciTokens:
               Issuer: https://ap20.uc.osg-htc.org:1094/ospool/ap20
-              Base Path: /ospool/ap20
+              Base Path: /ospool/ap20, /ospool/uc-shared
               Map Subject: True
         AllowedOrigins:
           - UChicago_OSGConnect_ap20
@@ -197,7 +197,7 @@ DataFederations:
         Authorizations:
           - SciTokens:
               Issuer: https://ap21.uc.osg-htc.org:1094/ospool/ap21
-              Base Path: /ospool/ap21
+              Base Path: /ospool/ap21, /ospool/uc-shared
               Map Subject: True
         AllowedOrigins:
           - UChicago_OSGConnect_ap21
@@ -214,7 +214,7 @@ DataFederations:
         Authorizations:
           - SciTokens:
               Issuer: https://ap22.uc.osg-htc.org:1094/ospool/ap22
-              Base Path: /ospool/ap22
+              Base Path: /ospool/ap22, /ospool/uc-shared
               Map Subject: True
         AllowedOrigins:
           - UChicago_OSGConnect_ap22
@@ -232,6 +232,18 @@ DataFederations:
           - SciTokens:
               Issuer: https://osg-htc.org/ospool/uc-shared
               Base Path: /ospool/uc-shared
+              Map Subject: True
+          - SciTokens:
+              Issuer: https://ap20.uc.osg-htc.org:1094/ospool/ap20
+              Base Path: /ospool/ap20, /ospool/uc-shared
+              Map Subject: True
+          - SciTokens:
+              Issuer: https://ap21.uc.osg-htc.org:1094/ospool/ap21
+              Base Path: /ospool/ap21, /ospool/uc-shared
+              Map Subject: True
+          - SciTokens:
+              Issuer: https://ap22.uc.osg-htc.org:1094/ospool/ap22
+              Base Path: /ospool/ap22, /ospool/uc-shared
               Map Subject: True
         AllowedOrigins:
           - UChicago_OSGConnect_ap23


### PR DESCRIPTION
See c3524138ac8d46eee2a3c33cb75fac50acab41c4 for an explanation why

We don't have a block for ap23 because https://osg-htc.org/ospool/uc-shared is the ap23 issuer