### PR TITLE
Fix CHTC ITB Pelican Origin auth endpoint port

### DIFF
--- a/topology/University of Wisconsin/CHTC/CHTC-ITB.yaml
+++ b/topology/University of Wisconsin/CHTC/CHTC-ITB.yaml
@@ -410,5 +410,6 @@ Resources:
         Description: ITB OSDF Pelican Origin
         Details:
           endpoint_override: itb-osdf-pelican-origin.osgdev.chtc.io:8443
+          auth_endpoint_override: itb-osdf-pelican-origin.osgdev.chtc.io:8443
     AllowedVOs:
       - GLOW


### PR DESCRIPTION
The auth and un-auth endpoints for the CHTC ITB Pelican Origin should both be 8443.

It seems that the ITB OSDF Pelican director puts the auth-endpoint at a higher priority than the regular endpoint, but since the auth_endpoint is still using the topology stash-cache default ports the director redirects the request to a port the origin never listens on.

From curl -v:
> link: <https://itb-osdf-pelican-origin.osgdev.chtc.io:1095/chtc/itb/osdf-pelican/ITB-OSDF-TESTFILE_4>; rel="duplicate"; pri=1; depth=1, <https://itb-osdf-pelican-origin.osgdev.chtc.io:8443/chtc/itb/osdf-pelican/ITB-OSDF-TESTFILE_4>; rel="duplicate"; pri=2; depth=1