### PR TITLE
/sage namespace should not be publicly readable

### DIFF
--- a/virtual-organizations/Sage.yaml
+++ b/virtual-organizations/Sage.yaml
@@ -32,7 +32,6 @@ DataFederations:
               Issuer: https://sagecontinuum.org
               Base Path: /sage
               Map Subject: False
-           - PUBLIC
         AllowedOrigins:
           - NEBRASKA_NRP_HCC_OSDF_ORIGIN 
         AllowedCaches:


### PR DESCRIPTION
Discussed on a Zoom call; the /sage namespace is not meant to be publicly readable so shouldn't have PUBLIC auth set.