### PR TITLE
Enabled multiple contact types and added "local" types

### DIFF
--- a/bin/osg-notify
+++ b/bin/osg-notify
@@ -133,7 +133,7 @@ def parseargs():
         oparser.error("--oim-owner-filter and --oim-recipients=vos options are conflicting")
     if args.name_filter and args.fqdn_filter:
         oparser.error("Can't specify both --oim-name-filter and --oim-fqdn-filter")
-    if (len(args.contact_type) == 0) or ("all" in args.contact_type):
+    if not args.contact_type or ("all" in args.contact_type):
         args.contact_type = ["all"]
 
     if args.from_name == 'security':

--- a/bin/osg-notify
+++ b/bin/osg-notify
@@ -116,8 +116,9 @@ def parseargs():
     oparser.add_argument("--oim-owner-filter", dest="owner_vo",
                          help="Filter on resources that list VO(s) as a partial owner")
 
-    oparser.add_argument("--oim-contact-type", default="all", dest="contact_type",
-                         choices=["all", "administrative", "miscellaneous", "security", "submitter", "site"],
+    oparser.add_argument("--oim-contact-type", action="append", default=[], dest="contact_type",
+                         choices=["all", "administrative", "miscellaneous", "security", "submitter", "site",
+                                  "local operational", "local security"],
                          help="Filter on contact type e.g. administrative, miscellaneous, security, submitter or site"
                          "(default: all)", )
     oparser.add_argument("--bypass-dns-check", action="store_true", dest="bypass_dns_check",
@@ -131,6 +132,8 @@ def parseargs():
         oparser.error("--oim-owner-filter and --oim-recipients=vos options are conflicting")
     if args.name_filter and args.fqdn_filter:
         oparser.error("Can't specify both --oim-name-filter and --oim-fqdn-filter")
+    if (len(args.contact_type) == 0) or ("all" in args.contact_type):
+        args.contact_type = ["all"]
 
     if args.from_name == 'security':
         args.from_name = 'OSG Security Team'

--- a/bin/osg-notify
+++ b/bin/osg-notify
@@ -116,7 +116,8 @@ def parseargs():
     oparser.add_argument("--oim-owner-filter", dest="owner_vo",
                          help="Filter on resources that list VO(s) as a partial owner")
 
-    oparser.add_argument("--oim-contact-type", action="append", default=[], dest="contact_type",
+    # should be safe to set default=set() here since we don't call parse_args() twice
+    oparser.add_argument("--oim-contact-type", action="append", default=set(), dest="contact_type",
                          choices=["all", "administrative", "miscellaneous", "security", "submitter", "site",
                                   "local operational", "local security"],
                          help="Filter on contact type e.g. administrative, miscellaneous, security, submitter or site"

--- a/src/topology_utils.py
+++ b/src/topology_utils.py
@@ -365,14 +365,15 @@ def filter_contacts(args, results):
                     args.fqdn_filter not in fqdn:
                 del results[fqdn]
 
-    if args.contact_type != 'all':
+    if 'all' not in args.contact_type:
         # filter out undesired contact types
         for name in list(results):
             contact_list = []
             for contact in results[name]:
                 contact_type = contact['ContactType']
-                if contact_type.startswith(args.contact_type):
-                    contact_list.append(contact)
+                for args_contact_type in args.contact_type:
+                    if contact_type.startswith(args_contact_type):
+                        contact_list.append(contact)
             if contact_list == []:
                 del results[name]
             else:


### PR DESCRIPTION
This change affects the `--oim-contact-type` command-line option. Now it can be specified more than once, and all matching contacts are used; also, I added the new “Local Operational” and “Local Security” contact types.

I tested this change with:

- No contact type argument (= all)
- The “all” contact type
- The “security” contact type
- The “security” and “local operational” contact types