### PR TITLE
add token issuers for the CERN IAM development instances

### DIFF
--- a/virtual-organizations/ATLAS.yaml
+++ b/virtual-organizations/ATLAS.yaml
@@ -14,8 +14,22 @@ Credentials:
       Subject: 750e9609-485a-4ed4-bf16-d5cc46c71024
       URL: https://atlas-auth.web.cern.ch/
       DefaultUnixUser: usatlas3
-    # - Description: ATLAS IAM development instance
-    #   URL: https://atlas-auth.cern.ch/
+
+    # IAM development instances
+
+    - Description: ATLAS IAM development instance
+      Subject: 7dee38a3-6ab8-4fe2-9e4c-58039c21d817
+      URL: https://atlas-auth.cern.ch/
+      DefaultUnixUser: usatlas1
+    - Description: ATLAS SAM/ETF (development)
+      Subject: 5c5d2a4d-9177-3efa-912f-1b4e5c9fb660
+      URL: https://atlas-auth.cern.ch/
+      DefaultUnixUser: usatlas2
+    - Description: ATLAS analysis (development)
+      Subject: 750e9609-485a-4ed4-bf16-d5cc46c71024
+      URL: https://atlas-auth.cern.ch/
+      DefaultUnixUser: usatlas3
+
 Community: The ATLAS physics community.
 Contacts:
   Administrative Contact:

--- a/virtual-organizations/CMS.yaml
+++ b/virtual-organizations/CMS.yaml
@@ -39,8 +39,42 @@ Credentials:
       URL: https://cms-auth.web.cern.ch/
       DefaultUnixUser: uscms
 
-    # - Description: CMS IAM development instance
-    #   URL: https://CMS-auth.cern.ch/
+    # IAM development instances
+
+    - Description: CMS IAM development instance
+      Subject: bad55f4e-602c-4e8d-a5c5-bd8ffb762113
+      URL: https://CMS-auth.cern.ch/
+      DefaultUnixUser: cmspilot
+
+    - Description: SAM/ETF tests (development)
+      Subject: 08ca855e-d715-410e-a6ff-ad77306e1763
+      URL: https://CMS-auth.cern.ch/
+      DefaultUnixUser: lcgadmin
+
+    - Description: CMS ITB pilots (development)
+      Subject: 490a9a36-0268-4070-8813-65af031be5a3
+      URL: https://CMS-auth.cern.ch/
+      DefaultUnixUser: cmspilot
+
+    - Description: CMS LOCAL pilots (development)
+      Subject: 07f75a9a-bb78-4735-938b-7e61b2b62d5c
+      URL: https://CMS-auth.cern.ch/
+      DefaultUnixUser: cmslocal
+
+    - Description: CMS ITB LOCAL pilots (development)
+      Subject: efbed8c1-f9a7-4063-92f7-f89c04ce04a3
+      URL: https://CMS-auth.cern.ch/
+      DefaultUnixUser: cmslocal
+
+    - Description: USCMS LOCAL pilots (development)
+      Subject: 99b97e4f-5cf0-4d3b-9fcc-82fa86dca1e8
+      URL: https://CMS-auth.cern.ch/
+      DefaultUnixUser: uscmslocal
+
+    - Description: USCMS HEPCloud pilots (development)
+      Subject: 2f327ad0-1934-4635-8ba3-ee72da0a304c
+      URL: https://CMS-auth.cern.ch/
+      DefaultUnixUser: uscms
 Contacts:
   Administrative Contact:
   - ID: 8489f9d11ec9723ae9f11619d325dbfa5516397c


### PR DESCRIPTION
This adds a new entry for each existing token issuer on their respective new host, with the same subject and default unix user. Let me know if something else should be updated as well.