### PR TITLE
Remove origin from ap23.uc.osg-htc.org

### DIFF
--- a/topology/University of Chicago/UChicago/UChicago_OSGConnect.yaml
+++ b/topology/University of Chicago/UChicago/UChicago_OSGConnect.yaml
@@ -226,8 +226,6 @@ Resources:
     Services:
       Submit Node:
         Description: OS Pool access point
-      XRootD origin server:
-        Description: OSG Connect Origin Server
     Tags:
       - OSPool
     AllowedVOs:


### PR DESCRIPTION
This was replaced by UChicago_OSGConnect_Pelican_Project_Origin