### PR TITLE
Add downtime for DENVER_INTERNET2_OSDF_CACHE due to '#toPelican'

### DIFF
--- a/topology/Internet2/Internet2Denver/I2DenverInfrastructure_downtime.yaml
+++ b/topology/Internet2/Internet2Denver/I2DenverInfrastructure_downtime.yaml
@@ -31,3 +31,14 @@
   Services:
   - XRootD cache server
 # ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 1801868080
+  Description: toPelican
+  Severity: Outage
+  StartTime: May 08, 2024 19:30 +0000
+  EndTime: May 24, 2024 19:30 +0000
+  CreatedTime: May 08, 2024 16:46 +0000
+  ResourceName: DENVER_INTERNET2_OSDF_CACHE
+  Services:
+  - XRootD cache server
+# ---------------------------------------------------------


### PR DESCRIPTION
Add downtime for DENVER_INTERNET2_OSDF_CACHE due to '#toPelican'