### PR TITLE
Upgrade Werkzeug to 3.0.3+

### DIFF
--- a/requirements-rootless.txt
+++ b/requirements-rootless.txt
@@ -28,6 +28,6 @@ requests~=2.31.0
 six~=1.16.0
 smmap~=5.0.0
 urllib3~=2.0.2
-Werkzeug~=2.3.4
+Werkzeug~=3.0.3
 WTForms~=3.0.1
 xmltodict~=0.13.0


### PR DESCRIPTION
We are upgrading from 2.3.4; incompatible changes from 2.3.x to 3.x are documented here: https://werkzeug.palletsprojects.com/en/3.0.x/changes/#version-3-0-0 ; none of them appear to affect us.