### PR TITLE
First attempt at registering new AP40 Pelican origin (INF-1796)

### DIFF
--- a/topology/University of Wisconsin/CHTC/CHTC.yaml
+++ b/topology/University of Wisconsin/CHTC/CHTC.yaml
@@ -526,9 +526,15 @@ Resources:
       - ap2007.chtc.wisc.edu 
       - ospool-ap2040.chtc.wisc.edu
       - ap40.chtc.wisc.edu
+      - ospool-2140.chtc.wisc.edu
+    DN: /CN=ospool-ap2140.chtc.wisc.edu
     Services:
       Submit Node:
         Description: OS Pool access point
+        Details:
+          hidden: false
+      XRootD origin server:
+        Description: OSDF Pelican origin
         Details:
           hidden: false
     Tags:

--- a/topology/University of Wisconsin/CHTC/CHTC.yaml
+++ b/topology/University of Wisconsin/CHTC/CHTC.yaml
@@ -537,6 +537,8 @@ Resources:
         Description: OSDF Pelican origin
         Details:
           hidden: false
+          endpoint_override: ospool-ap2140.chtc.wisc.edu:8443
+          auth_endpoint_override: ospool-ap2140.chtc.wisc.edu:8443          
     Tags:
       - OSPool
     VOOwnership:

--- a/topology/University of Wisconsin/CHTC/CHTC.yaml
+++ b/topology/University of Wisconsin/CHTC/CHTC.yaml
@@ -541,6 +541,8 @@ Resources:
       - OSPool
     VOOwnership:
       OSG: 100
+    AllowedVOs:
+      - OSG
 
   CHTC-ospool-eht:
     Active: true

--- a/virtual-organizations/OSG.yaml
+++ b/virtual-organizations/OSG.yaml
@@ -260,18 +260,18 @@ DataFederations:
       - Path: /ospool/ap40/data
         Authorizations:
           - SciTokens:
-              Issuer: https://ap40.uw.osg-htc.org:8443
+              Issuer: https://ospool-ap2140.chtc.wisc.edu:8443
               Base Path: /ospool/ap40
               Map Subject: True
         AllowedOrigins:
           - CHTC-ap40
         AllowedCaches:
           - ANY
-        Writeback: https://ap40.uw.osg-htc.org:8443
-        DirList: https://ap40.uw.osg-htc.org:8443
+        Writeback: https://ospool-ap2140.chtc.wisc.edu:8443
+        DirList: https://ospool-ap2140.chtc.wisc.edu:8443
         CredentialGeneration:
           Strategy: OAuth2
-          Issuer: https://ap40.uw.osg-htc.org:8443
+          Issuer: https://ospool-ap2140.chtc.wisc.edu:8443
           MaxScopeDepth: 4
 
       # SciTokens issuer for ap20

--- a/virtual-organizations/OSG.yaml
+++ b/virtual-organizations/OSG.yaml
@@ -136,10 +136,11 @@ DataFederations:
               Map Subject: True
         AllowedOrigins:
           - CHTC_OSPOOL_ORIGIN
+          - CHTC-ap40
         AllowedCaches:
           - ANY
-        Writeback: https://origin-auth2001.chtc.wisc.edu:1095
-        DirList: https://origin-auth2001.chtc.wisc.edu:1095
+        Writeback: https://ospool-ap2140.chtc.wisc.edu:8443
+        DirList: https://ospool-ap2140.chtc.wisc.edu:8443
         CredentialGeneration:
           Strategy: OAuth2
           Issuer: https://osg-htc.org/ospool
@@ -252,6 +253,23 @@ DataFederations:
           - ANY
         Writeback: https://ap22.uc.osg-htc.org:1095
         DirList: https://ap22.uc.osg-htc.org:1095
+        CredentialGeneration:
+          Strategy: OAuth2
+          Issuer: https://osg-htc.org/ospool
+          MaxScopeDepth: 4
+
+      - Path: /ospool/ap40/data
+        Authorizations:
+          - SciTokens:
+              Issuer: https://ap40.uw.osg-htc.org:8443
+              Base Path: /ospool/ap40
+              Map Subject: True
+        AllowedOrigins:
+          - CHTC-ap40
+        AllowedCaches:
+          - ANY
+        Writeback: https://ap40.uw.osg-htc.org:8443
+        DirList: https://ap40.uw.osg-htc.org:8443
         CredentialGeneration:
           Strategy: OAuth2
           Issuer: https://osg-htc.org/ospool

--- a/virtual-organizations/OSG.yaml
+++ b/virtual-organizations/OSG.yaml
@@ -136,11 +136,10 @@ DataFederations:
               Map Subject: True
         AllowedOrigins:
           - CHTC_OSPOOL_ORIGIN
-          - CHTC-ap40
         AllowedCaches:
           - ANY
-        Writeback: https://ospool-ap2140.chtc.wisc.edu:8443
-        DirList: https://ospool-ap2140.chtc.wisc.edu:8443
+        Writeback: https://origin-auth2001.chtc.wisc.edu:1095
+        DirList: https://origin-auth2001.chtc.wisc.edu:1095
         CredentialGeneration:
           Strategy: OAuth2
           Issuer: https://osg-htc.org/ospool

--- a/virtual-organizations/OSG.yaml
+++ b/virtual-organizations/OSG.yaml
@@ -272,7 +272,7 @@ DataFederations:
         DirList: https://ap40.uw.osg-htc.org:8443
         CredentialGeneration:
           Strategy: OAuth2
-          Issuer: https://osg-htc.org/ospool
+          Issuer: https://ap40.uw.osg-htc.org:8443
           MaxScopeDepth: 4
 
       # SciTokens issuer for ap20


### PR DESCRIPTION
This is going to be a very odd registration: we currently have the production AP running on `ap40.uw.osg-htc.org`, aka `ospool-2040.chtc.wisc.edu`. However, we need to stand up a new origin on decent hardware as `origin-auth2001` is falling over under load. We are using the new AP40 hardware, `ospool-2140.chtc.wisc.edu` for this in a similar setup to the UC APs (we plan to do an in-place replacement of the old AP40 with the new AP40).

I'm not sure what the right registrations are here exactly:
1.  We want to serve `/ospool/PROTECTED` from the new origin to address the acute issue
1.  But we also want to move users over to `/ospool/ap40/data` with the future AP40 transition
I'm not entirely sure what the issuers should be and the relevant FQDNs across the different fields.