### PR TITLE
Update LIGO.yaml to add SURF

### DIFF
--- a/virtual-organizations/LIGO.yaml
+++ b/virtual-organizations/LIGO.yaml
@@ -131,6 +131,7 @@ DataFederations:
           - SINGAPORE_INTERNET2_OSDF_CACHE
           - SPRACE_OSDF_CACHE
           - KAGRA_OSDF_CACHE
+          - SURF_MS4_OSDF_STASHCACHE
       - Path: /igwn/virgo
         Authorizations:
           - DN: /DC=org/DC=incommon/C=US/ST=Nebraska/O=University of Nebraska-Lincoln/CN=hcc-cvmfs-repo.unl.edu


### PR DESCRIPTION
Our cache instance is provisioned for IGWN/LVK.
Now we should be added to the list to serve data.