### PR TITLE
Correct base path for AP40 issuer

### DIFF
--- a/virtual-organizations/OSG.yaml
+++ b/virtual-organizations/OSG.yaml
@@ -197,7 +197,7 @@ DataFederations:
         Authorizations:
           - SciTokens:
               Issuer: https://osg-htc.org/ospool
-              Base Path: /ospool/ap40
+              Base Path: /ospool/ap40/data
               Map Subject: True
         AllowedOrigins:
           - CHTC-ap40


### PR DESCRIPTION
The AP40 issuer generates authorizations of the form `/$USERNAME` for files in `/ospool/ap40/data/$USERNAME`.  However, the base path for the issuer was set to `/ospool/ap40`.  Dropping the `/data` component caused failures in non-Pelican caches.