### PR TITLE
Add new commented-out LHC IAM development instances

### DIFF
--- a/virtual-organizations/ALICE.yaml
+++ b/virtual-organizations/ALICE.yaml
@@ -1,5 +1,9 @@
 AppDescription: ALICE collaboration, High Energy Physics experiment at CERN LHC
 CertificateOnly: false
+# Credentials:
+#   TokenIssuers:
+#     - Description: ALICE IAM development instance
+#       URL: https://alice-auth.cern.ch/
 Community: HEP
 Contacts:
   Administrative Contact:

--- a/virtual-organizations/ATLAS.yaml
+++ b/virtual-organizations/ATLAS.yaml
@@ -14,6 +14,8 @@ Credentials:
       Subject: 750e9609-485a-4ed4-bf16-d5cc46c71024
       URL: https://atlas-auth.web.cern.ch/
       DefaultUnixUser: usatlas3
+    # - Description: ATLAS IAM development instance
+    #   URL: https://atlas-auth.cern.ch/
 Community: The ATLAS physics community.
 Contacts:
   Administrative Contact:

--- a/virtual-organizations/CMS.yaml
+++ b/virtual-organizations/CMS.yaml
@@ -39,6 +39,8 @@ Credentials:
       URL: https://cms-auth.web.cern.ch/
       DefaultUnixUser: uscms
 
+    # - Description: CMS IAM development instance
+    #   URL: https://CMS-auth.cern.ch/
 Contacts:
   Administrative Contact:
   - ID: 8489f9d11ec9723ae9f11619d325dbfa5516397c

--- a/virtual-organizations/LHCb.yaml
+++ b/virtual-organizations/LHCb.yaml
@@ -1,5 +1,9 @@
 AppDescription: Data analysis and simulation work is carried out.
 CertificateOnly: true
+# Credentials:
+#   TokenIssuers:
+#     - Description: LHCb IAM development instance
+#       URL: https://lhcb-auth.cern.ch/
 Community: Large Hadron Collider Beauty Experiment studies production and decay of
   particles containing beauty and charm quarks.
 Contacts:


### PR DESCRIPTION
Comment them out since the osg-scitokens-mapfile uses these sections for generating the HTCondor-CE example mapfiles. To do that, we need a reasonable subject and default Unix user.