### PR TITLE
Use supported LDAP search_scope (SOFTWARE-5766)

### DIFF
--- a/src/webapp/ldap_data.py
+++ b/src/webapp/ldap_data.py
@@ -35,7 +35,7 @@ def get_cilogon_ldap_id_map(ldap_url, ldap_user, ldap_pass):
     conn = ldap3.Connection(server, ldap_user, ldap_pass, receive_timeout=CILOGON_LDAP_TIMEOUT)
     if not conn.bind():
         return None  # connection failure
-    conn.search(_cilogon_basedn, _ACTIVE_COPERSON_FILTER, search_scope='LEVEL', attributes=['*'])
+    conn.search(_cilogon_basedn, _ACTIVE_COPERSON_FILTER, search_scope=ldap3.LEVEL, attributes=['*'])
     result_data = [ (e.entry_dn, e.entry_attributes_as_dict)
                     for e in conn.entries ]
     conn.unbind()

--- a/src/webapp/ldap_data.py
+++ b/src/webapp/ldap_data.py
@@ -35,7 +35,10 @@ def get_cilogon_ldap_id_map(ldap_url, ldap_user, ldap_pass):
     conn = ldap3.Connection(server, ldap_user, ldap_pass, receive_timeout=CILOGON_LDAP_TIMEOUT)
     if not conn.bind():
         return None  # connection failure
-    conn.search(_cilogon_basedn, _ACTIVE_COPERSON_FILTER, search_scope=ldap3.LEVEL, attributes=['*'])
+    conn.search(_cilogon_basedn,
+                _ACTIVE_COPERSON_FILTER,
+                search_scope=ldap3.LEVEL,
+                attributes=['*'])
     result_data = [ (e.entry_dn, e.entry_attributes_as_dict)
                     for e in conn.entries ]
     conn.unbind()

--- a/src/webapp/ldap_data.py
+++ b/src/webapp/ldap_data.py
@@ -35,7 +35,7 @@ def get_cilogon_ldap_id_map(ldap_url, ldap_user, ldap_pass):
     conn = ldap3.Connection(server, ldap_user, ldap_pass, receive_timeout=CILOGON_LDAP_TIMEOUT)
     if not conn.bind():
         return None  # connection failure
-    conn.search(_cilogon_basedn, _ACTIVE_COPERSON_FILTER, search_scope='one', attributes=['*'])
+    conn.search(_cilogon_basedn, _ACTIVE_COPERSON_FILTER, search_scope='LEVEL', attributes=['*'])
     result_data = [ (e.entry_dn, e.entry_attributes_as_dict)
                     for e in conn.entries ]
     conn.unbind()


### PR DESCRIPTION
Unhelpfully missing from the Python documentation (https://ldap3.readthedocs.io/en/latest/searches.html):
BASE: retrieves attributes of the entry specified in the search_base.
LEVEL: retrieves attributes of the entries contained in the search_base. The base must reference a container object.
SUBTREE: retrieves attributes of the entries specified in the search_base and all subordinate containers downward.