### PR TITLE
Use YAML aliases to reduce duplication in LIGO namespace info

### DIFF
--- a/virtual-organizations/LIGO.yaml
+++ b/virtual-organizations/LIGO.yaml
@@ -93,7 +93,7 @@ DataFederations:
         AllowedOrigins:
           - CIT_LIGO_ORIGIN
           - LIGO-StashCache-Origin
-        AllowedCaches:
+        AllowedCaches: &ligo-allowed-caches
           - SUT-STASHCACHE
           - Georgia_Tech_PACE_GridFTP2
           - Stashcache-UCSD
@@ -137,36 +137,7 @@ DataFederations:
               Base Path: /user/ligo,/igwn,/igwn/cit,/igwn/test,/igwn/test-write
         AllowedOrigins:
           - UCL-Virgo-StashCache-Origin
-        AllowedCaches:
-          - SUT-STASHCACHE
-          - Georgia_Tech_PACE_GridFTP2
-          - Stashcache-UCSD
-          - Stashcache-UofA
-          - Stashcache-KISTI
-          - Stashcache-Houston
-          - Stashcache-Manhattan
-          - Stashcache-Sunnyvale
-          - Stashcache-Chicago
-          - Stashcache-Kansas
-          - PIC_STASHCACHE_CACHE
-          - SU_STASHCACHE_CACHE
-          - PSU-LIGO-CACHE
-          - MGHPCC_NRP_OSDF_CACHE
-          - SDSC_NRP_OSDF_CACHE
-          - NEBRASKA_NRP_OSDF_CACHE
-          - CINCINNATI_INTERNET2_OSDF_CACHE
-          - BOISE_INTERNET2_OSDF_CACHE
-          - INFN_CNAF_OSDF_CACHE
-          - CARDIFF_UK_OSDF_CACHE
-          - ComputeCanada-Cedar-Cache
-          - JACKSONVILLE_INTERNET2_OSDF_CACHE
-          - DENVER_INTERNET2_OSDF_CACHE
-          - AMSTERDAM_ESNET_OSDF_CACHE
-          - LONDON_ESNET_OSDF_CACHE
-          - HOUSTON2_INTERNET2_OSDF_CACHE
-          - CIT_LIGO_STASHCACHE
-          - SINGAPORE_INTERNET2_OSDF_CACHE
-          - SPRACE_OSDF_CACHE
+        AllowedCaches: *ligo-allowed-caches
       - Path: /igwn/ligo
         Authorizations:
           - FQAN: /osg/ligo
@@ -181,36 +152,7 @@ DataFederations:
               Base Path: /user/ligo,/igwn,/igwn/cit,/igwn/test,/igwn/test-write
         AllowedOrigins:
           - CIT_LIGO_ORIGIN_IFO
-        AllowedCaches:
-          - SUT-STASHCACHE
-          - Georgia_Tech_PACE_GridFTP2
-          - Stashcache-UCSD
-          - Stashcache-UofA
-          - Stashcache-KISTI
-          - Stashcache-Houston
-          - Stashcache-Manhattan
-          - Stashcache-Sunnyvale
-          - Stashcache-Chicago
-          - Stashcache-Kansas
-          - PIC_STASHCACHE_CACHE
-          - SU_STASHCACHE_CACHE
-          - PSU-LIGO-CACHE
-          - MGHPCC_NRP_OSDF_CACHE
-          - SDSC_NRP_OSDF_CACHE
-          - NEBRASKA_NRP_OSDF_CACHE
-          - CINCINNATI_INTERNET2_OSDF_CACHE
-          - BOISE_INTERNET2_OSDF_CACHE
-          - INFN_CNAF_OSDF_CACHE
-          - CARDIFF_UK_OSDF_CACHE
-          - ComputeCanada-Cedar-Cache
-          - JACKSONVILLE_INTERNET2_OSDF_CACHE
-          - DENVER_INTERNET2_OSDF_CACHE
-          - AMSTERDAM_ESNET_OSDF_CACHE
-          - LONDON_ESNET_OSDF_CACHE                    
-          - HOUSTON2_INTERNET2_OSDF_CACHE
-          - CIT_LIGO_STASHCACHE
-          - SINGAPORE_INTERNET2_OSDF_CACHE
-          - SPRACE_OSDF_CACHE
+        AllowedCaches: *ligo-allowed-caches
       - Path: /igwn/kagra
         Authorizations:
           - FQAN: /osg/ligo
@@ -225,36 +167,7 @@ DataFederations:
               Base Path: /user/ligo,/igwn,/igwn/cit,/igwn/test,/igwn/test-write
         AllowedOrigins:
           - KAGRA_OSDF_ORIGIN
