### PR TITLE
Update BNL-ATLAS_downtime.yaml

### DIFF
--- a/topology/Brookhaven National Laboratory/BNL ATLAS Tier1/BNL-ATLAS_downtime.yaml
+++ b/topology/Brookhaven National Laboratory/BNL ATLAS Tier1/BNL-ATLAS_downtime.yaml
@@ -1428,7 +1428,7 @@
   ID: 1630658348
   Description: Network downtime
   Severity: Outage
-  StartTime: Dec 19, 2023 11:00 +0000
+  StartTime: Dec 17, 2023 11:00 +0000
   EndTime: Dec 20, 2023 02:00 +0000
   CreatedTime: Oct 23, 2023 12:57 +0000
   ResourceName: BNL_ATLAS_1
@@ -1439,7 +1439,7 @@
   ID: 1630658349
   Description: Network downtime
   Severity: Outage
-  StartTime: Dec 19, 2023 11:00 +0000
+  StartTime: Dec 17, 2023 11:00 +0000
   EndTime: Dec 20, 2023 02:00 +0000
   CreatedTime: Oct 23, 2023 12:57 +0000
   ResourceName: BNL_ATLAS_2
@@ -1450,7 +1450,7 @@
   ID: 1630658350
   Description: Network downtime
   Severity: Outage
-  StartTime: Dec 19, 2023 11:00 +0000
+  StartTime: Dec 17, 2023 11:00 +0000
   EndTime: Dec 20, 2023 02:00 +0000
   CreatedTime: Oct 23, 2023 12:57 +0000
   ResourceName: BNL_ATLAS_3
@@ -1461,7 +1461,7 @@
   ID: 1630658351
   Description: Network downtime
   Severity: Outage
-  StartTime: Dec 19, 2023 11:00 +0000
+  StartTime: Dec 17, 2023 11:00 +0000
   EndTime: Dec 20, 2023 02:00 +0000
   CreatedTime: Oct 23, 2023 12:57 +0000
   ResourceName: BNL_ATLAS_4
@@ -1472,7 +1472,7 @@
   ID: 1630658352
   Description: Network downtime
   Severity: Outage
-  StartTime: Dec 19, 2023 11:00 +0000
+  StartTime: Dec 17, 2023 11:00 +0000
   EndTime: Dec 20, 2023 02:00 +0000
   CreatedTime: Oct 23, 2023 12:57 +0000
   ResourceName: BNL_ATLAS_6
@@ -1483,7 +1483,7 @@
   ID: 1630658353
   Description: Network downtime
   Severity: Outage
-  StartTime: Dec 19, 2023 11:00 +0000
+  StartTime: Dec 17, 2023 11:00 +0000
   EndTime: Dec 20, 2023 02:00 +0000
   CreatedTime: Oct 23, 2023 12:57 +0000
   ResourceName: BNL_ATLAS_7
@@ -1494,7 +1494,7 @@
   ID: 1630658354
   Description: Network downtime
   Severity: Outage
-  StartTime: Dec 19, 2023 11:00 +0000
+  StartTime: Dec 17, 2023 11:00 +0000
   EndTime: Dec 20, 2023 02:00 +0000
   CreatedTime: Oct 23, 2023 12:57 +0000
   ResourceName: BNL_ATLAS_8
@@ -1505,7 +1505,7 @@
   ID: 1630658355
   Description: Network downtime
   Severity: Outage
-  StartTime: Dec 19, 2023 11:00 +0000
+  StartTime: Dec 17, 2023 11:00 +0000
   EndTime: Dec 20, 2023 02:00 +0000
   CreatedTime: Oct 23, 2023 12:57 +0000
   ResourceName: BNL_ATLAS_CVMFS_Squid
@@ -1516,7 +1516,7 @@
   ID: 1630658356
   Description: Network downtime
   Severity: Outage
-  StartTime: Dec 19, 2023 11:00 +0000
+  StartTime: Dec 17, 2023 11:00 +0000
   EndTime: Dec 20, 2023 02:00 +0000
   CreatedTime: Oct 23, 2023 12:57 +0000
   ResourceName: BNL_ATLAS_Frontier_Squid
@@ -1527,7 +1527,7 @@
   ID: 1630658357
   Description: Network downtime
   Severity: Outage
-  StartTime: Dec 19, 2023 11:00 +0000
+  StartTime: Dec 17, 2023 11:00 +0000
   EndTime: Dec 20, 2023 02:00 +0000
   CreatedTime: Oct 23, 2023 12:57 +0000
   ResourceName: BNL_ATLAS_SE
@@ -1539,7 +1539,7 @@
   ID: 1630658358
   Description: Network downtime
   Severity: Outage
-  StartTime: Dec 19, 2023 11:00 +0000
+  StartTime: Dec 17, 2023 11:00 +0000
   EndTime: Dec 20, 2023 02:00 +0000
   CreatedTime: Oct 23, 2023 12:57 +0000
   ResourceName: BNL_ATLAS_SE_AWS_East
@@ -1550,7 +1550,7 @@
   ID: 1630658359
   Description: Network downtime
   Severity: Outage
-  StartTime: Dec 19, 2023 11:00 +0000
+  StartTime: Dec 17, 2023 11:00 +0000
   EndTime: Dec 20, 2023 02:00 +0000
   CreatedTime: Oct 23, 2023 12:57 +0000
   ResourceName: BNL_ATLAS_SE_AWS_West
@@ -1561,7 +1561,7 @@
   ID: 1630658360
   Description: Network downtime
   Severity: Outage
-  StartTime: Dec 19, 2023 11:00 +0000
+  StartTime: Dec 17, 2023 11:00 +0000
   EndTime: Dec 20, 2023 02:00 +0000
   CreatedTime: Oct 23, 2023 12:57 +0000
   ResourceName: BNL_ATLAS_SE_AWS_West2
@@ -1572,7 +1572,7 @@
   ID: 1630658361
   Description: Network downtime
   Severity: Outage
-  StartTime: Dec 19, 2023 11:00 +0000
+  StartTime: Dec 17, 2023 11:00 +0000
   EndTime: Dec 20, 2023 02:00 +0000
   CreatedTime: Oct 23, 2023 12:57 +0000
   ResourceName: BNL_ATLAS_SE_GRIDFTP
@@ -1583,7 +1583,7 @@
   ID: 1630658362
   Description: Network downtime
   Severity: Outage
-  StartTime: Dec 19, 2023 11:00 +0000
+  StartTime: Dec 17, 2023 11:00 +0000
   EndTime: Dec 20, 2023 02:00 +0000
   CreatedTime: Oct 23, 2023 12:57 +0000
   ResourceName: lhcmon-bnl
@@ -1594,7 +1594,7 @@
   ID: 1630658363
   Description: Network downtime
   Severity: Outage
-  StartTime: Dec 19, 2023 11:00 +0000
+  StartTime: Dec 17, 2023 11:00 +0000
   EndTime: Dec 20, 2023 02:00 +0000
   CreatedTime: Oct 23, 2023 12:57 +0000
   ResourceName: lhcperfmon-bnl
@@ -1605,7 +1605,7 @@
   ID: 1630658364
   Description: Network downtime
   Severity: Outage
-  StartTime: Dec 19, 2023 11:00 +0000
+  StartTime: Dec 17, 2023 11:00 +0000
   EndTime: Dec 20, 2023 02:00 +0000
   CreatedTime: Oct 23, 2023 12:57 +0000
   ResourceName: ps-development


### PR DESCRIPTION
advance the downtime to ensure the farm is drained so the nfs partitions can be unmounted well ahead of the downtime