### PR TITLE
Retiring nih-origin.osgdev.chtc.io

### DIFF
--- a/topology/University of Wisconsin/CHTC/CHTC-OSDF.yaml
+++ b/topology/University of Wisconsin/CHTC/CHTC-OSDF.yaml
@@ -159,7 +159,7 @@ Resources:
       - ANY
 
   CHTC_NIH_ORIGIN:
-    Active: true
+    Active: false
     Description: This is an origin server serving NIH image analysis data
     ID: 1454
     ContactLists:


### PR DESCRIPTION
Retiring nih-origin.osgdev.chtc.io