-        AllowedCaches:
-          - SUT-STASHCACHE
-          - Georgia_Tech_PACE_GridFTP2
-          - Stashcache-UCSD
-          - Stashcache-UofA
-          - Stashcache-KISTI
-          - Stashcache-Houston
-          - Stashcache-Manhattan
-          - Stashcache-Sunnyvale
-          - Stashcache-Chicago
-          - Stashcache-Kansas
-          - PIC_STASHCACHE_CACHE
-          - SU_STASHCACHE_CACHE
-          - PSU-LIGO-CACHE
-          - MGHPCC_NRP_OSDF_CACHE
-          - SDSC_NRP_OSDF_CACHE
-          - NEBRASKA_NRP_OSDF_CACHE
-          - CINCINNATI_INTERNET2_OSDF_CACHE
-          - BOISE_INTERNET2_OSDF_CACHE
-          - INFN_CNAF_OSDF_CACHE
-          - CARDIFF_UK_OSDF_CACHE
-          - ComputeCanada-Cedar-Cache
-          - JACKSONVILLE_INTERNET2_OSDF_CACHE
-          - DENVER_INTERNET2_OSDF_CACHE
-          - AMSTERDAM_ESNET_OSDF_CACHE
-          - LONDON_ESNET_OSDF_CACHE
-          - HOUSTON2_INTERNET2_OSDF_CACHE
-          - CIT_LIGO_STASHCACHE
-          - SINGAPORE_INTERNET2_OSDF_CACHE
-          - SPRACE_OSDF_CACHE
+        AllowedCaches: *ligo-allowed-caches
       - Path: /igwn/shared
         Authorizations:
           - FQAN: /osg/ligo
@@ -269,36 +182,7 @@ DataFederations:
               Base Path: /user/ligo,/igwn,/igwn/cit,/igwn/test,/igwn/test-write
         AllowedOrigins:
           - CIT_LIGO_ORIGIN_SHARED
-        AllowedCaches:
-          - SUT-STASHCACHE
-          - Georgia_Tech_PACE_GridFTP2
-          - Stashcache-UCSD
-          - Stashcache-UofA
-          - Stashcache-KISTI
-          - Stashcache-Houston
-          - Stashcache-Manhattan
-          - Stashcache-Sunnyvale
-          - Stashcache-Chicago
-          - Stashcache-Kansas
-          - PIC_STASHCACHE_CACHE
-          - SU_STASHCACHE_CACHE
-          - PSU-LIGO-CACHE
-          - MGHPCC_NRP_OSDF_CACHE
-          - SDSC_NRP_OSDF_CACHE
-          - NEBRASKA_NRP_OSDF_CACHE
-          - CINCINNATI_INTERNET2_OSDF_CACHE
-          - BOISE_INTERNET2_OSDF_CACHE
-          - INFN_CNAF_OSDF_CACHE
-          - CARDIFF_UK_OSDF_CACHE
-          - ComputeCanada-Cedar-Cache
-          - JACKSONVILLE_INTERNET2_OSDF_CACHE
-          - DENVER_INTERNET2_OSDF_CACHE
-          - AMSTERDAM_ESNET_OSDF_CACHE
-          - LONDON_ESNET_OSDF_CACHE
-          - HOUSTON2_INTERNET2_OSDF_CACHE
-          - CIT_LIGO_STASHCACHE
-          - SINGAPORE_INTERNET2_OSDF_CACHE
-          - SPRACE_OSDF_CACHE
+        AllowedCaches: *ligo-allowed-caches
       - Path: /igwn/cit
         Authorizations:
           - FQAN: /osg/ligo
@@ -313,36 +197,7 @@ DataFederations:
               Base Path: /user/ligo,/igwn,/igwn/cit,/igwn/test,/igwn/test-write
         AllowedOrigins:
           - CIT_LIGO_ORIGIN_STAGING
-        AllowedCaches:
-          - SUT-STASHCACHE
-          - Georgia_Tech_PACE_GridFTP2
-          - Stashcache-UCSD
-          - Stashcache-UofA
-          - Stashcache-KISTI
-          - Stashcache-Houston
-          - Stashcache-Manhattan
-          - Stashcache-Sunnyvale
-          - Stashcache-Chicago
-          - Stashcache-Kansas
-          - PIC_STASHCACHE_CACHE
-          - SU_STASHCACHE_CACHE
-          - PSU-LIGO-CACHE
-          - MGHPCC_NRP_OSDF_CACHE
-          - SDSC_NRP_OSDF_CACHE
-          - NEBRASKA_NRP_OSDF_CACHE
-          - CINCINNATI_INTERNET2_OSDF_CACHE
-          - BOISE_INTERNET2_OSDF_CACHE
-          - INFN_CNAF_OSDF_CACHE
-          - CARDIFF_UK_OSDF_CACHE
-          - ComputeCanada-Cedar-Cache
-          - JACKSONVILLE_INTERNET2_OSDF_CACHE
-          - DENVER_INTERNET2_OSDF_CACHE
-          - AMSTERDAM_ESNET_OSDF_CACHE
-          - LONDON_ESNET_OSDF_CACHE
-          - HOUSTON2_INTERNET2_OSDF_CACHE
-          - CIT_LIGO_STASHCACHE
-          - SINGAPORE_INTERNET2_OSDF_CACHE
-          - SPRACE_OSDF_CACHE
+        AllowedCaches: *ligo-allowed-caches
         Writeback: https://origin-staging.ligo.caltech.edu:1095
       - Path: /igwn/test
         Authorizations:
