### PR TITLE
correct typo in Purdue CMS topology

### DIFF
--- a/topology/Purdue University/Purdue CMS/Purdue.yaml
+++ b/topology/Purdue University/Purdue CMS/Purdue.yaml
@@ -1,9 +1,9 @@
 GroupDescription: CMS tier 2 facility at Purdue University, West Lafayette, IN.
 GroupID: 393
-Production: false
+Production: true
 Resources:
   Purdue-Hadoop-CE:
-    Active: true
+    Active: false
     ContactLists:
       Administrative Contact:
         Primary:


### PR DESCRIPTION
I believe I set the wrong attribute to false in my previous edit.  Possibly causing issue with our squids showing up as registered.