### PR TITLE
Add scheduled downtime for GLOW T2_US_Wisconsin for HDFS upgrade

### DIFF
--- a/topology/University of Wisconsin/GLOW/GLOW_downtime.yaml
+++ b/topology/University of Wisconsin/GLOW/GLOW_downtime.yaml
@@ -3061,3 +3061,212 @@
   Services:
   - CE
 # ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 1808793267
+  Description: Updating our Hadoop File System on our data nodes and name nodes
+  Severity: Severe
+  StartTime: May 20, 2024 13:00 +0000
+  EndTime: May 20, 2024 22:00 +0000
+  CreatedTime: May 16, 2024 17:08 +0000
+  ResourceName: GLOW
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 1808793268
+  Description: Updating our Hadoop File System on our data nodes and name nodes
+  Severity: Severe
+  StartTime: May 20, 2024 13:00 +0000
+  EndTime: May 20, 2024 22:00 +0000
+  CreatedTime: May 16, 2024 17:08 +0000
+  ResourceName: GLOW-CMS
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 1808793269
+  Description: Updating our Hadoop File System on our data nodes and name nodes
+  Severity: Severe
+  StartTime: May 20, 2024 13:00 +0000
+  EndTime: May 20, 2024 22:00 +0000
+  CreatedTime: May 16, 2024 17:08 +0000
+  ResourceName: GLOW-CMS-SE
+  Services:
+  - SRMv2
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 1808793270
+  Description: Updating our Hadoop File System on our data nodes and name nodes
+  Severity: Severe
+  StartTime: May 20, 2024 13:00 +0000
+  EndTime: May 20, 2024 22:00 +0000
+  CreatedTime: May 16, 2024 17:08 +0000
+  ResourceName: GLOW-CONDOR-CE
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 1808793271
+  Description: Updating our Hadoop File System on our data nodes and name nodes
+  Severity: Severe
+  StartTime: May 20, 2024 13:00 +0000
+  EndTime: May 20, 2024 22:00 +0000
+  CreatedTime: May 16, 2024 17:08 +0000
+  ResourceName: GLOW-OSG
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 1808793272
+  Description: Updating our Hadoop File System on our data nodes and name nodes
+  Severity: Severe
+  StartTime: May 20, 2024 13:00 +0000
+  EndTime: May 20, 2024 22:00 +0000
+  CreatedTime: May 16, 2024 17:08 +0000
+  ResourceName: GLOW_SQUID
+  Services:
+  - Squid
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 1808793273
+  Description: Updating our Hadoop File System on our data nodes and name nodes
+  Severity: Severe
+  StartTime: May 20, 2024 13:00 +0000
+  EndTime: May 20, 2024 22:00 +0000
+  CreatedTime: May 16, 2024 17:08 +0000
+  ResourceName: GLOW_SQUID1
+  Services:
+  - Squid
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 1808793274
+  Description: Updating our Hadoop File System on our data nodes and name nodes
+  Severity: Severe
+  StartTime: May 20, 2024 13:00 +0000
+  EndTime: May 20, 2024 22:00 +0000
+  CreatedTime: May 16, 2024 17:08 +0000
+  ResourceName: GLOW_SQUID2
+  Services:
+  - Squid
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 1808793275
+  Description: Updating our Hadoop File System on our data nodes and name nodes
+  Severity: Severe
+  StartTime: May 20, 2024 13:00 +0000
+  EndTime: May 20, 2024 22:00 +0000
+  CreatedTime: May 16, 2024 17:08 +0000
+  ResourceName: GLOW_SQUID3
+  Services:
+  - Squid
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 1808793276
+  Description: Updating our Hadoop File System on our data nodes and name nodes
+  Severity: Severe
+  StartTime: May 20, 2024 13:00 +0000
+  EndTime: May 20, 2024 22:00 +0000
+  CreatedTime: May 16, 2024 17:08 +0000
+  ResourceName: GLOW_SQUID4
+  Services:
+  - Squid
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 1808793277
+  Description: Updating our Hadoop File System on our data nodes and name nodes
+  Severity: Severe
+  StartTime: May 20, 2024 13:00 +0000
+  EndTime: May 20, 2024 22:00 +0000
+  CreatedTime: May 16, 2024 17:08 +0000
+  ResourceName: GLOW_SUBMIT1
+  Services:
+  - Submit Node
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 1808793278
+  Description: Updating our Hadoop File System on our data nodes and name nodes
+  Severity: Severe
+  StartTime: May 20, 2024 13:00 +0000
+  EndTime: May 20, 2024 22:00 +0000
+  CreatedTime: May 16, 2024 17:08 +0000
+  ResourceName: GLOW_SUBMIT2
+  Services:
+  - Submit Node
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 1808793279
+  Description: Updating our Hadoop File System on our data nodes and name nodes
+  Severity: Severe
+  StartTime: May 20, 2024 13:00 +0000
+  EndTime: May 20, 2024 22:00 +0000
+  CreatedTime: May 16, 2024 17:08 +0000
+  ResourceName: GLOW_SUBMIT3
+  Services:
+  - Submit Node
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 1808793280
+  Description: Updating our Hadoop File System on our data nodes and name nodes
+  Severity: Severe
+  StartTime: May 20, 2024 13:00 +0000
+  EndTime: May 20, 2024 22:00 +0000
+  CreatedTime: May 16, 2024 17:08 +0000
+  ResourceName: GLOW_SUBMIT4
+  Services:
+  - Submit Node
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 1808793281
+  Description: Updating our Hadoop File System on our data nodes and name nodes
+  Severity: Severe
+  StartTime: May 20, 2024 13:00 +0000
+  EndTime: May 20, 2024 22:00 +0000
+  CreatedTime: May 16, 2024 17:08 +0000
+  ResourceName: GLOW_SUBMIT5
+  Services:
+  - Submit Node
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 1808793282
+  Description: Updating our Hadoop File System on our data nodes and name nodes
+  Severity: Severe
+  StartTime: May 20, 2024 13:00 +0000
+  EndTime: May 20, 2024 22:00 +0000
+  CreatedTime: May 16, 2024 17:08 +0000
+  ResourceName: GLOW_SUBMIT6
+  Services:
+  - Submit Node
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 1808793283
+  Description: Updating our Hadoop File System on our data nodes and name nodes
+  Severity: Severe
+  StartTime: May 20, 2024 13:00 +0000
+  EndTime: May 20, 2024 22:00 +0000
+  CreatedTime: May 16, 2024 17:08 +0000
+  ResourceName: GLOW_SUBMIT_CERN
+  Services:
+  - Submit Node
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 1808793284
+  Description: Updating our Hadoop File System on our data nodes and name nodes
+  Severity: Severe
+  StartTime: May 20, 2024 13:00 +0000
+  EndTime: May 20, 2024 22:00 +0000
+  CreatedTime: May 16, 2024 17:08 +0000
+  ResourceName: US-Wisconsin BW
+  Services:
+  - net.perfSONAR.Bandwidth
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 1808793285
+  Description: Updating our Hadoop File System on our data nodes and name nodes
+  Severity: Severe
+  StartTime: May 20, 2024 13:00 +0000
+  EndTime: May 20, 2024 22:00 +0000
+  CreatedTime: May 16, 2024 17:08 +0000
+  ResourceName: US-Wisconsin LT
+  Services:
+  - net.perfSONAR.Latency
+# ---------------------------------------------------------


### PR DESCRIPTION
T2_US_Wisconsin will be updating HDFS on the name nodes, which will prevent writing to /store, so we are scheduling a downtime for this upgrade.