### PR TITLE
Add downtime for CHICAGO I2 cache due to node offline

### DIFF
--- a/topology/Internet2/Internet2Chicago/I2ChicagoInfrastructure_downtime.yaml
+++ b/topology/Internet2/Internet2Chicago/I2ChicagoInfrastructure_downtime.yaml
@@ -1,0 +1,11 @@
+- Class: UNSCHEDULED
+  ID: 1631843312
+  Description: Node offline
+  Severity: Outage
+  StartTime: Oct 24, 2023 16:00 +0000
+  EndTime: Oct 27, 2023 19:30 +0000
+  CreatedTime: Oct 24, 2023 21:52 +0000
+  ResourceName: Stashcache-Chicago
+  Services:
+  - XRootD cache server
+# ---------------------------------------------------------


### PR DESCRIPTION
Add downtime for CHICAGO I2 cache due to node offline