### PR TITLE
Update CIT_LIGO.yaml

### DIFF
--- a/topology/California Institute of Technology/Caltech LIGO/CIT_LIGO.yaml
+++ b/topology/California Institute of Technology/Caltech LIGO/CIT_LIGO.yaml
@@ -93,7 +93,6 @@ Resources:
           ID: c50e7cc9d0086272ef995fb76461612d40c70435
     FQDN: origin-readtest.ligo.caltech.edu
     DN: /DC=org/DC=incommon/C=US/ST=California/O=California Institute of Technology/CN=origin-readtest.ligo.caltech.edu
-    ID: 
     Services:
       XRootD origin server:
         Description: StashCache Origin server
@@ -113,7 +112,6 @@ Resources:
           ID: c50e7cc9d0086272ef995fb76461612d40c70435
     FQDN: origin-writetest.ligo.caltech.edu
     DN: /DC=org/DC=incommon/C=US/ST=California/O=California Institute of Technology/CN=origin-writetest.ligo.caltech.edu
-    ID: 
     Services:
       XRootD origin server:
         Description: StashCache Origin server

--- a/topology/California Institute of Technology/Caltech LIGO/CIT_LIGO.yaml
+++ b/topology/California Institute of Technology/Caltech LIGO/CIT_LIGO.yaml
@@ -79,6 +79,46 @@ Resources:
         Description: StashCache Origin server
     AllowedVOs:
       - LIGO
+  CIT_LIGO_ORIGIN_TEST:
+    Active: true
+    Description: This serves proprietary LIGO interferometer data in a test configuration
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          Name: Stuart Anderson
+          ID: c50e7cc9d0086272ef995fb76461612d40c70435
+      Security Contact:
+        Primary:
+          Name: Stuart Anderson
+          ID: c50e7cc9d0086272ef995fb76461612d40c70435
+    FQDN: origin-readtest.ligo.caltech.edu
+    DN: /DC=org/DC=incommon/C=US/ST=California/O=California Institute of Technology/CN=origin-readtest.ligo.caltech.edu
+    ID: 
+    Services:
+      XRootD origin server:
+        Description: StashCache Origin server
+    AllowedVOs:
+      - LIGO
+  CIT_LIGO_ORIGIN_TEST_WRITE:
+    Active: true
+    Description: This serves proprietary user data staged to and from the CIT cluster in a test configuration
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          Name: Stuart Anderson
+          ID: c50e7cc9d0086272ef995fb76461612d40c70435
+      Security Contact:
+        Primary:
+          Name: Stuart Anderson
+          ID: c50e7cc9d0086272ef995fb76461612d40c70435
+    FQDN: origin-writetest.ligo.caltech.edu
+    DN: /DC=org/DC=incommon/C=US/ST=California/O=California Institute of Technology/CN=origin-writetest.ligo.caltech.edu
+    ID: 
+    Services:
+      XRootD origin server:
+        Description: StashCache Origin server
+    AllowedVOs:
+      - LIGO
   CIT_LIGO_SQUID1:
     ContactLists:
       Administrative Contact:


### PR DESCRIPTION
This adds information for two test OSDF origin servers that we are standing up, to allow us to test using both CILogon issued SciTokens and access-point issued SciTokens, without disrupting production services during our ongoing observing run. As per usual, the "ID" field of the new servers is left blank, so that someone from PATh can fill in an available ID.