### PR TITLE
Use 165 as the ID for Pelican origin instead of 163

### DIFF
--- a/topology/services.yaml
+++ b/topology/services.yaml
@@ -26,7 +26,7 @@ perfsonar data store: 145
 Connect: 149
 XRootD origin server: 147
 XRootD cache server: 156
-Pelican origin: 163
+Pelican origin: 165
 Pelican cache: 164
 XRootD HA component: 148
 Virtual Machine Host: 150


### PR DESCRIPTION
163 is also used by EOS

The map looks for Pelican origins by the service name, not number, so no changes are needed there.