### PR TITLE
updated squid proxy list for LIGO-Caltech VO

### DIFF
--- a/topology/California Institute of Technology/Caltech LIGO/CIT_LIGO.yaml
+++ b/topology/California Institute of Technology/Caltech LIGO/CIT_LIGO.yaml
@@ -117,7 +117,7 @@ Resources:
         Description: StashCache Origin server
     AllowedVOs:
       - LIGO
-  CIT_LIGO_SQUID1:
+  CIT_LIGO_SQUID:
     ContactLists:
       Administrative Contact:
         Primary:
@@ -127,42 +127,8 @@ Resources:
         Primary:
           Name: Stuart Anderson
           ID: c50e7cc9d0086272ef995fb76461612d40c70435
-    FQDN: dcs-squid1.ligo.caltech.edu
+    FQDN: dcs-squid.ligo.caltech.edu
     ID: 1316
-    Services:
-      Squid:
-        Description: Frontier-squid proxy server
-    AllowedVOs:
-      - LIGO
-  CIT_LIGO_SQUID2:
-    ContactLists:
-      Administrative Contact:
-        Primary:
-          Name: Stuart Anderson
-          ID: c50e7cc9d0086272ef995fb76461612d40c70435
-      Security Contact:
-        Primary:
-          Name: Stuart Anderson
-          ID: c50e7cc9d0086272ef995fb76461612d40c70435
-    FQDN: dcs-squid2.ligo.caltech.edu
-    ID: 1317
-    Services:
-      Squid:
-        Description: Frontier-squid proxy server
-    AllowedVOs:
-      - LIGO
-  CIT_LIGO_SQUID3:
-    ContactLists:
-      Administrative Contact:
-        Primary:
-          Name: Stuart Anderson
-          ID: c50e7cc9d0086272ef995fb76461612d40c70435
-      Security Contact:
-        Primary:
-          Name: Stuart Anderson
-          ID: c50e7cc9d0086272ef995fb76461612d40c70435
-    FQDN: dcs-squid3.ligo.caltech.edu
-    ID: 1318
     Services:
       Squid:
         Description: Frontier-squid proxy server


### PR DESCRIPTION
removed deprecated squid proxies:
dcs-squid1.ligo.caltech.edu
dcs-squid2.ligo.caltech.edu
dcs-squid3.ligo.caltech.edu

and replaced with single squid proxy dcs-squid.ligo.caltech.edu