### PR TITLE
Update UERJ_downtime.yaml

### DIFF
--- a/topology/Universidade do Estado do Rio de Janeiro/T2_BR_UERJ/UERJ_downtime.yaml
+++ b/topology/Universidade do Estado do Rio de Janeiro/T2_BR_UERJ/UERJ_downtime.yaml
@@ -1286,4 +1286,64 @@
   Services:
   - Squid
 # ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 1724229273
+  Description: Unfortunately, we continue to have instabilities in the external network
+    and for this reason we will need to extend the downtime.
+  Severity: Severe
+  StartTime: Feb 08, 2024 20:20 +0000
+  EndTime: Feb 23, 2024 20:00 +0000
+  CreatedTime: Feb 08, 2024 20:08 +0000
+  ResourceName: UERJ_CE
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 1724234439
+  Description: Unfortunately, we continue to have instabilities in the external network
+    and for this reason we will need to extend the downtime.
+  Severity: Severe
+  StartTime: Feb 08, 2024 20:20 +0000
+  EndTime: Feb 23, 2024 20:00 +0000
+  CreatedTime: Feb 08, 2024 20:17 +0000
+  ResourceName: UERJ_CE_2
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 1724234872
+  Description: Unfortunately, we continue to have instabilities in the external network
+    and for this reason we will need to extend the downtime.
+  Severity: Severe
+  StartTime: Feb 08, 2024 20:20 +0000
+  EndTime: Feb 23, 2024 20:00 +0000
+  CreatedTime: Feb 08, 2024 20:18 +0000
+  ResourceName: UERJ_SQUID
+  Services:
+  - Squid
+# ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 1724235056
+  Description: Unfortunately, we continue to have instabilities in the external network
+    and for this reason we will need to extend the downtime.
+  Severity: Severe
+  StartTime: Feb 08, 2024 20:20 +0000
+  EndTime: Feb 23, 2024 20:00 +0000
+  CreatedTime: Feb 08, 2024 20:18 +0000
+  ResourceName: UERJ_SQUID_2
+  Services:
+  - Squid
+# ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 1724235408
+  Description: Unfortunately, we continue to have instabilities in the external network
+    and for this reason we will need to extend the downtime.
+  Severity: Severe
+  StartTime: Feb 08, 2024 20:20 +0000
+  EndTime: Feb 23, 2024 20:00 +0000
+  CreatedTime: Feb 08, 2024 20:19 +0000
+  ResourceName: UERJ_SE
+  Services:
+  - SRMv2
+# ---------------------------------------------------------
 


### PR DESCRIPTION
Add downtime for UERJ_CE, UERJ_CE_2, UERJ_SE, UERJ_SQUID, UERJ_SQUID_2 due to instabilities in the external network (IPv6).