### PR TITLE
Correct the CMS site name for the HPC4L site

### DIFF
--- a/topology/American University of Beirut/HPC For Lebanon/HPC4L.yaml
+++ b/topology/American University of Beirut/HPC For Lebanon/HPC4L.yaml
@@ -24,7 +24,7 @@ Resources:
       CMS: 100
     WLCGInformation:
       APELNormalFactor: 0
-      AccountingName: T2_LB_AUB
+      AccountingName: T2_LB_HPC4L
       HEPSPEC: 0
       InteropAccounting: false
       InteropMonitoring: true
@@ -52,7 +52,7 @@ Resources:
       CMS: 100
     WLCGInformation:
       APELNormalFactor: 0
-      AccountingName: T2_LB_AUB
+      AccountingName: T2_LB_HPC4L
       HEPSPEC: 0
       InteropAccounting: true
       InteropBDII: true


### PR DESCRIPTION
Per Stephan Lammel, this is the correct CMS (WLCG) site name.