### PR TITLE
Add downtime for BOISE_INTERNET2_OSDF_CACHE due to major flapping

### DIFF
--- a/topology/Internet2/Internet2Boise/I2BoiseInfrastructure_downtime.yaml
+++ b/topology/Internet2/Internet2Boise/I2BoiseInfrastructure_downtime.yaml
@@ -9,3 +9,14 @@
   Services:
   - XRootD cache server
 # ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 1734583526
+  Description: major flapping
+  Severity: Outage
+  StartTime: Feb 20, 2024 20:30 +0000
+  EndTime: Feb 23, 2024 20:30 +0000
+  CreatedTime: Feb 20, 2024 19:45 +0000
+  ResourceName: BOISE_INTERNET2_OSDF_CACHE
+  Services:
+  - XRootD cache server
+# ---------------------------------------------------------


### PR DESCRIPTION
Add downtime for BOISE_INTERNET2_OSDF_CACHE due to major flapping