### PR TITLE
end dt for UCSD cache

### DIFF
--- a/topology/University of California San Diego/UCSD OSG/StashCaches_downtime.yaml
+++ b/topology/University of California San Diego/UCSD OSG/StashCaches_downtime.yaml
@@ -35,7 +35,7 @@
   Description: Mark as down until Fabio can check
   Severity: Outage
   StartTime: Jul 15, 2024 19:00 +0000
-  EndTime: Jul 25, 2024 19:00 +0000
+  EndTime: Jul 15, 2024 21:40 +0000
   CreatedTime: Jul 15, 2024 19:18 +0000
   ResourceName: Stashcache-UCSD
   Services:


### PR DESCRIPTION
Diego fixed this one by reducing requested memory from the k8 config.