### PR TITLE
Add downtime for LEHIGH-HAWK-OSDF-CACHE due to Overloaded

### DIFF
--- a/topology/Lehigh University/Lehigh - Hawk/Lehigh - Hawk_downtime.yaml
+++ b/topology/Lehigh University/Lehigh - Hawk/Lehigh - Hawk_downtime.yaml
@@ -86,4 +86,15 @@
   Services:
   - CE
 # ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 1782060687
+  Description: Overloaded
+  Severity: Outage
+  StartTime: Apr 15, 2024 08:00 +0000
+  EndTime: Apr 22, 2024 19:00 +0000
+  CreatedTime: Apr 15, 2024 18:34 +0000
+  ResourceName: LEHIGH-HAWK-OSDF-CACHE
+  Services:
+  - XRootD cache server
+# ---------------------------------------------------------
 


### PR DESCRIPTION
The monitoring shows increased "connection refuse" and time-outs in all the monitoring tests.