### PR TITLE
Add downtime for DENVER_INTERNET2_OSDF_CACHE due to overloaded

### DIFF
--- a/topology/Internet2/Internet2Denver/I2DenverInfrastructure_downtime.yaml
+++ b/topology/Internet2/Internet2Denver/I2DenverInfrastructure_downtime.yaml
@@ -9,3 +9,14 @@
   Services:
   - XRootD cache server
 # ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 1749305669
+  Description: overloaded
+  Severity: Outage
+  StartTime: Mar 08, 2024 20:30 +0000
+  EndTime: Mar 11, 2024 20:30 +0000
+  CreatedTime: Mar 08, 2024 20:42 +0000
+  ResourceName: DENVER_INTERNET2_OSDF_CACHE
+  Services:
+  - XRootD cache server
+# ---------------------------------------------------------


### PR DESCRIPTION
Add downtime for DENVER_INTERNET2_OSDF_CACHE due to overloaded