### PR TITLE
Add downtime for  Stashcache-Chicago due to Hardware issues RAID problem

### DIFF
--- a/topology/Internet2/Internet2Chicago/I2ChicagoInfrastructure_downtime.yaml
+++ b/topology/Internet2/Internet2Chicago/I2ChicagoInfrastructure_downtime.yaml
@@ -20,3 +20,14 @@
   Services:
   - XRootD cache server
 # ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 1800341180
+  Description: Hardware issues RAID problem
+  Severity: Outage
+  StartTime: May 06, 2024 19:30 +0000
+  EndTime: May 10, 2024 19:30 +0000
+  CreatedTime: May 06, 2024 22:21 +0000
+  ResourceName: Stashcache-Chicago
+  Services:
+  - XRootD cache server
+# ---------------------------------------------------------


### PR DESCRIPTION
Add downtime for  Stashcache-Chicago due to Hardware issues RAID problem