### PR TITLE
Remove OASIS repository captmnv.opensciencegrid.org

### DIFF
--- a/virtual-organizations/Captmnv.yaml
+++ b/virtual-organizations/Captmnv.yaml
@@ -26,9 +26,7 @@ OASIS:
       - /DC=com/DC=DigiCert-Grid/O=Open Science Grid/OU=People/CN=Joe Boyd 579
       - /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Joe Boyd 3582
       ID: cb55ac2721726ebc83c3781ebe798e05ba425c47
-  OASISRepoURLs:
-  - http://oasiscfs.fnal.gov:8000/cvmfs/captmnv.opensciencegrid.org/
-  UseOASIS: true
+  UseOASIS: false
 ParentVO:
   ID: 9
   Name: Fermilab


### PR DESCRIPTION
See OSG FD#75483