### PR TITLE
Add /chtc/PROTECTED/sc-origin2000, a namespace served by sc-origin2000.chtc.wisc.edu

### DIFF
--- a/virtual-organizations/GLOW.yaml
+++ b/virtual-organizations/GLOW.yaml
@@ -74,8 +74,8 @@ DataFederations:
           - DN: /DC=org/DC=cilogon/C=US/O=University of Wisconsin-Madison/CN=Matyas Selmeci A148276
           - SciTokens:
               Issuer: https://chtc.cs.wisc.edu
-              Base Path: /chtc
-              Map Subject: False
+              BasePath: /chtc
+              MapSubject: True
         AllowedOrigins:
           - CHTC_STASHCACHE_ORIGIN_2000
         AllowedCaches:

--- a/virtual-organizations/GLOW.yaml
+++ b/virtual-organizations/GLOW.yaml
@@ -68,6 +68,19 @@ DataFederations:
         AllowedCaches:
           - ANY
 
+      - Path: /chtc/PROTECTED/sc-origin2000
+        Authorizations:
+          - FQAN: /GLOW
+          - DN: /DC=org/DC=cilogon/C=US/O=University of Wisconsin-Madison/CN=Matyas Selmeci A148276
+          - SciTokens:
+              Issuer: https://chtc.cs.wisc.edu
+              Base Path: /chtc
+              Map Subject: False
+        AllowedOrigins:
+          - CHTC_STASHCACHE_ORIGIN_2000
+        AllowedCaches:
+          - ANY
+
       - Path: /chtc/itb/helm-origin/PROTECTED
         Authorizations:
           - FQAN: /GLOW


### PR DESCRIPTION
I would like to serve some protected data off of sc-origin2000 (a non-container instance) to test systemd service files.