### PR TITLE
Disable non-functional shoveler cache

### DIFF
--- a/topology/University of Wisconsin/CHTC/CHTC-OSDF.yaml
+++ b/topology/University of Wisconsin/CHTC/CHTC-OSDF.yaml
@@ -181,7 +181,7 @@ Resources:
       - ANY
 
   CHTC_OSGDEV_SHOVELER_CACHE:
-    Active: true
+    Active: false
     Description: This is a testing StashCache cache server with a shoveler at UW running on the Tiger Kubernetes cluster.
     ContactLists:
       Administrative Contact:


### PR DESCRIPTION
The fact this is enabled is causing problems with the directors as it is assumed caches registered in topology are usable.

@matyasselmeci 