### PR TITLE
Fixed pattern matching error with NetworkInterface objects (SOFTWARE-5423)

### DIFF
--- a/src/net_name_addr_utils.py
+++ b/src/net_name_addr_utils.py
@@ -307,8 +307,9 @@ def iface_matches(network_iface, pattern):
     `network_iface` matches `pattern`, False otherwise
 
     """
-    if fnmatch.fnmatch(network_iface, pattern):
-        return True
+    for _, addrs in network_iface.addresses.items():
+        if fnmatch.fnmatch(' '.join(addrs), pattern):
+            return True    
     for _, addrs in network_iface.addresses.items():
         if fnmatch.filter(addrs, pattern):
             return True


### PR DESCRIPTION
An error occurs when running the osg-notify script with specific parameters (see more at [this](https://opensciencegrid.atlassian.net/browse/SOFTWARE-5423) ticket). This is due to a utility function trying to perform pattern matching on a `NetworkInterface` object, which does not have a default string representation. I modified the pattern matching logic so that it would look for patterns in the correct location and data type. 