### PR TITLE
Retiring brown-osg CE

### DIFF
--- a/topology/Purdue University/Purdue CMS/Purdue.yaml
+++ b/topology/Purdue University/Purdue CMS/Purdue.yaml
@@ -1,6 +1,6 @@
 GroupDescription: CMS tier 2 facility at Purdue University, West Lafayette, IN.
 GroupID: 393
-Production: true
+Production: false
 Resources:
   Purdue-Hadoop-CE:
     Active: true
@@ -180,7 +180,7 @@ Resources:
       StorageCapacityMin: 1
       TapeCapacity: 0
   Purdue-Brown:
-    Active: true
+    Active: false
     ContactLists:
       Administrative Contact:
         Primary:


### PR DESCRIPTION
We are retiring the brown cluster, so I have set the brown-osg-ce active status to false.  Also I noticed hadoop-osg was still set active, it has been retired for some time now, I have also set it to false.