### PR TITLE
Add downtime for NMSU-Discovery-CE1 due to maintenance.

### DIFF
--- a/topology/New Mexico State University/New Mexico State Discovery/NMSU_DISCOVERY_downtime.yaml
+++ b/topology/New Mexico State University/New Mexico State Discovery/NMSU_DISCOVERY_downtime.yaml
@@ -58,4 +58,14 @@
   ResourceName: NMSU-Discovery-CE1
   Services:
   - CE
+- Class: SCHEDULED
+  ID: 1696997558
+  Description: Scheduled biannual cluster maintenance
+  Severity: Outage
+  StartTime: Jan 08, 2024 15:00 +0000
+  EndTime: Jan 22, 2024 08:00 +0000
+  CreatedTime: Jan 08, 2024 07:42 +0000
+  ResourceName: NMSU-Discovery-CE1
+  Services:
+  - CE
 # ---------------------------------------------------------


### PR DESCRIPTION
This is a 2 week biannual downtime for maintenance, upgrades, and any other reorganization.  SSH access will be intermittent but there is a reservation set in Slurm to prevent job scheduling, assuming Slurm is available at all during this time window.