### PR TITLE
Remove /nasa/nsdf

### DIFF
--- a/virtual-organizations/NRP.yaml
+++ b/virtual-organizations/NRP.yaml
@@ -134,17 +134,6 @@ DataFederations:
           - SDSC_NRP_OSDF_ORIGIN
         AllowedCaches:
           - ANY
-      - Path: /nasa/nsdf
-        Authorizations:
-          - PUBLIC
-          - SciTokens:
-              Issuer: https://t.nationalresearchplatform.org/nasa
-              Base Path: /nasa/nsdf
-              Map Subject: False
-        AllowedOrigins:
-          - Missouri-Rise-Origin1-NRP
-        AllowedCaches:
-          - ANY
       - Path: /nrp/osdf
         Authorizations:
           - PUBLIC


### PR DESCRIPTION
This patch undoes #4121. I think there was some miscommunication about what exactly what was needed.

@williamnswanson and I are trying to set up a Pelican-based OSDF origin at SDSC. This topology entry is currently preventing the origin from registering itself via the usual flow.

At that moment, the goal is to be able to write into the origin. Whether non-Pelican caches are supported for reading from it is a problem that we can deal with later.