### PR TITLE
Update Hewlett Packard Labs LongName

### DIFF
--- a/topology/Hewlett Packard Enterprise/Hewlett Packard Labs/SITE.yaml
+++ b/topology/Hewlett Packard Enterprise/Hewlett Packard Labs/SITE.yaml
@@ -4,7 +4,7 @@ City: Milpitas
 Country: United States
 Description: Hewlett Packard Labs
 Latitude: 37.43
-LongName:  Hewlett Packard Laboratory
+LongName: Hewlett Packard Labs
 Longitude: -121.923
 State: CA
 Zipcode: 95035


### PR DESCRIPTION
Per https://github.com/opensciencegrid/topology/pull/3813#pullrequestreview-2009846213, The LongName for this site should be "Hewlett Packard Labs" instead of "Hewlett Packard Laboratory"