### PR TITLE
Laf/Swat Firebird: Dropped CC* tag; FD #78353

### DIFF
--- a/topology/Lafayette College/Lafayette ITS/Lafayette-Firebird.yaml
+++ b/topology/Lafayette College/Lafayette ITS/Lafayette-Firebird.yaml
@@ -21,5 +21,3 @@ Resources:
     Services:
       CE:
         Description: Hosted CE
-    Tags:
-      - CC*

--- a/topology/Swarthmore College/Swarthmore ITS/Swarthmore-Firebird.yaml
+++ b/topology/Swarthmore College/Swarthmore ITS/Swarthmore-Firebird.yaml
@@ -21,5 +21,3 @@ Resources:
     Services:
       CE:
         Description: Hosted CE
-    Tags:
-      - CC*


### PR DESCRIPTION
Not sure how we thought they were CC* – that may have been my mistake along the way. Even Lafayette by itself was not.