### PR TITLE
Update LIGO.yaml to add /igwn/cit namespace

### DIFF
--- a/virtual-organizations/LIGO.yaml
+++ b/virtual-organizations/LIGO.yaml
@@ -85,10 +85,10 @@ DataFederations:
           - FQAN: /virgo/ligo
           - SciTokens:
               Issuer: https://cilogon.org/igwn
-              Base Path: /user/ligo,/igwn
+              Base Path: /user/ligo,/igwn,/igwn/cit
           - SciTokens:
               Issuer: https://test.cilogon.org/igwn
-              Base Path: /user/ligo,/igwn
+              Base Path: /user/ligo,/igwn,/igwn/cit
         AllowedOrigins:
           - CIT_LIGO_ORIGIN
           - LIGO-StashCache-Origin
@@ -133,10 +133,10 @@ DataFederations:
           # But the problem should be solved either by topology (ideally) or the SciTokens XRootD plugin.
           - SciTokens:
               Issuer: https://cilogon.org/igwn
-              Base Path: /user/ligo,/igwn
+              Base Path: /user/ligo,/igwn,/igwn/cit
           - SciTokens:
               Issuer: https://test.cilogon.org/igwn
-              Base Path: /user/ligo,/igwn
+              Base Path: /user/ligo,/igwn,/igwn/cit
         AllowedOrigins:
           - UCL-Virgo-StashCache-Origin
         AllowedCaches:
@@ -180,10 +180,10 @@ DataFederations:
           # But the problem should be solved either by topology (ideally) or the SciTokens XRootD plugin.
           - SciTokens:
               Issuer: https://cilogon.org/igwn
-              Base Path: /user/ligo,/igwn
+              Base Path: /user/ligo,/igwn,/igwn/cit
           - SciTokens:
               Issuer: https://test.cilogon.org/igwn
-              Base Path: /user/ligo,/igwn
+              Base Path: /user/ligo,/igwn,/igwn/cit
         AllowedOrigins:
           - CIT_LIGO_ORIGIN_IFO
         AllowedCaches:
@@ -227,10 +227,10 @@ DataFederations:
           # But the problem should be solved either by topology (ideally) or the SciTokens XRootD plugin.
           - SciTokens:
               Issuer: https://cilogon.org/igwn
-              Base Path: /user/ligo,/igwn
+              Base Path: /user/ligo,/igwn,/igwn/cit
           - SciTokens:
               Issuer: https://test.cilogon.org/igwn
-              Base Path: /user/ligo,/igwn
+              Base Path: /user/ligo,/igwn,/igwn/cit
         AllowedOrigins:
           - CIT_LIGO_ORIGIN_SHARED
         AllowedCaches:
@@ -263,6 +263,54 @@ DataFederations:
           - CIT_LIGO_STASHCACHE
           - SINGAPORE_INTERNET2_OSDF_CACHE
           - SPRACE_OSDF_CACHE
+      - Path: /igwn/cit
+        Authorizations:
+          - FQAN: /osg/ligo
+          - FQAN: /virgo
+          - FQAN: /virgo/virgo
+          - FQAN: /virgo/ligo
+          # No Scitokens issuers because they are duplicated with the /user/ligo path.
+          # As long as the caches are kept in sync, this below fix should be fine.
+          # But the problem should be solved either by topology (ideally) or the SciTokens XRootD plugin.
+          - SciTokens:
+              Issuer: https://cilogon.org/igwn
+              Base Path: /user/ligo,/igwn,/igwn/cit
+          - SciTokens:
+              Issuer: https://test.cilogon.org/igwn
+              Base Path: /user/ligo,/igwn,/igwn/cit
+        AllowedOrigins:
+          - CIT_LIGO_ORIGIN_STAGING
+        AllowedCaches:
+          - SUT-STASHCACHE
+          - Georgia_Tech_PACE_GridFTP2
+          - Stashcache-UCSD
+          - Stashcache-UofA
+          - Stashcache-KISTI
+          - Stashcache-Houston
+          - Stashcache-Manhattan
+          - Stashcache-Sunnyvale
+          - Stashcache-Chicago
+          - Stashcache-Kansas
+          - PIC_STASHCACHE_CACHE
+          - SU_STASHCACHE_CACHE
+          - PSU-LIGO-CACHE
+          - MGHPCC_NRP_OSDF_CACHE
+          - SDSC_NRP_OSDF_CACHE
+          - NEBRASKA_NRP_OSDF_CACHE
+          - CINCINNATI_INTERNET2_OSDF_CACHE
+          - BOISE_INTERNET2_OSDF_CACHE
+          - T1_STASHCACHE_CACHE
+          - CARDIFF_UK_OSDF_CACHE
+          - ComputeCanada-Cedar-Cache
+          - JACKSONVILLE_INTERNET2_OSDF_CACHE
+          - DENVER_INTERNET2_OSDF_CACHE
+          - AMSTERDAM_ESNET_OSDF_CACHE
+          - LONDON_ESNET_OSDF_CACHE
+          - HOUSTON2_INTERNET2_OSDF_CACHE
+          - CIT_LIGO_STASHCACHE
+          - SINGAPORE_INTERNET2_OSDF_CACHE
+          - SPRACE_OSDF_CACHE
+        Writeback: https://origin-staging.ligo.caltech.edu:1095
       - Path: /gwdata
         Authorizations:
           - PUBLIC


### PR DESCRIPTION
This namespace will be served by the CIT_LIGO_ORIGIN_STAGING server, and provides OSDF access for user data that is uploaded and downloaded using the osdf file transfer plugin. It is similar in function to the `/osgconnect/protected` namespace for OSPool users.

This PR also updates the base paths of all of our namespaces, because the base path for this new namespace is different, and the generated scitokens.conf files will only create one entry per SciTokens issuer, so all base paths for each of our two issuers must be repeated.