### PR TITLE
Add test origins to LIGO.yaml

### DIFF
--- a/virtual-organizations/LIGO.yaml
+++ b/virtual-organizations/LIGO.yaml
@@ -86,10 +86,10 @@ DataFederations:
           - FQAN: /virgo/ligo
           - SciTokens:
               Issuer: https://cilogon.org/igwn
-              Base Path: /user/ligo,/igwn,/igwn/cit
+              Base Path: /user/ligo,/igwn,/igwn/cit,/igwn/test,/igwn/test-write
           - SciTokens:
               Issuer: https://test.cilogon.org/igwn
-              Base Path: /user/ligo,/igwn,/igwn/cit
+              Base Path: /user/ligo,/igwn,/igwn/cit,/igwn/test,/igwn/test-write
         AllowedOrigins:
           - CIT_LIGO_ORIGIN
           - LIGO-StashCache-Origin
@@ -134,10 +134,10 @@ DataFederations:
           # But the problem should be solved either by topology (ideally) or the SciTokens XRootD plugin.
           - SciTokens:
               Issuer: https://cilogon.org/igwn
-              Base Path: /user/ligo,/igwn,/igwn/cit
+              Base Path: /user/ligo,/igwn,/igwn/cit,/igwn/test,/igwn/test-write
           - SciTokens:
               Issuer: https://test.cilogon.org/igwn
-              Base Path: /user/ligo,/igwn,/igwn/cit
+              Base Path: /user/ligo,/igwn,/igwn/cit,/igwn/test,/igwn/test-write
         AllowedOrigins:
           - UCL-Virgo-StashCache-Origin
         AllowedCaches:
@@ -181,10 +181,10 @@ DataFederations:
           # But the problem should be solved either by topology (ideally) or the SciTokens XRootD plugin.
           - SciTokens:
               Issuer: https://cilogon.org/igwn
-              Base Path: /user/ligo,/igwn,/igwn/cit
+              Base Path: /user/ligo,/igwn,/igwn/cit,/igwn/test,/igwn/test-write
           - SciTokens:
               Issuer: https://test.cilogon.org/igwn
-              Base Path: /user/ligo,/igwn,/igwn/cit
+              Base Path: /user/ligo,/igwn,/igwn/cit,/igwn/test,/igwn/test-write
         AllowedOrigins:
           - CIT_LIGO_ORIGIN_IFO
         AllowedCaches:
@@ -228,10 +228,10 @@ DataFederations:
           # But the problem should be solved either by topology (ideally) or the SciTokens XRootD plugin.
           - SciTokens:
               Issuer: https://cilogon.org/igwn
-              Base Path: /user/ligo,/igwn,/igwn/cit
+              Base Path: /user/ligo,/igwn,/igwn/cit,/igwn/test,/igwn/test-write
           - SciTokens:
               Issuer: https://test.cilogon.org/igwn
-              Base Path: /user/ligo,/igwn,/igwn/cit
+              Base Path: /user/ligo,/igwn,/igwn/cit,/igwn/test,/igwn/test-write
         AllowedOrigins:
           - KAGRA_OSDF_ORIGIN
         AllowedCaches:
@@ -275,10 +275,10 @@ DataFederations:
           # But the problem should be solved either by topology (ideally) or the SciTokens XRootD plugin.
           - SciTokens:
               Issuer: https://cilogon.org/igwn
-              Base Path: /user/ligo,/igwn,/igwn/cit
+              Base Path: /user/ligo,/igwn,/igwn/cit,/igwn/test,/igwn/test-write
           - SciTokens:
               Issuer: https://test.cilogon.org/igwn
-              Base Path: /user/ligo,/igwn,/igwn/cit
+              Base Path: /user/ligo,/igwn,/igwn/cit,/igwn/test,/igwn/test-write
         AllowedOrigins:
           - CIT_LIGO_ORIGIN_SHARED
         AllowedCaches:
@@ -322,10 +322,10 @@ DataFederations:
           # But the problem should be solved either by topology (ideally) or the SciTokens XRootD plugin.
           - SciTokens:
               Issuer: https://cilogon.org/igwn
-              Base Path: /user/ligo,/igwn,/igwn/cit
+              Base Path: /user/ligo,/igwn,/igwn/cit,/igwn/test,/igwn/test-write
           - SciTokens:
               Issuer: https://test.cilogon.org/igwn
-              Base Path: /user/ligo,/igwn,/igwn/cit
+              Base Path: /user/ligo,/igwn,/igwn/cit,/igwn/test,/igwn/test-write
         AllowedOrigins:
           - CIT_LIGO_ORIGIN_STAGING
         AllowedCaches:
@@ -359,6 +359,107 @@ DataFederations:
           - SINGAPORE_INTERNET2_OSDF_CACHE
           - SPRACE_OSDF_CACHE
         Writeback: https://origin-staging.ligo.caltech.edu:1095
