### PR TITLE
Removed OASISRepoURLs parameter and value.

### DIFF
--- a/virtual-organizations/BNL.yaml
+++ b/virtual-organizations/BNL.yaml
@@ -34,8 +34,6 @@ OASIS:
       DNs:
       -  /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=destefan/CN=665120/CN=John Steven De Stefano Jr
       ID: 8a7d75ea65a2962520279197c72df6a16e1533a1
-  OASISRepoURLs:
-  - http://cvmfs.sdcc.bnl.gov:8010/cvmfs/test0.sdcc.bnl.gov 
   UseOASIS: true
 PrimaryURL: http://www.bnl.gov
 ReportingGroups:


### PR DESCRIPTION
I am told by Dave D. that removing this parameter is one necessary step in ensuring the repository URL that someone added there, which is a test repository and is not meant for external publication or distribution, is removed from OASIS replication.