### PR TITLE
Revert changes to /ospool/uc-shared (UCOPS-114)

### DIFF
--- a/virtual-organizations/OSG.yaml
+++ b/virtual-organizations/OSG.yaml
@@ -214,7 +214,7 @@ DataFederations:
         Authorizations:
           - SciTokens:
               Issuer: https://ap22.uc.osg-htc.org:1094/ospool/ap22
-              Base Path: /ospool/ap22/data,/ospool/uc-shared/project
+              Base Path: /ospool/ap22
               Map Subject: True
         AllowedOrigins:
           - UChicago_OSGConnect_ap22
@@ -227,15 +227,11 @@ DataFederations:
           Issuer: https://osg-htc.org/ospool
           MaxScopeDepth: 4
 
-      - Path: /ospool/uc-shared/project
+      - Path: /ospool/uc-shared
         Authorizations:
           - SciTokens:
               Issuer: https://osg-htc.org/ospool/uc-shared
-              Base Path: /ospool/uc-shared/project
-              Map Subject: True
-          - SciTokens:
-              Issuer: https://ap22.uc.osg-htc.org:1094/ospool/ap22
-              Base Path: /ospool/ap22/data,/ospool/uc-shared/project
+              Base Path: /ospool/uc-shared
               Map Subject: True
         AllowedOrigins:
           - UChicago_OSGConnect_ap23


### PR DESCRIPTION
These changes are negatively affecting Xenon and the desired semantics
are currently unclear.

This reverts the following commits:

-   c923af6490d3e7a027ab3cd155ae3ced5b20c502
-   0b52f72c01693d3162151821cbd27d949ca47335