### PR TITLE
retire sl-um-es5.slateci.io

### DIFF
--- a/topology/University of Michigan/AGLT2/AGLT2.yaml
+++ b/topology/University of Michigan/AGLT2/AGLT2.yaml
@@ -37,7 +37,7 @@ Resources:
     VOOwnership:
       ATLAS: 90
   AGLT2-squid-3:
-    Active: true
+    Active: false
     ContactLists:
       Administrative Contact:
         Primary:
@@ -66,7 +66,7 @@ Resources:
       Squid:
         Description: Generic squid service
         Details:
-          Monitored: true
+          Monitored: false
     VOOwnership:
       ATLAS: 90
   AGLT2-squid-4:


### PR DESCRIPTION
we are retiring sl-um-es5, taking it out from service and monitor