### PR TITLE
Test downtime for Pelican topology downtime integration testing

### DIFF
--- a/topology/University of Wisconsin/CHTC/CHTC-ITB_downtime.yaml
+++ b/topology/University of Wisconsin/CHTC/CHTC-ITB_downtime.yaml
@@ -9,3 +9,14 @@
   Services:
   - CE
 # ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 1903815939
+  Description: Downtime to test Pelican topology downtime integration
+  Severity: Outage
+  StartTime: Sep 4, 2024 12:00 -0600
+  EndTime: Sep 4, 2024 17:00 -0600
+  CreatedTime: Sep 4, 2024 11:00 -0600
+  ResourceName: CHTC-ITB-OSDF-PELICAN-ORIGIN
+  Services:
+  - Pelican origin
+# ---------------------------------------------------------


### PR DESCRIPTION
Pelican v7.10.4 should be able to put components into downtime in the Director if the component goes into downtime in topology, this downtime/outage pr is to test that it is working properly.