### PR TITLE
Register CHTC ITB OSDF PELICAN CACHE in Topology

### DIFF
--- a/topology/University of Wisconsin/CHTC/CHTC-ITB.yaml
+++ b/topology/University of Wisconsin/CHTC/CHTC-ITB.yaml
@@ -440,13 +440,13 @@ Resources:
         Tertiary:
           ID: OSG1000003
           Name: Brian Lin
-    FQDN: itb-osdf-pelican-cache.osgdev.chtc.io
-    DN: /CN=itb-osdf-pelican-cache.osgdev.chtc.io
+    FQDN: itb-osdf-pelican-cache.osdf-dev.chtc.io
+    DN: /CN=itb-osdf-pelican-cache.osdf-dev.chtc.io
     Services:
       XRootD cache server:
         Description: ITB OSDF Pelican Cache
         Details:
-          endpoint_override: itb-osdf-pelican-cache.osgdev.chtc.io:8443
-          auth_endpoint_override: itb-osdf-pelican-cache.osgdev.chtc.io:8443
+          endpoint_override: itb-osdf-pelican-cache.osdf-dev.chtc.io:8443
+          auth_endpoint_override: itb-osdf-pelican-cache.osdf-dev.chtc.io:8443
     AllowedVOs:
       - GLOW

--- a/topology/University of Wisconsin/CHTC/CHTC-ITB.yaml
+++ b/topology/University of Wisconsin/CHTC/CHTC-ITB.yaml
@@ -413,3 +413,40 @@ Resources:
           auth_endpoint_override: itb-osdf-pelican-origin.osgdev.chtc.io:8443
     AllowedVOs:
       - GLOW
+
+  CHTC-ITB-OSDF-PELICAN-CACHE:
+    Active: true
+    Description: >-
+      This is a cache used for testing the Pelican client and
+      integration with the OSDF
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          ID: OSG1000589
+          Name: William N Swanson
+        Secondary:
+          ID: OSG1000002
+          Name: Matyas Selmeci
+        Tertiary:
+          ID: OSG1000003
+          Name: Brian Lin
+      Security Contact:
+        Primary:
+          ID: OSG1000589
+          Name: William N Swanson
+        Secondary:
+          ID: OSG1000002
+          Name: Matyas Selmeci
+        Tertiary:
+          ID: OSG1000003
+          Name: Brian Lin
+    FQDN: itb-osdf-pelican-cache.osgdev.chtc.io
+    DN: /CN=itb-osdf-pelican-cache.osgdev.chtc.io
+    Services:
+      XRootD cache server:
+        Description: ITB OSDF Pelican Cache
+        Details:
+          endpoint_override: itb-osdf-pelican-cache.osgdev.chtc.io:8443
+          auth_endpoint_override: itb-osdf-pelican-cache.osgdev.chtc.io:8443
+    AllowedVOs:
+      - GLOW


### PR DESCRIPTION
Register the CHTC's ITB OSDF Pelican cache in topology.