### PR TITLE
ResourceAllocations changes for TG-CHE200122

### DIFF
--- a/projects/TG-CHE200122.yaml
+++ b/projects/TG-CHE200122.yaml
@@ -29,19 +29,14 @@ ResourceAllocations:
   - Type: XRAC
     SubmitResources:
       - CHTC-XD-SUBMIT
+      - CHTC-ap40
     ExecuteResourceGroups:
       - GroupName: SDSC-Expanse
         LocalAllocationID: "cwr109"
-      # Bridges2
-      - GroupName: PSC-Bridges2
-        LocalAllocationID: "che200052p"
-      # Stampede2 (OSG allocation)
-      - GroupName: TACC-Stampede2
-        LocalAllocationID: "TG-DDM160003"
   - Type: Other
     SubmitResources:
       - CHTC-XD-SUBMIT
-      - UChicago_OSGConnect_login04
+      - CHTC-ap40
     ExecuteResourceGroups:
       - GroupName: TACC-Frontera
         LocalAllocationID: "CHE20009"


### PR DESCRIPTION
- Remove access to OSG Stampede2 allocation (no frontend group)
- Remove Bridges2 allocation (expired)
- Add access to allocation to ap40 and remove it from login04