### PR TITLE
Retire CHTC_TIGER_CACHE (stash-cache.osg.chtc.io)

### DIFF
--- a/topology/University of Wisconsin/CHTC/CHTC-OSDF.yaml
+++ b/topology/University of Wisconsin/CHTC/CHTC-OSDF.yaml
@@ -36,7 +36,7 @@ Resources:
       - ANY
 
   CHTC_TIGER_CACHE:
-    Active: true
+    Active: false
     Description: This is a StashCache cache server at UW running on the Tiger Kubernetes cluster.
     ID: 1098
     ContactLists:


### PR DESCRIPTION
Retire stash-cache.osg.chtc.io, since it is a pre-Pelican cache with a slow network connection. (https://opensciencegrid.atlassian.net/issues/INF-2221)