### PR TITLE
Allow users from all UC APs to access the shared project space

### DIFF
--- a/virtual-organizations/OSG.yaml
+++ b/virtual-organizations/OSG.yaml
@@ -146,7 +146,7 @@ DataFederations:
         Authorizations:
           - SciTokens:
               Issuer: https://ap20.uc.osg-htc.org:1094/ospool/ap20
-              Base Path: /ospool/ap20
+              Base Path: /ospool/ap20,/ospool/uc-shared/project
               Map Subject: True
         AllowedOrigins:
           - UChicago_OSGConnect_ap20
@@ -163,7 +163,7 @@ DataFederations:
         Authorizations:
           - SciTokens:
               Issuer: https://ap21.uc.osg-htc.org:1094/ospool/ap21
-              Base Path: /ospool/ap21
+              Base Path: /ospool/ap21,/ospool/uc-shared/project
               Map Subject: True
         AllowedOrigins:
           - UChicago_OSGConnect_ap21
@@ -180,7 +180,7 @@ DataFederations:
         Authorizations:
           - SciTokens:
               Issuer: https://ap22.uc.osg-htc.org:1094/ospool/ap22
-              Base Path: /ospool/ap22,/ospool/ap22/data,/ospool/uc-shared/project
+              Base Path: /ospool/ap22,/ospool/uc-shared/project
               Map Subject: True
         AllowedOrigins:
           - UChicago_OSGConnect_ap22
@@ -248,8 +248,16 @@ DataFederations:
               Base Path: /ospool/uc-shared/project
               Map Subject: True
           - SciTokens:
+              Issuer: https://ap20.uc.osg-htc.org:1094/ospool/ap20
+              Base Path: /ospool/ap20,/ospool/uc-shared/project
+              Map Subject: True
+          - SciTokens:
+              Issuer: https://ap21.uc.osg-htc.org:1094/ospool/ap21
+              Base Path: /ospool/ap21,/ospool/uc-shared/project
+              Map Subject: True
+          - SciTokens:
               Issuer: https://ap22.uc.osg-htc.org:1094/ospool/ap22
-              Base Path: /ospool/ap22,/ospool/ap22/data,/ospool/uc-shared/project
+              Base Path: /ospool/ap22,/ospool/uc-shared/project
               Map Subject: True
         AllowedOrigins:
           - UChicago_OSGConnect_ap23


### PR DESCRIPTION
(UCOPS-114)

It looks like on AP20-22 we set prefix the username scopes with /data
so we shouldn't have to include `/ospool/ap2*/data` in the base path