### PR TITLE
Add "Pelican origin" and "Pelican cache" service types

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -22,7 +22,7 @@ from webapp import default_config
 from webapp.common import readfile, to_xml_bytes, to_json_bytes, Filters, support_cors, simplify_attr_list, is_null, \
     escape, cache_control_private, PreJSON, is_true, GRIDTYPE_1, GRIDTYPE_2, NamespacesFilters
 from webapp.flask_common import create_accepted_response
-from webapp.exceptions import DataError, ResourceNotRegistered, ResourceMissingService
+from webapp.exceptions import DataError, ResourceNotRegistered, ResourceMissingServices
 from webapp.forms import GenerateDowntimeForm, GenerateResourceGroupDowntimeForm, GenerateProjectForm
 from webapp.models import GlobalData
 from webapp.oasis_managers import get_oasis_manager_endpoint_info
@@ -603,7 +603,7 @@ def _get_cache_authfile(public_only):
                                  fqdn=cache_fqdn,
                                  legacy=app.config["STASHCACHE_LEGACY_AUTH"],
                                  suppress_errors=False)
-    except (ResourceNotRegistered, ResourceMissingService) as e:
+    except (ResourceNotRegistered, ResourceMissingServices) as e:
         return Response("# {}\n"
                         "# Please check your query or contact help@osg-htc.org\n"
                         .format(str(e)),
@@ -627,7 +627,7 @@ def _get_origin_authfile(public_only):
     try:
         auth = stashcache.generate_origin_authfile(global_data=global_data, fqdn=request.args['fqdn'],
                                                    suppress_errors=False, public_origin=public_only)
-    except (ResourceNotRegistered, ResourceMissingService) as e:
+    except (ResourceNotRegistered, ResourceMissingServices) as e:
         return Response("# {}\n"
                         "# Please check your query or contact help@osg-htc.org\n"
                         .format(str(e)),

--- a/src/webapp/common.py
+++ b/src/webapp/common.py
@@ -396,5 +396,7 @@ def cache_control_private(f):
 
 XROOTD_CACHE_SERVER = "XRootD cache server"
 XROOTD_ORIGIN_SERVER = "XRootD origin server"
+PELICAN_CACHE = "Pelican cache"
+PELICAN_ORIGIN = "Pelican origin"
 GRIDTYPE_1 = "OSG Production Resource"
 GRIDTYPE_2 = "OSG Integration Test Bed Resource"

--- a/src/webapp/data_federation.py
+++ b/src/webapp/data_federation.py
@@ -4,7 +4,7 @@ import urllib.parse
 from collections import OrderedDict
 from typing import Optional, List, Dict, Tuple, Union, Set
 
-from .common import XROOTD_CACHE_SERVER, XROOTD_ORIGIN_SERVER, ParsedYaml, is_null
+from .common import PELICAN_CACHE, PELICAN_ORIGIN, XROOTD_CACHE_SERVER, XROOTD_ORIGIN_SERVER, ParsedYaml, is_null
 try:
     from .x509 import generate_dn_hash
 except ImportError:  # if asn1 is unavailable
@@ -89,14 +89,16 @@ class SciTokenAuth(AuthMethod):
                 f"map_subject={self.map_subject}"
 
     def get_scitokens_conf_block(self, service_name: str):
-        if service_name not in [XROOTD_CACHE_SERVER, XROOTD_ORIGIN_SERVER]:
-            raise ValueError(f"service_name must be '{XROOTD_CACHE_SERVER}' or '{XROOTD_ORIGIN_SERVER}'")
+        if service_name not in {PELICAN_CACHE, PELICAN_ORIGIN, XROOTD_CACHE_SERVER, XROOTD_ORIGIN_SERVER}:
+            raise ValueError(
+                f"service_name must be one of: '{PELICAN_CACHE}', '{PELICAN_ORIGIN}', "
+                f"'{XROOTD_CACHE_SERVER}', or '{XROOTD_ORIGIN_SERVER}'")
         block = (f"[Issuer {self.issuer}]\n"
                  f"issuer = {self.issuer}\n"
                  f"base_path = {self.base_path}\n")
         if self.restricted_path:
             block += f"restricted_path = {self.restricted_path}\n"
-        if service_name == XROOTD_ORIGIN_SERVER:
+        if service_name in {PELICAN_ORIGIN, XROOTD_ORIGIN_SERVER}:
             block += f"map_subject = {self.map_subject}\n"
 
         return block

--- a/src/webapp/exceptions.py
+++ b/src/webapp/exceptions.py
@@ -25,10 +25,17 @@ class ResourceDataError(DataError):
         super().__init__(f"Resource {resource.name}, FQDN {resource.fqdn}: {text}")
 
 
-class ResourceMissingService(ResourceDataError):
-    def __init__(self, resource: "Resource", service_name: str):
-        self.service_name = service_name
-        super().__init__(resource=resource, text=f"Missing expected service {service_name}")
+class ResourceMissingServices(ResourceDataError):
+    def __init__(self, resource: "Resource", service_names):
+        if isinstance(service_names, str):
+            service_names = [service_names]
+        self.service_names = service_names
+        self.service_names_str = ", ".join(service_names)
+        super().__init__(
+            resource=resource,
+            text="None of the following expected services are available: " +
+                 self.service_names_str
+        )
 
 
 class VODataError(DataError):

--- a/src/webapp/topology.py
+++ b/src/webapp/topology.py
@@ -9,7 +9,7 @@ import icalendar
 
 from .common import RGDOWNTIME_SCHEMA_URL, RGSUMMARY_SCHEMA_URL, Filters, ParsedYaml, \
     is_null, expand_attr_list_single, expand_attr_list, ensure_list, XROOTD_ORIGIN_SERVER, XROOTD_CACHE_SERVER, \
-    gen_id_from_yaml, GRIDTYPE_1, GRIDTYPE_2, is_true
+    gen_id_from_yaml, GRIDTYPE_1, GRIDTYPE_2, is_true, PELICAN_ORIGIN, PELICAN_CACHE
 from .contacts_reader import ContactsData, User
 from .exceptions import DataError
 
@@ -111,8 +111,25 @@ class Resource(object):
         self.name = name
         self.service_types = common_data.service_types
         self.common_data = common_data
+        # Some "indexes" to speed up data lookup
+        self.has_xrootd_cache = False
+        self.has_xrootd_origin = False
+        self.has_pelican_cache = False
+        self.has_pelican_origin = False
+        self.service_names = []
         if not is_null(yaml_data, "Services"):
             self.services = self._expand_services(yaml_data["Services"])
+            for svc in self.services:
+                if "Name" in svc:
+                    self.service_names.append(svc["Name"])
+                    if svc["Name"] == XROOTD_CACHE_SERVER:
+                        self.has_xrootd_cache = True
+                    elif svc["Name"] == XROOTD_ORIGIN_SERVER:
+                        self.has_xrootd_origin = True
+                    elif svc["Name"] == PELICAN_CACHE:
+                        self.has_pelican_cache = True
+                    elif svc["Name"] == PELICAN_ORIGIN:
+                        self.has_pelican_origin = True
         else:
             self.services = []
         self.service_names = [n["Name"] for n in self.services if "Name" in n]

--- a/topology/University of Wisconsin/CHTC/CHTC-ITB.yaml
+++ b/topology/University of Wisconsin/CHTC/CHTC-ITB.yaml
@@ -406,11 +406,8 @@ Resources:
     FQDN: itb-osdf-pelican-origin.osdf-dev.chtc.io
     DN: /CN=itb-osdf-pelican-origin.osdf-dev.chtc.io
     Services:
-      XRootD origin server:
+      Pelican origin:
         Description: ITB OSDF Pelican Origin
-        Details:
-          endpoint_override: itb-osdf-pelican-origin.osdf-dev.chtc.io:8443
-          auth_endpoint_override: itb-osdf-pelican-origin.osdf-dev.chtc.io:8443
     AllowedVOs:
       - GLOW
 
@@ -443,10 +440,7 @@ Resources:
     FQDN: itb-osdf-pelican-cache.osdf-dev.chtc.io
     DN: /CN=itb-osdf-pelican-cache.osdf-dev.chtc.io
     Services:
-      XRootD cache server:
+      Pelican cache:
         Description: ITB OSDF Pelican Cache
-        Details:
-          endpoint_override: itb-osdf-pelican-cache.osdf-dev.chtc.io:8443
-          auth_endpoint_override: itb-osdf-pelican-cache.osdf-dev.chtc.io:8443
     AllowedVOs:
       - GLOW

--- a/topology/services.yaml
+++ b/topology/services.yaml
@@ -26,6 +26,8 @@ perfsonar data store: 145
 Connect: 149
 XRootD origin server: 147
 XRootD cache server: 156
+Pelican origin: 163
+Pelican cache: 164
 XRootD HA component: 148
 Virtual Machine Host: 150
 Certificate Provider: 151


### PR DESCRIPTION
Most cache/origin endpoints work the same for the Pelican cache/origin service types as they do for the XRootD cache/origin services

The exception is the namespaces JSON which explicitly excludes Pelican caches/origins. (SOFTWARE-5867)