### PR TITLE
Update the IssuerName for AP40 to match its local credmon setting

### DIFF
--- a/virtual-organizations/OSG.yaml
+++ b/virtual-organizations/OSG.yaml
@@ -196,7 +196,7 @@ DataFederations:
       - Path: /ospool/ap40/data
         Authorizations:
           - SciTokens:
-              Issuer: https://ospool-ap2140.chtc.wisc.edu:8443
+              Issuer: https://osg-htc.org/ospool
               Base Path: /ospool/ap40
               Map Subject: True
         AllowedOrigins:


### PR DESCRIPTION
The new change also matches what is used for Pelican.  This should fix access to AP40 files from non-Pelican caches.