### PR TITLE
Unregister the UChicago .well-known directories

### DIFF
--- a/virtual-organizations/OSG.yaml
+++ b/virtual-organizations/OSG.yaml
@@ -210,32 +210,36 @@ DataFederations:
           Issuer: https://ospool-ap2140.chtc.wisc.edu:8443
           MaxScopeDepth: 4
 
-      # SciTokens issuer for ap20
-      - Path: /ospool/ap20/.well-known
-        Authorizations:
-          - PUBLIC
-        AllowedOrigins:
-          - UChicago_OSGConnect_ap20
-        # Do not cache this: direct access only
-        AllowedCaches: []
+      ### These scitokens issuers are intentionally unregistered: the xrootd
+      ### service serving them does not pull config from Topology, and the
+      ### data is not meant to be cached.
 
-      # SciTokens issuer for ap21
-      - Path: /ospool/ap21/.well-known
-        Authorizations:
-          - PUBLIC
-        AllowedOrigins:
-          - UChicago_OSGConnect_ap21
-        # Do not cache this: direct access only
-        AllowedCaches: []
+      # # SciTokens issuer for ap20
+      # - Path: /ospool/ap20/.well-known
+      #   Authorizations:
+      #     - PUBLIC
+      #   AllowedOrigins:
+      #     - UChicago_OSGConnect_ap20
+      #   # Do not cache this: direct access only
+      #   AllowedCaches: []
 
-      # SciTokens issuer for ap22
-      - Path: /ospool/ap22/.well-known
-        Authorizations:
-          - PUBLIC
-        AllowedOrigins:
-          - UChicago_OSGConnect_ap22
-        # Do not cache this: direct access only
-        AllowedCaches: []
+      # # SciTokens issuer for ap21
+      # - Path: /ospool/ap21/.well-known
+      #   Authorizations:
+      #     - PUBLIC
+      #   AllowedOrigins:
+      #     - UChicago_OSGConnect_ap21
+      #   # Do not cache this: direct access only
+      #   AllowedCaches: []
+
+      # # SciTokens issuer for ap22
+      # - Path: /ospool/ap22/.well-known
+      #   Authorizations:
+      #     - PUBLIC
+      #   AllowedOrigins:
+      #     - UChicago_OSGConnect_ap22
+      #   # Do not cache this: direct access only
+      #   AllowedCaches: []
 
       - Path: /ospool/uc-shared/project
         Authorizations:


### PR DESCRIPTION
/ospool/ap20/.well-known, /ospool/ap21/.well-known, /ospool/ap22/.well-known

These registrations confuse Pelican; fortunately the registrations are unnecessary because the directories are served by an xrootd service that has a manually configured Authfile, and they are not cached.