### PR TITLE
Add DirList to KAGRA origins in LIGO.yaml

### DIFF
--- a/virtual-organizations/LIGO.yaml
+++ b/virtual-organizations/LIGO.yaml
@@ -192,6 +192,7 @@ DataFederations:
         AllowedOrigins:
           - KAGRA_OSDF_ORIGIN
         AllowedCaches: *ligo-allowed-caches
+        DirList: https://kagra-dsr-b2.icrr.u-tokyo.ac.jp:1095
       - Path: /igwn/shared
         Authorizations:
           - DN: /DC=org/DC=incommon/C=US/ST=Nebraska/O=University of Nebraska-Lincoln/CN=hcc-cvmfs-repo.unl.edu


### PR DESCRIPTION
This PR adds DirList attributes specific to KAGRA within the LIGO.yaml VO file, similar to #4289 by @josh-willis. These additions ensure that directory configurations for KAGRA align with future LIGO topology requirements.