### PR TITLE
Further extend osdf uw cache downtime

### DIFF
--- a/topology/University of Wisconsin/CHTC/CHTC-OSDF_downtime.yaml
+++ b/topology/University of Wisconsin/CHTC/CHTC-OSDF_downtime.yaml
@@ -235,7 +235,7 @@
   Description: HW issue
   Severity: Outage
   StartTime: Oct 01, 2024 08:00 +0000
-  EndTime: Oct 03, 2024 15:30 +0000
+  EndTime: Oct 07, 2024 15:30 +0000
   CreatedTime: Oct 01, 2024 23:54 +0000
   ResourceName: CHTC_PELICAN_CACHE
   Services:


### PR DESCRIPTION
Further extend the downtime for the OSDF UW pelican cache until next Monday, when I'll be able to take a better look at what's going wrong with the check mk monitoring.