+      - Path: /igwn/test
+        Authorizations:
+          - FQAN: /osg/ligo
+          - FQAN: /virgo
+          - FQAN: /virgo/virgo
+          - FQAN: /virgo/ligo
+          # No Scitokens issuers because they are duplicated with the /user/ligo path.
+          # As long as the caches are kept in sync, this below fix should be fine.
+          # But the problem should be solved either by topology (ideally) or the SciTokens XRootD plugin.
+          - SciTokens:
+              Issuer: https://cilogon.org/igwn
+              Base Path: /user/ligo,/igwn,/igwn/cit,/igwn/test,/igwn/test-write
+          - SciTokens:
+              Issuer: https://test.cilogon.org/igwn
+              Base Path: /user/ligo,/igwn,/igwn/cit,/igwn/test,/igwn/test-write
+          - SciTokens:
+              Issuer: https://osdf.igwn.org/cit
+              Base Path: /igwn/test,/igwn/test-write
+        AllowedOrigins:
+          - CIT_LIGO_ORIGIN_TEST
+        AllowedCaches:
+          - SUT-STASHCACHE
+          - Georgia_Tech_PACE_GridFTP2
+          - Stashcache-UCSD
+          - Stashcache-UofA
+          - Stashcache-KISTI
+          - Stashcache-Houston
+          - Stashcache-Manhattan
+          - Stashcache-Sunnyvale
+          - Stashcache-Chicago
+          - Stashcache-Kansas
+          - PIC_STASHCACHE_CACHE
+          - SU_STASHCACHE_CACHE
+          - PSU-LIGO-CACHE
+          - MGHPCC_NRP_OSDF_CACHE
+          - SDSC_NRP_OSDF_CACHE
+          - NEBRASKA_NRP_OSDF_CACHE
+          - CINCINNATI_INTERNET2_OSDF_CACHE
+          - BOISE_INTERNET2_OSDF_CACHE
+          - INFN_CNAF_OSDF_CACHE
+          - CARDIFF_UK_OSDF_CACHE
+          - ComputeCanada-Cedar-Cache
+          - JACKSONVILLE_INTERNET2_OSDF_CACHE
+          - DENVER_INTERNET2_OSDF_CACHE
+          - AMSTERDAM_ESNET_OSDF_CACHE
+          - LONDON_ESNET_OSDF_CACHE                    
+          - HOUSTON2_INTERNET2_OSDF_CACHE
+          - CIT_LIGO_STASHCACHE
+          - SINGAPORE_INTERNET2_OSDF_CACHE
+          - SPRACE_OSDF_CACHE
+      - Path: /igwn/test-write
+        Authorizations:
+          - FQAN: /osg/ligo
+          - FQAN: /virgo
+          - FQAN: /virgo/virgo
+          - FQAN: /virgo/ligo
+          # No Scitokens issuers because they are duplicated with the /user/ligo path.
+          # As long as the caches are kept in sync, this below fix should be fine.
+          # But the problem should be solved either by topology (ideally) or the SciTokens XRootD plugin.
+          - SciTokens:
+              Issuer: https://cilogon.org/igwn
+              Base Path: /user/ligo,/igwn,/igwn/cit,/igwn/test,/igwn/test-write
+          - SciTokens:
+              Issuer: https://test.cilogon.org/igwn
+              Base Path: /user/ligo,/igwn,/igwn/cit,/igwn/test,/igwn/test-write
+          - SciTokens:
+              Issuer: https://osdf.igwn.org/cit
+              Base Path: /igwn/test,/igwn/test-write
+        AllowedOrigins:
+          - CIT_LIGO_ORIGIN_TEST_WRITE
+        AllowedCaches:
+          - SUT-STASHCACHE
+          - Georgia_Tech_PACE_GridFTP2
+          - Stashcache-UCSD
+          - Stashcache-UofA
+          - Stashcache-KISTI
+          - Stashcache-Houston
+          - Stashcache-Manhattan
+          - Stashcache-Sunnyvale
+          - Stashcache-Chicago
+          - Stashcache-Kansas
+          - PIC_STASHCACHE_CACHE
+          - SU_STASHCACHE_CACHE
+          - PSU-LIGO-CACHE
+          - MGHPCC_NRP_OSDF_CACHE
+          - SDSC_NRP_OSDF_CACHE
+          - NEBRASKA_NRP_OSDF_CACHE
+          - CINCINNATI_INTERNET2_OSDF_CACHE
+          - BOISE_INTERNET2_OSDF_CACHE
+          - INFN_CNAF_OSDF_CACHE
+          - CARDIFF_UK_OSDF_CACHE
+          - ComputeCanada-Cedar-Cache
+          - JACKSONVILLE_INTERNET2_OSDF_CACHE
+          - DENVER_INTERNET2_OSDF_CACHE
+          - AMSTERDAM_ESNET_OSDF_CACHE
+          - LONDON_ESNET_OSDF_CACHE                    
+          - HOUSTON2_INTERNET2_OSDF_CACHE
+          - CIT_LIGO_STASHCACHE
+          - SINGAPORE_INTERNET2_OSDF_CACHE
+          - SPRACE_OSDF_CACHE
+        Writeback: https://origin-writetest.ligo.caltech.edu:1095
       - Path: /gwdata
         Authorizations:
           - PUBLIC


### PR DESCRIPTION
This PR integrates two new test origins---`CIT_LIGO_ORIGIN_TEST` and `CIT_LIGO_ORIGIN_TEST_WRITE`---into the OSDF for the LIGO VO. The former is to test a combination of vault-issued tokens from CILogon and AP-issued tokens in a standard xrootd origin; the second is to test the same mixture in writeback mode to an origin with xrootd-privileged.

A couple of notes:
1. It is deliberate that we need two new base-paths, `/igwn/test` and `/igwn/test-write`. We do this so that we can use the existing scopes of our CILogon tokens, and therefore are testing with tokens that match what users will get (whether they use CILogon-issued tokens or AP-issued tokens). This has the side-effect that we have to add those two new paths to the `Base Path` for all of our Namespaces, since those are grouped together by token issuer. Hence the other changed lines in this file.
2. The new AP-issuer is for now only added to these test origins, since part of what we want to test is that this doesn't break anything before extending it to production origins. Therefore that issuer only supports the two new `Base Path`s for now.