### PR TITLE
Update FANDM-ITS_downtime.yaml

### DIFF
--- a/topology/Franklin and Marshall College/FANDM-ITS/FANDM-ITS_downtime.yaml
+++ b/topology/Franklin and Marshall College/FANDM-ITS/FANDM-ITS_downtime.yaml
@@ -10,3 +10,16 @@
   Services:
   - CE
 # ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 1803422265
+  Description: Cluster is now up after maintenance.  We noted before that the partition
+    has changed from osg to nodes.  Please resume sending jobs
+  Severity: No Significant Outage Expected
+  StartTime: May 10, 2024 08:00 +0000
+  EndTime: May 10, 2024 08:00 +0000
+  CreatedTime: May 10, 2024 07:57 +0000
+  ResourceName: FANDM-ITS-CE1
+  Services:
+  - CE
+# ---------------------------------------------------------
+


### PR DESCRIPTION
Cluster is back on-line.
We removed the osg partition, so jobs will now have to go to the nodes partition