### PR TITLE
Issuer info in namespaces JSON (SOFTWARE-5768)

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -538,6 +538,10 @@ The JSON also contains an attribute `namespaces` that is a list of namespaces wi
     Note that scopes are usually relative to the namespace path.
   - `vault_server`: the Vault server for the `Vault` strategy or null
   - `vault_issuer`: the Vault issuer for the `Vault` strategy (or null).
+- `scitokens` is information about any `SciTokens` sections in the `Authorizations` list for that namespace (or the empty list if there are none). Each list item has:
+  - `issuer`: the value of the `Issuer` field in the scitokens block
+  - `base_path`: a list which is the value of the `BasePath` (or `Base Path`) field split on commas
+  - `restricted_path`: a list which is the value of the `RestrictedPath` (or `Restricted Path`) field split on commas, or the empty list if unspecified
 
 The final result looks like
 ```json
@@ -567,6 +571,7 @@ The final result looks like
       "dirlisthost": null,
       "path": "/xenon/PROTECTED",
       "readhttps": true,
+      "scitokens": [],
       "usetokenonread": false,
       "writebackhost": null
     },
@@ -582,6 +587,11 @@ The final result looks like
       "dirlisthost": "https://origin-auth2001.chtc.wisc.edu:1095",
       "path": "/ospool/PROTECTED",
       "readhttps": true,
+      "scitokens": {
+        "issuer": "https://osg-htc.org/ospool",
+        "base_path": ["/ospool/PROTECTED", "/s3.amazonaws.com/us-east-1", "/s3.amazonaws.com/us-west-1"],
+        "restricted_path": []
+      },
       "usetokenonread": true,
       "writebackhost": "https://origin-auth2001.chtc.wisc.edu:1095"
     }

--- a/src/stashcache.py
+++ b/src/stashcache.py
@@ -522,6 +522,13 @@ def get_credential_generation_dict_for_namespace(ns: Namespace) -> Optional[Dict
     return info
 
 
+def get_scitokens_list_for_namespace(ns: Namespace) -> List[Dict]:
+    """Return the list of scitokens issuer info for the .namespaces[*].scitokens attribute in the namespaces JSON"""
+    return list(
+        filter(None, (a.get_namespaces_scitokens_block() for a in ns.authz_list))
+    )
+
+
 def get_namespaces_info(global_data: GlobalData) -> PreJSON:
     """Return data for the /stashcache/namespaces JSON endpoint.
 
@@ -564,6 +571,7 @@ def get_namespaces_info(global_data: GlobalData) -> PreJSON:
             "caches": [],
             "origins": [],
             "credential_generation": get_credential_generation_dict_for_namespace(ns),
+            "scitokens": get_scitokens_list_for_namespace(ns),
         }
 
         for cache_name, cache_resource_obj in cache_resource_objs.items():

--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -73,13 +73,13 @@ def client():
 
 
 class TestNamespaces:
-    @pytest.fixture(scope="class")
+    @pytest.fixture
     def namespaces_json(self, client) -> Dict:
         response = client.get('/stashcache/namespaces')
         assert response.status_code == 200
         return response.json
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture
     def namespaces(self, namespaces_json) -> List[Dict]:
         assert "namespaces" in namespaces_json
         return namespaces_json["namespaces"]

--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -1,6 +1,7 @@
 import re
 import flask
 import pytest
+from typing import Dict
 import urllib.parse
 from pytest_mock import MockerFixture
 
@@ -69,6 +70,66 @@ TEST_ENDPOINTS = [
 def client():
     with app.test_client() as client:
         yield client
+
+
+class TestNamespaces:
+    @pytest.fixture(scope="class")
+    def namespaces_json(self, client) -> Dict:
+        response = client.get('/stashcache/namespaces')
+        assert response.status_code == 200
+        return response.json
+
+    @staticmethod
+    def validate_cache_schema(cc):
+        assert HOST_PORT_RE.match(cc["auth_endpoint"])
+        assert HOST_PORT_RE.match(cc["endpoint"])
+        assert cc["resource"] and isinstance(cc["resource"], str)
+
+    @staticmethod
+    def validate_namespace_schema(ns):
+        assert isinstance(ns["caches"], list)  # we do have a case where it's empty
+        assert ns["path"].startswith("/")  # implies str
+        assert isinstance(ns["readhttps"], bool)
+        assert isinstance(ns["usetokenonread"], bool)
+        assert ns["dirlisthost"] is None or PROTOCOL_HOST_PORT_RE.match(ns["dirlisthost"])
+        assert ns["writebackhost"] is None or PROTOCOL_HOST_PORT_RE.match(ns["writebackhost"])
+        credgen = ns["credential_generation"]
+        if credgen is not None:
+            assert isinstance(credgen["max_scope_depth"], int) and credgen["max_scope_depth"] > -1
+            assert credgen["strategy"] in CredentialGeneration.STRATEGIES
+            assert credgen["issuer"]
+            parsed_issuer = urllib.parse.urlparse(credgen["issuer"])
+            assert parsed_issuer.netloc and parsed_issuer.scheme == "https"
+            if credgen["vault_server"]:
+                assert isinstance(credgen["vault_server"], str)
+            if credgen["vault_issuer"]:
+                assert isinstance(credgen["vault_issuer"], str)
+            if credgen["base_path"]:
+                assert isinstance(credgen["base_path"], str)
+
+    def test_caches(self, namespaces_json):
+        assert "caches" in namespaces_json
+        caches = namespaces_json["caches"]
+        # Have a reasonable number of caches
+        assert len(caches) > 20
+        for cache in caches:
+            self.validate_cache_schema(cache)
+
+    def test_namespaces(self, namespaces_json):
+        assert "namespaces" in namespaces_json
+        namespaces = namespaces_json["namespaces"]
+        # Have a reasonable number of namespaces
+        assert len(namespaces) > 15
+
+        found_credgen = False
+        for namespace in namespaces:
+            if namespace["credential_generation"] is not None:
+                found_credgen = True
+            self.validate_namespace_schema(namespace)
+            if namespace["caches"]:
+                for cache in namespace["caches"]:
+                    self.validate_cache_schema(cache)
+        assert found_credgen, "At least one namespace with credential_generation"
 
 
 class TestAPI:
@@ -188,60 +249,6 @@ class TestAPI:
                 del app.config["STASHCACHE_LEGACY_AUTH"]
             else:
                 app.config["STASHCACHE_LEGACY_AUTH"] = old_legacy_auth
-
-    def test_stashcache_namespaces(self, client: flask.Flask):
-        def validate_cache_schema(cc):
-            assert HOST_PORT_RE.match(cc["auth_endpoint"])
-            assert HOST_PORT_RE.match(cc["endpoint"])
-            assert cc["resource"] and isinstance(cc["resource"], str)
-
-        def validate_namespace_schema(ns):
-            assert isinstance(ns["caches"], list)  # we do have a case where it's empty
-            assert ns["path"].startswith("/")  # implies str
-            assert isinstance(ns["readhttps"], bool)
-            assert isinstance(ns["usetokenonread"], bool)
-            assert ns["dirlisthost"] is None or PROTOCOL_HOST_PORT_RE.match(ns["dirlisthost"])
-            assert ns["writebackhost"] is None or PROTOCOL_HOST_PORT_RE.match(ns["writebackhost"])
-            credgen = ns["credential_generation"]
-            if credgen is not None:
-                assert isinstance(credgen["max_scope_depth"], int) and credgen["max_scope_depth"] > -1
-                assert credgen["strategy"] in CredentialGeneration.STRATEGIES
-                assert credgen["issuer"]
-                parsed_issuer = urllib.parse.urlparse(credgen["issuer"])
-                assert parsed_issuer.netloc and parsed_issuer.scheme == "https"
-                if credgen["vault_server"]:
-                    assert isinstance(credgen["vault_server"], str)
-                if credgen["vault_issuer"]:
-                    assert isinstance(credgen["vault_issuer"], str)
-                if credgen["base_path"]:
-                    assert isinstance(credgen["base_path"], str)
-
-        response = client.get('/stashcache/namespaces')
-        assert response.status_code == 200
-        namespaces_json = response.json
-
-        assert "caches" in namespaces_json
-        caches = namespaces_json["caches"]
-        # Have a reasonable number of caches
-        assert len(caches) > 20
-        for cache in caches:
-            validate_cache_schema(cache)
-
-        assert "namespaces" in namespaces_json
-        namespaces = namespaces_json["namespaces"]
-        # Have a reasonable number of namespaces
-        assert len(namespaces) > 15
-
-        found_credgen = False
-        for namespace in namespaces:
-            if namespace["credential_generation"] is not None:
-                found_credgen = True
-            validate_namespace_schema(namespace)
-            if namespace["caches"]:
-                for cache in namespace["caches"]:
-                    validate_cache_schema(cache)
-        assert found_credgen, "At least one namespace with credential_generation"
-
 
     def test_institution_accept_type(self, client: flask.Flask):
         """Checks both formats output the same content"""

--- a/src/tests/test_stashcache.py
+++ b/src/tests/test_stashcache.py
@@ -5,6 +5,8 @@ import pytest
 import re
 from pytest_mock import MockerFixture
 import time
+from typing import List, Dict
+import urllib, urllib.parse
 
 # Rewrites the path so the app can be imported like it normally is
 import os
@@ -18,7 +20,11 @@ os.environ['TESTING'] = "True"
 from app import app, global_data
 from webapp import models, topology, vos_data
 from webapp.common import load_yaml_file
+from webapp.data_federation import CredentialGeneration
 import stashcache
+
+HOST_PORT_RE = re.compile(r"[a-zA-Z0-9.-]{3,63}:[0-9]{2,5}")
+PROTOCOL_HOST_PORT_RE = re.compile(r"[a-z]+://" + HOST_PORT_RE.pattern)
 
 GRID_MAPPING_REGEX = re.compile(r'^"(/[^"]*CN=[^"]+")\s+([0-9a-f]{8}[.]0)$')
 # ^^ the DN starts with a slash and will at least have a CN in it.
@@ -216,6 +222,88 @@ class TestStashcache:
             else:
                 assert False, f'Unexpected text "{line}".\nFull text:\n{text}\n'
         assert num_mappings > 5, f"Too few mappings found.\nFull text:\n{text}\n"
+
+
+class TestNamespaces:
+    @pytest.fixture
+    def namespaces_json(self, test_global_data) -> Dict:
+        return stashcache.get_namespaces_info(test_global_data)
+
+    @pytest.fixture
+    def namespaces(self, namespaces_json) -> List[Dict]:
+        assert "namespaces" in namespaces_json
+        return namespaces_json["namespaces"]
+
+    @staticmethod
+    def validate_cache_schema(cc):
+        assert HOST_PORT_RE.match(cc["auth_endpoint"])
+        assert HOST_PORT_RE.match(cc["endpoint"])
+        assert cc["resource"] and isinstance(cc["resource"], str)
+
+    @staticmethod
+    def validate_namespace_schema(ns):
+        assert isinstance(ns["caches"], list)  # we do have a case where it's empty
+        assert ns["path"].startswith("/")  # implies str
+        assert isinstance(ns["readhttps"], bool)
+        assert isinstance(ns["usetokenonread"], bool)
+        assert ns["dirlisthost"] is None or PROTOCOL_HOST_PORT_RE.match(ns["dirlisthost"])
+        assert ns["writebackhost"] is None or PROTOCOL_HOST_PORT_RE.match(ns["writebackhost"])
+        credgen = ns["credential_generation"]
+        if credgen is not None:
+            assert isinstance(credgen["max_scope_depth"], int) and credgen["max_scope_depth"] > -1
+            assert credgen["strategy"] in CredentialGeneration.STRATEGIES
+            assert credgen["issuer"]
+            parsed_issuer = urllib.parse.urlparse(credgen["issuer"])
+            assert parsed_issuer.netloc and parsed_issuer.scheme == "https"
+            if credgen["vault_server"]:
+                assert isinstance(credgen["vault_server"], str)
+            if credgen["vault_issuer"]:
+                assert isinstance(credgen["vault_issuer"], str)
+            if credgen["base_path"]:
+                assert isinstance(credgen["base_path"], str)
+
+    def test_caches(self, namespaces_json):
+        assert "caches" in namespaces_json
+        caches = namespaces_json["caches"]
+        # Have a reasonable number of caches
+        assert len(caches) > 20
+        for cache in caches:
+            self.validate_cache_schema(cache)
+
+    def test_namespaces(self, namespaces):
+        # Have a reasonable number of namespaces
+        assert len(namespaces) > 15
+
+        found_credgen = False
+        for namespace in namespaces:
+            if namespace["credential_generation"] is not None:
+                found_credgen = True
+            self.validate_namespace_schema(namespace)
+            if namespace["caches"]:
+                for cache in namespace["caches"]:
+                    self.validate_cache_schema(cache)
+        assert found_credgen, "At least one namespace with credential_generation"
+
+    @staticmethod
+    def validate_scitokens_block(sci):
+        assert sci["issuer"]
+        assert isinstance(sci["issuer"], str)
+        assert "://" in sci["issuer"]
+        assert isinstance(sci["basepath"], list)
+        assert sci["basepath"]  # must have at least 1
+        for bp in sci["basepath"]:
+            assert bp.startswith("/")  # implies str
+            assert "," not in bp
+        assert isinstance(sci["restrictedpath"], list)
+        for rp in sci["restrictedpath"]:  # may be empty
+            assert rp.startswith("/")  # implies str
+            assert "," not in rp
+
+    def test_issuers_in_namespaces(self, namespaces):
+        for namespace in namespaces:
+            assert isinstance(namespace["scitokens"], list)
+            for scitokens_block in namespace["scitokens"]:
+                self.validate_scitokens_block(scitokens_block)
 
 
 if __name__ == '__main__':

--- a/src/tests/test_stashcache.py
+++ b/src/tests/test_stashcache.py
@@ -291,13 +291,13 @@ class TestNamespaces:
         assert sci["issuer"]
         assert isinstance(sci["issuer"], str)
         assert "://" in sci["issuer"]
-        assert isinstance(sci["basepath"], list)
-        assert sci["basepath"]  # must have at least 1
-        for bp in sci["basepath"]:
+        assert isinstance(sci["base_path"], list)
+        assert sci["base_path"]  # must have at least 1
+        for bp in sci["base_path"]:
             assert bp.startswith("/")  # implies str
             assert "," not in bp
-        assert isinstance(sci["restrictedpath"], list)
-        for rp in sci["restrictedpath"]:  # may be empty
+        assert isinstance(sci["restricted_path"], list)
+        for rp in sci["restricted_path"]:  # may be empty
             assert rp.startswith("/")  # implies str
             assert "," not in rp
 
@@ -321,8 +321,8 @@ class TestNamespaces:
         assert len(ns["scitokens"]) == 1
         sci = ns["scitokens"][0]
         assert sci["issuer"] == TEST_ISSUER
-        assert sci["basepath"] == [TEST_BASEPATH]
-        assert sci["restrictedpath"] == []
+        assert sci["base_path"] == [TEST_BASEPATH]
+        assert sci["restricted_path"] == []
 
 
     def test_testvo_namespace(self, namespaces):
@@ -344,8 +344,8 @@ class TestNamespaces:
         assert len(ns["scitokens"]) == 1
         sci = ns["scitokens"][0]
         assert sci["issuer"] == TEST_ISSUER
-        assert sci["basepath"] == [TEST_BASEPATH]
-        assert sci["restrictedpath"] == []
+        assert sci["base_path"] == [TEST_BASEPATH]
+        assert sci["restricted_path"] == []
 
 
 if __name__ == '__main__':

--- a/src/tests/test_stashcache.py
+++ b/src/tests/test_stashcache.py
@@ -45,7 +45,8 @@ MOCK_DNS_AND_HASHES = {
 MOCK_DN_LIST = list(MOCK_DNS_AND_HASHES.keys())
 
 
-def get_test_global_data(global_data: models.GlobalData) -> models.GlobalData:
+@pytest.fixture
+def test_global_data() -> models.GlobalData:
     """Get a copy of the global data with some entries created for testing"""
     new_global_data = copy.deepcopy(global_data)
 
@@ -105,8 +106,7 @@ class TestStashcache:
 
         assert spy.call_count == 0
 
-    def test_scitokens_issuer_sections(self, client: flask.Flask):
-        test_global_data = get_test_global_data(global_data)
+    def test_scitokens_issuer_sections(self, test_global_data):
         origin_scitokens_conf = stashcache.generate_origin_scitokens(
             test_global_data, TEST_ITB_HELM_ORIGIN)
         assert origin_scitokens_conf.strip(), "Generated scitokens.conf empty"
@@ -128,9 +128,7 @@ class TestStashcache:
             print(f"Generated origin scitokens.conf text:\n{origin_scitokens_conf}\n", file=sys.stderr)
             raise
 
-    def test_scitokens_issuer_public_read_auth_write_namespaces_info(self, client: flask.Flask):
-        test_global_data = get_test_global_data(global_data)
-
+    def test_scitokens_issuer_public_read_auth_write_namespaces_info(self, test_global_data):
         namespaces_json = stashcache.get_namespaces_info(test_global_data)
         namespaces = namespaces_json["namespaces"]
         testvo_PUBLIC_namespace_list = [
@@ -145,9 +143,7 @@ class TestStashcache:
         assert ns["writebackhost"] == f"https://{TEST_SC_ORIGIN}:1095", \
             "writebackhost is wrong for namespace with auth write"
 
-    def test_scitokens_issuer_public_read_auth_write_scitokens_conf(self, client: flask.Flask):
-        test_global_data = get_test_global_data(global_data)
-
+    def test_scitokens_issuer_public_read_auth_write_scitokens_conf(self, test_global_data):
         origin_scitokens_conf = stashcache.generate_origin_scitokens(
             test_global_data, TEST_SC_ORIGIN)
         assert origin_scitokens_conf.strip(), "Generated scitokens.conf empty"

--- a/src/webapp/data_federation.py
+++ b/src/webapp/data_federation.py
@@ -104,12 +104,12 @@ class SciTokenAuth(AuthMethod):
         return block
 
     def get_namespaces_scitokens_block(self):
-        basepath = re.split(r"\s*,\s*", self.base_path)
-        restrictedpath = re.split(r"\s*,\s*", self.restricted_path) if self.restricted_path else []
+        base_path = re.split(r"\s*,\s*", self.base_path)
+        restricted_path = re.split(r"\s*,\s*", self.restricted_path) if self.restricted_path else []
         return {
             "issuer": self.issuer,
-            "basepath": basepath,
-            "restrictedpath": restrictedpath,
+            "base_path": base_path,
+            "restricted_path": restricted_path,
         }
 
 

--- a/src/webapp/data_federation.py
+++ b/src/webapp/data_federation.py
@@ -1,3 +1,4 @@
+import re
 import urllib
 import urllib.parse
 from collections import OrderedDict
@@ -25,6 +26,8 @@ class AuthMethod:
     def get_grid_mapfile_line(self):
         return ""
 
+    def get_namespaces_scitokens_block(self):
+        return None
 
 class NullAuth(AuthMethod):
     pass
@@ -99,6 +102,15 @@ class SciTokenAuth(AuthMethod):
             block += f"map_subject = {self.map_subject}\n"
 
         return block
+
+    def get_namespaces_scitokens_block(self):
+        basepath = re.split(r"\s*,\s*", self.base_path)
+        restrictedpath = re.split(r"\s*,\s*", self.restricted_path) if self.restricted_path else []
+        return {
+            "issuer": self.issuer,
+            "basepath": basepath,
+            "restrictedpath": restrictedpath,
+        }
 
 
 # TODO Use a dataclass (https://docs.python.org/3.9/library/dataclasses.html)


### PR DESCRIPTION
Add info about scitokens issuers for each namespaces to the JSON served by the `/osdf/namespaces` endpoint (a.k.a. `/stashcache/namespaces` and `/stashcache/namespaces.json`).  The schema is described in https://opensciencegrid.atlassian.net/browse/SOFTWARE-5760.