### PR TITLE
Add downtime for SU_STASHCACHE_CACHE due to possibly overloaded

### DIFF
--- a/topology/Syracuse University/SU ITS/SyracuseCachingInfrastructure_downtime.yaml
+++ b/topology/Syracuse University/SU ITS/SyracuseCachingInfrastructure_downtime.yaml
@@ -1,0 +1,11 @@
+- Class: UNSCHEDULED
+  ID: 1736357724
+  Description: 'possibly overloaded, checking with the admin '
+  Severity: Outage
+  StartTime: Feb 22, 2024 20:30 +0000
+  EndTime: Feb 27, 2024 20:30 +0000
+  CreatedTime: Feb 22, 2024 21:02 +0000
+  ResourceName: SU_STASHCACHE_CACHE
+  Services:
+  - XRootD cache server
+# ---------------------------------------------------------


### PR DESCRIPTION

Add downtime for SU_STASHCACHE_CACHE due to possibly overloaded, checking with the admin