### PR TITLE
Update CHTC_PELICAN_CACHE to use port 8443

### DIFF
--- a/topology/University of Wisconsin/CHTC/CHTC-OSDF.yaml
+++ b/topology/University of Wisconsin/CHTC/CHTC-OSDF.yaml
@@ -239,6 +239,8 @@ Resources:
     Services:
       XRootD cache server:
         Description: Pelican cache server
+        Details:
+          endpoint_override: osdf-uw-cache.svc.osg-htc.org:8443
     VOOwnership:
       GLOW: 100
     AllowedVOs:


### PR DESCRIPTION
Add an endpoint_override to have the CHTC_PELICAN_CACHE advertised on port 8443 instead of 8000.