### PR TITLE
Add downtime for FNAL_OSDF_ORIGIN due to Testing the pelican sw

### DIFF
--- a/topology/Fermi National Accelerator Laboratory/FermiGrid/FNAL_OSDF_downtime.yaml
+++ b/topology/Fermi National Accelerator Laboratory/FermiGrid/FNAL_OSDF_downtime.yaml
@@ -1,0 +1,11 @@
+- Class: UNSCHEDULED
+  ID: 1831468972
+  Description: Testing the pelican sw
+  Severity: Outage
+  StartTime: Jun 11, 2024 08:00 +0000
+  EndTime: Jun 21, 2024 19:30 +0000
+  CreatedTime: Jun 11, 2024 23:01 +0000
+  ResourceName: FNAL_OSDF_ORIGIN
+  Services:
+  - XRootD origin server
+# ---------------------------------------------------------


### PR DESCRIPTION
Add downtime for FNAL_OSDF_ORIGIN due to Testing the pelican sw