### PR TITLE
Drop Procfile and gunicorn

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,0 @@
-web: env PYTHONPATH=$PYTHONPATH:$PWD/src gunicorn app:app --log-file=-
-

--- a/requirements-rootless.txt
+++ b/requirements-rootless.txt
@@ -12,7 +12,6 @@ Flask~=2.3.2
 Flask-WTF~=1.1.1
 gitdb~=4.0.10
 GitPython~=3.1.31
-gunicorn~=20.1.0
 icalendar~=5.0.5
 idna~=3.4
 itsdangerous~=2.1.2


### PR DESCRIPTION
It is only used for hosting Topology on Heroku, which we no longer do. gunicorn has an unpatched security issue so I'd like to get rid of it.