@@ -361,36 +216,7 @@ DataFederations:
               Base Path: /igwn/test,/igwn/test-write
         AllowedOrigins:
           - CIT_LIGO_ORIGIN_TEST
-        AllowedCaches:
-          - SUT-STASHCACHE
-          - Georgia_Tech_PACE_GridFTP2
-          - Stashcache-UCSD
-          - Stashcache-UofA
-          - Stashcache-KISTI
-          - Stashcache-Houston
-          - Stashcache-Manhattan
-          - Stashcache-Sunnyvale
-          - Stashcache-Chicago
-          - Stashcache-Kansas
-          - PIC_STASHCACHE_CACHE
-          - SU_STASHCACHE_CACHE
-          - PSU-LIGO-CACHE
-          - MGHPCC_NRP_OSDF_CACHE
-          - SDSC_NRP_OSDF_CACHE
-          - NEBRASKA_NRP_OSDF_CACHE
-          - CINCINNATI_INTERNET2_OSDF_CACHE
-          - BOISE_INTERNET2_OSDF_CACHE
-          - INFN_CNAF_OSDF_CACHE
-          - CARDIFF_UK_OSDF_CACHE
-          - ComputeCanada-Cedar-Cache
-          - JACKSONVILLE_INTERNET2_OSDF_CACHE
-          - DENVER_INTERNET2_OSDF_CACHE
-          - AMSTERDAM_ESNET_OSDF_CACHE
-          - LONDON_ESNET_OSDF_CACHE                    
-          - HOUSTON2_INTERNET2_OSDF_CACHE
-          - CIT_LIGO_STASHCACHE
-          - SINGAPORE_INTERNET2_OSDF_CACHE
-          - SPRACE_OSDF_CACHE
+        AllowedCaches: *ligo-allowed-caches
       - Path: /igwn/test-write
         Authorizations:
           - FQAN: /osg/ligo
@@ -408,36 +234,7 @@ DataFederations:
               Base Path: /igwn/test,/igwn/test-write
         AllowedOrigins:
           - CIT_LIGO_ORIGIN_TEST_WRITE
-        AllowedCaches:
-          - SUT-STASHCACHE
-          - Georgia_Tech_PACE_GridFTP2
-          - Stashcache-UCSD
-          - Stashcache-UofA
-          - Stashcache-KISTI
-          - Stashcache-Houston
-          - Stashcache-Manhattan
-          - Stashcache-Sunnyvale
-          - Stashcache-Chicago
-          - Stashcache-Kansas
-          - PIC_STASHCACHE_CACHE
-          - SU_STASHCACHE_CACHE
-          - PSU-LIGO-CACHE
-          - MGHPCC_NRP_OSDF_CACHE
-          - SDSC_NRP_OSDF_CACHE
-          - NEBRASKA_NRP_OSDF_CACHE
-          - CINCINNATI_INTERNET2_OSDF_CACHE
-          - BOISE_INTERNET2_OSDF_CACHE
-          - INFN_CNAF_OSDF_CACHE
-          - CARDIFF_UK_OSDF_CACHE
-          - ComputeCanada-Cedar-Cache
-          - JACKSONVILLE_INTERNET2_OSDF_CACHE
-          - DENVER_INTERNET2_OSDF_CACHE
-          - AMSTERDAM_ESNET_OSDF_CACHE
-          - LONDON_ESNET_OSDF_CACHE                    
-          - HOUSTON2_INTERNET2_OSDF_CACHE
-          - CIT_LIGO_STASHCACHE
-          - SINGAPORE_INTERNET2_OSDF_CACHE
-          - SPRACE_OSDF_CACHE
+        AllowedCaches: *ligo-allowed-caches
         Writeback: https://origin-writetest.ligo.caltech.edu:1095
       - Path: /gwdata
         Authorizations:


### PR DESCRIPTION
https://pyyaml.org/wiki/PyYAMLDocumentation#aliases