### PR TITLE
Register production Pelican cache for the CHTC (INF-1536)

### DIFF
--- a/topology/University of Wisconsin/CHTC/CHTC-OSDF.yaml
+++ b/topology/University of Wisconsin/CHTC/CHTC-OSDF.yaml
@@ -209,3 +209,33 @@ Resources:
       GLOW: 100
     AllowedVOs:
       - ANY
+
+  CHTC_PELICAN_CACHE:
+    Active: true
+    Description: This is a Pelican cache server at UW running on the Tiger Kubernetes cluster
+    ContactLists:
+      Administrative Contact:
+        Primary: 
+          ID: OSG1000589
+          Name: William Swanson
+        Secondary:
+          ID: OSG1000002
+          Name: Matyas Selmeci
+        Tertiary:
+          ID: OSG1000003
+          Name: Brian Lin
+      Security Contact:
+        Primary:
+          ID: OSG1000589
+          Name: William Swanson
+        Secondary:
+          ID: OSG1000002
+          Name: Matyas Selmeci
+        Tertiary:
+          ID: OSG1000003
+          Name: Brian Lin
+    FQDN: osdf-uw-cache.svc.osg-htc.org
+    DN: /CN=osdf-uw-cache.svc.osg-htc.org
+    Services:
+      XRootD cache server:
+        Description: Pelican cache server

--- a/topology/University of Wisconsin/CHTC/CHTC-OSDF.yaml
+++ b/topology/University of Wisconsin/CHTC/CHTC-OSDF.yaml
@@ -239,3 +239,7 @@ Resources:
     Services:
       XRootD cache server:
         Description: Pelican cache server
+    VOOwnership:
+      GLOW: 100
+    AllowedVOs:
+      - ANY

--- a/topology/University of Wisconsin/CHTC/CHTC-OSDF.yaml
+++ b/topology/University of Wisconsin/CHTC/CHTC-OSDF.yaml
@@ -217,7 +217,7 @@ Resources:
       Administrative Contact:
         Primary: 
           ID: OSG1000589
-          Name: William Swanson
+          Name: William N Swanson
         Secondary:
           ID: OSG1000002
           Name: Matyas Selmeci
@@ -227,7 +227,7 @@ Resources:
       Security Contact:
         Primary:
           ID: OSG1000589
-          Name: William Swanson
+          Name: William N Swanson
         Secondary:
           ID: OSG1000002
           Name: Matyas Selmeci


### PR DESCRIPTION
Add the production pelican cache at `osdf-uw-cache.svc.osg-htc.org` as a CHTC resource.