### PR TITLE
Remove old Squid services for MWT2

### DIFF
--- a/topology/University of Chicago/MWT2 ATLAS UC/MWT2.yaml
+++ b/topology/University of Chicago/MWT2 ATLAS UC/MWT2.yaml
@@ -441,7 +441,7 @@ Resources:
     VOOwnership:
       ATLAS: 100
   MWT2_SLATE_UC:
-    Active: true
+    Active: false
     ContactLists:
       Administrative Contact:
         Primary:
@@ -477,11 +477,11 @@ Resources:
         Description: Generic squid service
         Details:
           uri_override: uct2-slate.mwt2.org:32200
-          Monitored: true
+          Monitored: false
     VOOwnership:
       ATLAS: 100
   MWT2_SLATE_UC_2:
-    Active: true
+    Active: false
     ContactLists:
       Administrative Contact:
         Primary:
@@ -534,7 +534,7 @@ Resources:
         Description: Generic squid service
         Details:
           uri_override: sl-uc-xcache1.slateci.io:32202
-          Monitored: true
+          Monitored: false
     VOOwnership:
       ATLAS: 100
   MWT2_SLATE_IU:


### PR DESCRIPTION
Set both squids on `sl-uc-xcache1.slateci.io` and `uct2-slate` to disabled and unmonitored. These are the same machine, it is getting rebuilt and moved into another Kubernetes cluster. We may re-activate them later.