### PR TITLE
Add downtime for DENVER_INTERNET2_OSDF_CACHE due to overloaded

### DIFF
--- a/topology/Internet2/Internet2Denver/I2DenverInfrastructure_downtime.yaml
+++ b/topology/Internet2/Internet2Denver/I2DenverInfrastructure_downtime.yaml
@@ -42,3 +42,15 @@
   Services:
   - XRootD cache server
 # ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 1867467090
+  Description: overloaded
+  Severity: Outage
+  StartTime: Jul 23, 2024 05:01 +0000
+  EndTime: Jul 26, 2024 16:30 +0000
+  CreatedTime: Jul 23, 2024 14:58 +0000
+  ResourceName: DENVER_INTERNET2_OSDF_CACHE
+  Services:
+  - XRootD cache server
+# ---------------------------------------------------------
+


### PR DESCRIPTION
Add downtime for DENVER_INTERNET2_OSDF_CACHE due to overloaded