### PR TITLE
Add downtime for DENVER_INTERNET2_OSDF_CACHE due to overloaded

### DIFF
--- a/topology/Internet2/Internet2Denver/I2DenverInfrastructure_downtime.yaml
+++ b/topology/Internet2/Internet2Denver/I2DenverInfrastructure_downtime.yaml
@@ -1,0 +1,11 @@
+- Class: SCHEDULED
+  ID: 1736255663
+  Description: overloaded
+  Severity: Outage
+  StartTime: Feb 22, 2024 20:30 +0000
+  EndTime: Feb 26, 2024 20:30 +0000
+  CreatedTime: Feb 22, 2024 18:12 +0000
+  ResourceName: DENVER_INTERNET2_OSDF_CACHE
+  Services:
+  - XRootD cache server
+# ---------------------------------------------------------


### PR DESCRIPTION
Add downtime for DENVER_INTERNET2_OSDF_CACHE due to overloaded