### PR TITLE
Add InstitutionID and FieldOfScienceID to the project OrderedDict

### DIFF
--- a/src/webapp/project_reader.py
+++ b/src/webapp/project_reader.py
@@ -47,7 +47,8 @@ def get_resource_allocation(ra: Dict, idx: int) -> OrderedDict:
 
 def get_one_project(file: str, campus_grid_ids: Dict, vos_data: VOsData) -> Dict:
     project = OrderedDict.fromkeys(["ID", "Name", "Description", "PIName", "Organization", "Department",
-                                    "FieldOfScience", "Sponsor", "ResourceAllocations"])
+                                    "FieldOfScience", "Sponsor", "ResourceAllocations", "InstitutionID",
+                                    "FieldOfScienceID"])
     data = None
     try:
         data = load_yaml_file(file)


### PR DESCRIPTION
so the ordering of the XML elements matches the schema regardless of what order the fields were specified in the YAML.