### PR TITLE
Add downtime for Purdue_US_T2 for power transfer

### DIFF
--- a/topology/Purdue University/Purdue CMS/Purdue_downtime.yaml
+++ b/topology/Purdue University/Purdue CMS/Purdue_downtime.yaml
@@ -2131,3 +2131,14 @@
   Services:
   - net.perfSONAR.Latency
 # ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 1819162937
+  Description: Power transfer for datacenter circuits
+  Severity: Severe
+  StartTime: May 30, 2024 11:00 +0000
+  EndTime: May 30, 2024 21:00 +0000
+  CreatedTime: May 28, 2024 17:11 +0000
+  ResourceName: Purdue-EOS-SE
+  Services:
+  - EOS
+# ---------------------------------------------------------


### PR DESCRIPTION
this is a precautionary downtime in the event that we completely lose power to our storage element during the power transfer.  No downtime is actually expected