### PR TITLE
Add downtime for FDP_OSDF_CACHE due to testing the pelican sw

### DIFF
--- a/topology/DIII-D National Fusion Facility/National Fusion Facility/FDP-OSDF_downtime.yaml
+++ b/topology/DIII-D National Fusion Facility/National Fusion Facility/FDP-OSDF_downtime.yaml
@@ -1,0 +1,11 @@
+- Class: UNSCHEDULED
+  ID: 1873946840
+  Description: testing the pelican sw
+  Severity: Outage
+  StartTime: Jul 28, 2024 08:01 +0000
+  EndTime: Aug 09, 2024 19:03 +0000
+  CreatedTime: Jul 31, 2024 02:58 +0000
+  ResourceName: FDP_OSDF_CACHE
+  Services:
+  - XRootD cache server
+# ---------------------------------------------------------


### PR DESCRIPTION
Add downtime for FDP_OSDF_CACHE due to testing the pelican sw