### PR TITLE
Fix KAGRA OSDF origin location

### DIFF
--- a/topology/The University of Tokyo/Kashiwa/KAGRA-OSDF.yaml
+++ b/topology/The University of Tokyo/Kashiwa/KAGRA-OSDF.yaml
@@ -2,12 +2,12 @@
 Production: true
 SupportCenter: Self Supported
 
-GroupDescription: These are the OSDF resources at the KAGRA Observatory
+GroupDescription: These are the OSDF KAGRA resources at the Kashiwa Data Center
 
 Resources:
   KAGRA_OSDF_ORIGIN:
     Active: true
-    Description: This is an OSDF origin at the KAGRA Observatory
+    Description: This is an OSDF origin at Kashiwa Data Center
     ContactLists:
       Administrative Contact:
         Primary:


### PR DESCRIPTION
Hello @matyasselmeci ,

I noticed that KAGRA OSDF origin is registered in the wrong location. 
It is located in the Kashiwa Data Center. Could you please check if this is correct fix?
Maybe additional tuning might be required.

Best regards,
Marco