### PR TITLE
Change /chtc-itb to /chtc/itb/osdf-pelican (since it's served by CHTC-ITB-OSDF-PELICAN-ORIGIN)

### DIFF
--- a/virtual-organizations/GLOW.yaml
+++ b/virtual-organizations/GLOW.yaml
@@ -130,11 +130,11 @@ DataFederations:
           Issuer: https://chtc.cs.wisc.edu
           MaxScopeDepth: 3
 
-      - Path: /chtc-itb
+      - Path: /chtc/itb/osdf-pelican
         Authorizations:
           - SciTokens:
               Issuer: https://chtc.cs.wisc.edu
-              Base Path: /chtc-itb
+              Base Path: /chtc
               Map Subject: True
         AllowedOrigins:
           - CHTC-ITB-OSDF-PELICAN-ORIGIN


### PR DESCRIPTION
Set the Base Path in the CHTC issuer definition of that namespace to `/chtc` to match the other uses of that issuer.