### PR TITLE
Add downtime for BOISE_INTERNET2_OSDF_CACHE due to #toPelican

### DIFF
--- a/topology/Internet2/Internet2Boise/I2BoiseInfrastructure_downtime.yaml
+++ b/topology/Internet2/Internet2Boise/I2BoiseInfrastructure_downtime.yaml
@@ -20,3 +20,14 @@
   Services:
   - XRootD cache server
 # ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 1806272100
+  Description: '#toPelican'
+  Severity: Outage
+  StartTime: May 12, 2024 19:30 +0000
+  EndTime: May 18, 2024 06:59 +0000
+  CreatedTime: May 13, 2024 19:06 +0000
+  ResourceName: BOISE_INTERNET2_OSDF_CACHE
+  Services:
+  - XRootD cache server
+# ---------------------------------------------------------


### PR DESCRIPTION
Add downtime for BOISE_INTERNET2_OSDF_CACHE due to #toPelican