### PR TITLE
Run one WSGI process per Topology container

### DIFF
--- a/docker/apache.conf
+++ b/docker/apache.conf
@@ -5,7 +5,7 @@ LoadModule wsgi_module /usr/local/lib64/python3.9/site-packages/mod_wsgi/server/
 WSGIPythonPath /app
 
 # Run apps in separate processes to stop yaml.CSafeLoader import-time error
-WSGIDaemonProcess topology  home=/app processes=5
+WSGIDaemonProcess topology  home=/app
 WSGIDaemonProcess topomerge home=/app
 
 # vhost for topology, SSL terminated here (for gridsite auth)


### PR DESCRIPTION
(we will use Kubernetes replicas for load balancing)

This should avoid conflicts from concurrent git pulls, and give us better metrics (since we'll have one `/metrics` endpoint per pod).