### PR TITLE
Add "include_downed" and "include_inactive" params to the /osdf/namespaces endpoint

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -512,7 +512,10 @@ base_path = /ospool/PROTECTED
 
 ### Namespaces JSON generation
 
-The JSON file containing cache and namespace information for stashcp is served at `/stashcache/namespaces`.
+The JSON file containing cache and namespace information for stashcp/OSDF is served at `/osdf/namespaces`.
+The endpoint takes two optional parameters, `include_downed=1`, and `include_inactive=1`;
+if they are set, caches in downtime or that are not marked as active, respectively, are also included in the result.
+Otherwise, they are not included.
 
 The JSON contains an attribute `caches` that is a list of caches.
 Each cache in the list contains the following attributes:

--- a/src/app.py
+++ b/src/app.py
@@ -17,7 +17,8 @@ from wtforms import ValidationError
 from flask_wtf.csrf import CSRFProtect
 
 from webapp import default_config
-from webapp.common import readfile, to_xml_bytes, to_json_bytes, Filters, support_cors, simplify_attr_list, is_null, escape, cache_control_private, PreJSON
+from webapp.common import readfile, to_xml_bytes, to_json_bytes, Filters, support_cors, simplify_attr_list, is_null, \
+    escape, cache_control_private, PreJSON, is_true
 from webapp.flask_common import create_accepted_response
 from webapp.exceptions import DataError, ResourceNotRegistered, ResourceMissingService
 from webapp.forms import GenerateDowntimeForm, GenerateResourceGroupDowntimeForm, GenerateProjectForm
@@ -513,8 +514,10 @@ def scitokens():
 def stashcache_namespaces_json():
     if not stashcache:
         return Response("Can't get scitokens config: stashcache module unavailable", status=503)
+    include_downed = is_true(request.args.get("include_downed", False))
+    include_inactive = is_true(request.args.get("include_inactive", False))
     try:
