### PR TITLE
"Fix" get_ligo_dn_list test to work with the /igwn/kagra namespace

### DIFF
--- a/src/tests/test_stashcache.py
+++ b/src/tests/test_stashcache.py
@@ -98,14 +98,14 @@ class TestStashcache:
 
         stashcache.generate_cache_authfile(global_data, "osg-sunnyvale-stashcache.nrp.internet2.edu")
 
-        assert spy.call_count == 5
+        assert spy.call_count == 6
 
     def test_allowedVO_includes_LIGO_for_ligo_inclusion(self, client: flask.Flask, mocker: MockerFixture):
         spy = mocker.spy(global_data, "get_ligo_dn_list")
 
         stashcache.generate_cache_authfile(global_data, "stashcache.gwave.ics.psu.edu")
 
-        assert spy.call_count == 5
+        assert spy.call_count == 6
 
     def test_allowedVO_excludes_LIGO_and_ANY_for_ligo_inclusion(self, client: flask.Flask, mocker: MockerFixture):
         spy = mocker.spy(global_data, "get_ligo_dn_list")


### PR DESCRIPTION
that was added in #3539