### PR TITLE
fixing the  /knightlab/mirror/ncbi-genbank-refseq for public read

### DIFF
--- a/virtual-organizations/NRP.yaml
+++ b/virtual-organizations/NRP.yaml
@@ -72,6 +72,7 @@ DataFederations:
           - ANY
       - Path: /knightlab/mirror/ncbi-genbank-refseq
         Authorizations:
+          - PUBLIC
           - SciTokens:
               Issuer: https://t.nationalresearchplatform.org/knightlab
               Base Path: /knightlab/mirror/ncbi-genbank-refseq


### PR DESCRIPTION
fixing the  /knightlab/mirror/ncbi-genbank-refseq for public read