### PR TITLE
Add downtime for CARDIFF_UK_OSDF_CACHE due to <REASON>

### DIFF
--- a/topology/Cardiff University/Cardiff Computing Cluster/CardiffPRPCachingInfrastructure_downtime.yaml
+++ b/topology/Cardiff University/Cardiff Computing Cluster/CardiffPRPCachingInfrastructure_downtime.yaml
@@ -19,3 +19,15 @@
   ResourceName: CARDIFF_UK_OSDF_CACHE
   Services:
   - XRootD cache server
+# ---------------------------------------------------------
+  - Class: UNSCHEDULED
+  ID: 1782049725
+  Description: Overloaded, setting for CVMF_ONLY
+  Severity: Outage
+  StartTime: Apr 15, 2024 08:00 +0000
+  EndTime: Apr 16, 2024 05:30 +0000
+  CreatedTime: Apr 15, 2024 18:16 +0000
+  ResourceName: CARDIFF_UK_OSDF_CACHE
+  Services:
+  - XRootD cache server
+# ---------------------------------------------------------


### PR DESCRIPTION
Overloaded, setting for CVMF_ONLY