-        return Response(to_json_bytes(stashcache.get_namespaces_info(global_data)),
+        return Response(to_json_bytes(stashcache.get_namespaces_info(global_data, include_downed, include_inactive)),
                         mimetype='application/json')
     except ResourceNotRegistered as e:
         return Response("# {}\n"

--- a/src/stashcache.py
+++ b/src/stashcache.py
@@ -538,12 +538,14 @@ def get_scitokens_list_for_namespace(ns: Namespace) -> List[Dict]:
     )
 
 
-def get_namespaces_info(global_data: GlobalData) -> PreJSON:
+def get_namespaces_info(global_data: GlobalData, include_downed=False, include_inactive=False) -> PreJSON:
     """Return data for the /stashcache/namespaces JSON endpoint.
 
     This includes a list of caches and origins, with some data about their endpoints,
     and a list of namespaces with some data about each namespace; see README.md for details.
 
+    If `include_downed` is True, caches/origins in downtime are also included.
+    If `include_inactive` is True, caches/origins that are not marked as active are also included.
     """
     # Helper functions
 
@@ -635,8 +637,8 @@ def get_namespaces_info(global_data: GlobalData) -> PreJSON:
     for group in resource_groups:
         for resource in group.resources:
             if (_resource_has_cache(resource)
-                    and resource.is_active
-                    and not _resource_has_downed_cache(resource, topology)
+                    and (include_inactive or resource.is_active)
+                    and (include_downed or not _resource_has_downed_cache(resource, topology))
             ):
                 cache_resource_objs[resource.name] = resource
                 cache_resource_dicts[resource.name] = _cache_resource_dict(resource)
@@ -649,8 +651,8 @@ def get_namespaces_info(global_data: GlobalData) -> PreJSON:
     for group in resource_groups:
         for resource in group.resources:
             if (_resource_has_origin(resource)
-                    and resource.is_active
-                    and not _resource_has_downed_origin(resource, topology)
+                    and (include_inactive or resource.is_active)
+                    and (include_downed or not _resource_has_downed_origin(resource, topology))
             ):
                 origin_resource_objs[resource.name] = resource
                 origin_resource_dicts[resource.name] = _origin_resource_dict(resource)

--- a/src/tests/data/testrg.yaml
+++ b/src/tests/data/testrg.yaml
@@ -212,11 +212,11 @@ Resources:
     AllowedVOs:
       - testvo
 
-  TEST-ITB-HELM-CACHE1:
+  TEST-ITB-HELM-CACHE1-inactive:
     Active: false
     Description: >-
       This is a testing StashCache cache server the Tiger cluster,
-      deployed via Helm.
+      deployed via Helm.  It is inactive.
     ID: 91339
     ContactLists:
       Administrative Contact:
@@ -244,3 +244,34 @@ Resources:
       - testvo
       - OSG
 
+  TEST-ITB-HELM-CACHE2-down:
+    Active: true
+    Description: >-
+      This is a testing StashCache cache server the Tiger cluster,
+      deployed via Helm. It is active but down
+    ID: 91340
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          ID: OSG1000003
+          Name: Brian Lin
+        Tertiary:
+          ID: OSG1000002
+          Name: Matyas Selmeci
+      Security Contact:
+        Primary:
+          ID: OSG1000002
+          Name: Matyas Selmeci
+        Secondary:
+          ID: OSG1000015
+          Name: Aaron Moate
+    FQDN: helm-cache2.osgdev.test.io
+    DN: /CN=helm-cache2.osgdev.test.io
+    Services:
+      XRootD cache server:
+        Description: StashCache cache server
+    VOOwnership:
+      testvo: 100
+    AllowedVOs:
+      - testvo
+      - OSG

--- a/src/tests/data/testrg_downtime.yaml
+++ b/src/tests/data/testrg_downtime.yaml
@@ -1,0 +1,10 @@
+- Class: UNSCHEDULED
+  ID: 1
+  Description: down for testing
+  Severity: Outage
+  StartTime: Mar 28, 2017 22:00 -0500
+  EndTime: Jan 18, 2038 21:14 -0600
+  CreatedTime: Feb 19, 2024 11:25 -0600
+  ResourceName: TEST-ITB-HELM-CACHE2-down
+  Services:
+    - XRootD cache server

--- a/src/tests/test_stashcache.py
+++ b/src/tests/test_stashcache.py
@@ -33,6 +33,7 @@ I2_TEST_CACHE = "osg-sunnyvale-stashcache.nrp.internet2.edu"
 # ^^ one of the Internet2 caches; these serve both public and LIGO data
 # fake origins in our test data:
 TEST_ITB_HELM_ORIGIN = "helm-origin.osgdev.test.io"
+TEST_ITB_HELM_CACHE1_RESOURCE = "TEST-ITB-HELM-CACHE1"
 TEST_SC_ORIGIN = "sc-origin.test.wisc.edu"
 TEST_ORIGIN_AUTH2000 = "origin-auth2000.test.wisc.edu"
 TEST_ISSUER = "https://test.wisc.edu"
@@ -252,6 +253,17 @@ class TestNamespaces:
         assert "namespaces" in namespaces_json
         return namespaces_json["namespaces"]
 
+    @pytest.fixture
+    def caches(self, namespaces_json) -> List[Dict]:
+        assert "caches" in namespaces_json
+        return namespaces_json["caches"]
+
+    @pytest.fixture
+    def caches_include_inactive(self, test_global_data) -> List[Dict]:
+        namespaces_json = stashcache.get_namespaces_info(test_global_data, include_inactive=True)
+        assert "caches" in namespaces_json
+        return namespaces_json["caches"]
+
     @staticmethod
     def validate_cache_schema(cc):
         assert HOST_PORT_RE.match(cc["auth_endpoint"])
@@ -280,9 +292,7 @@ class TestNamespaces:
             if credgen["base_path"]:
                 assert isinstance(credgen["base_path"], str)
 
-    def test_caches(self, namespaces_json):
-        assert "caches" in namespaces_json
-        caches = namespaces_json["caches"]
+    def test_caches(self, caches):
         # Have a reasonable number of caches
         assert len(caches) > 20
         for cache in caches:
@@ -363,6 +373,15 @@ class TestNamespaces:
         assert sci["base_path"] == [TEST_BASEPATH]
         assert sci["restricted_path"] == []
 
+    def test_caches_include_inactive_param(self, caches, caches_include_inactive):
+        assert TEST_ITB_HELM_CACHE1_RESOURCE not in (
+            x["resource"] for x in caches
+        ), "Inactive cache wrongly present in namespaces JSON without ?include_inactive=1"
+        assert TEST_ITB_HELM_CACHE1_RESOURCE in (
+            x["resource"] for x in caches_include_inactive
+        ), "Inactive cache missing from namespaces JSON with ?include_inactive=1"
+
+    # TODO Add test for ?include_downed=1
 
 if __name__ == '__main__':
     pytest.main()

--- a/src/webapp/common.py
+++ b/src/webapp/common.py
@@ -29,7 +29,7 @@ VOSUMMARY_SCHEMA_URL = "https://topology.opensciencegrid.org/schema/vosummary.xs
 
 SSH_WITH_KEY = os.path.abspath(os.path.dirname(__file__) + "/ssh_with_key.sh")
 
-ParsedYaml = NewType("ParsedYaml", Dict[str, Any])  # a complex data structure that's a result of parsing a YAML file
+ParsedYaml = NewType("ParsedYaml", Union[List, Dict[str, Any]])  # a complex data structure that's a result of parsing a YAML file
 PreJSON = NewType("PreJSON", Union[List, Dict[str, Any]])  # a complex data structure that will be converted to JSON in the webapp
 T = TypeVar("T")
 

--- a/src/webapp/common.py
+++ b/src/webapp/common.py
@@ -275,6 +275,18 @@ def git_clone_or_pull(repo, dir, branch, ssh_key=None) -> bool:
     return ok
 
 
+def is_true(input_) -> bool:
+    """Convert various types of input to a boolean.  Specifically, strings and bytes are checked for the values
+    '1', 'true', 'yes', 'on', case-insensitively.  Other types are just cast to bool using the built-in function.
+    """
+    if isinstance(input_, bytes):
+        input_ = input_.decode(errors="replace")
+    if not isinstance(input_, str):
+        return bool(input)
+    input_ = input_.lower()
+    return input_ in ("1", "true", "yes", "on")
+
+
 def git_clone_or_fetch_mirror(repo, git_dir, ssh_key=None) -> bool:
     if os.path.exists(git_dir):
         ok = run_git_cmd(["fetch", "origin"], git_dir=git_dir, ssh_key=ssh_key)

--- a/src/webapp/topology.py
+++ b/src/webapp/topology.py
@@ -472,7 +472,7 @@ class Downtime(object):
         self.data = yaml_data
         for k in ["StartTime", "EndTime", "ID", "Class", "Severity", "ResourceName", "Services"]:
             if is_null(yaml_data, k):
-                raise ValueError(k)
+                raise ValueError(f"{k} is missing or empty")
         self.start_time = self.parsetime(yaml_data["StartTime"])
         self.end_time = self.parsetime(yaml_data["EndTime"])
         self.created_time = None

--- a/src/webapp/topology.py
+++ b/src/webapp/topology.py
@@ -469,6 +469,8 @@ class Downtime(object):
 
     def __init__(self, rg: ResourceGroup, yaml_data: ParsedYaml, common_data: CommonData):
         self.rg = rg
+        if not isinstance(yaml_data, dict):
+            raise TypeError("yaml data of type %s is not a dictionary" % type(yaml_data))
         self.data = yaml_data
         for k in ["StartTime", "EndTime", "ID", "Class", "Severity", "ResourceName", "Services"]:
             if is_null(yaml_data, k):
@@ -754,10 +756,22 @@ class Topology(object):
         except KeyError:
             log.warning("RG %s/%s does not exist -- skipping downtime", sitename, rgname)
             return
+
+        # If someone passes an entire downtime file, add all the downtimes
+        if isinstance(downtime, list):
+            for dt in downtime:
+                self._add_one_downtime(rg, dt)
+            return
+        self._add_one_downtime(rg, downtime)
+
+    def _add_one_downtime(self, rg: ResourceGroup, downtime: ParsedYaml):
         try:
             dt = Downtime(rg, downtime, self.common_data)
         except (KeyError, ValueError) as err:
             log.warning("Invalid or missing data in downtime -- skipping: %r", err)
+            return
+        except TypeError as err:
+            log.warning("Invalid type in downtime(s) -- skipping: %r", err)
             return
         self.downtimes_by_timeframe[dt.timeframe].append(dt)
         if dt.timeframe == Timeframe.PRESENT:


### PR DESCRIPTION
If set, the output will _not_ exclude caches/origins that are in downtime, or marked as inactive.
(SOFTWARE-5826)

Along the way, I noticed that if I try to pass a downtime file (with an entire list of downtimes) to Topology.add_downtime() it will fail with a KeyError because it was expecting a dict.  This was unexpected so I added checks.