### PR TITLE
More downtime for sc-cache

### DIFF
--- a/topology/University of Wisconsin/CHTC/CHTC-OSDF_downtime.yaml
+++ b/topology/University of Wisconsin/CHTC/CHTC-OSDF_downtime.yaml
@@ -164,3 +164,14 @@
   Services:
   - XRootD cache server
 # ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 1748387171
+  Description: keep this down for a while
+  Severity: Intermittent Outage
+  StartTime: Mar 07, 2024 19:11 +0000
+  EndTime: Apr 09, 2024 19:11 +0000
+  CreatedTime: Mar 07, 2024 19:11 +0000
+  ResourceName: CHTC_STASHCACHE_CACHE
+  Services:
+  - XRootD cache server
+# ---------------------------------------------------------


### PR DESCRIPTION
keep this down for a while to decrease load (and avoid monitoring alerts)