### PR TITLE
Add downtime for DENVER_INTERNET2_OSDF_CACHE due to toPelican

### DIFF
--- a/topology/Internet2/Internet2Denver/I2DenverInfrastructure_downtime.yaml
+++ b/topology/Internet2/Internet2Denver/I2DenverInfrastructure_downtime.yaml
@@ -20,3 +20,14 @@
   Services:
   - XRootD cache server
 # ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 1794218482
+  Description: toPelican
+  Severity: Outage
+  StartTime: Apr 29, 2024 21:30 +0000
+  EndTime: May 03, 2024 19:30 +0000
+  CreatedTime: Apr 29, 2024 20:17 +0000
+  ResourceName: DENVER_INTERNET2_OSDF_CACHE
+  Services:
+  - XRootD cache server
+# ---------------------------------------------------------


### PR DESCRIPTION
Add downtime for DENVER_INTERNET2_OSDF_CACHE due to toPelican