### PR TITLE
Add townsend-submit to CHTC topology

### DIFF
--- a/topology/University of Wisconsin/CHTC/CHTC.yaml
+++ b/topology/University of Wisconsin/CHTC/CHTC.yaml
@@ -656,4 +656,27 @@ Resources:
     VOOwnership:
       GLOW: 100
 
+  CHTC-townsend-submit:
+    Active: true
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          ID: OSG1000015
+          Name: Aaron Moate
+      Security Contact:
+        Primary:
+          ID: OSG1000015
+          Name: Aaron Moate
+    Description: CHTC Access Point
+    FQDN: townsend-submit.chtc.wisc.edu
+    Services:
+      Submit Node:
+        Description: OS Pool access point
+        Details:
+          hidden: false
+    Tags:
+      - OSPool
+    VOOwnership:
+      GLOW: 100
+
 SupportCenter: GLOW-TECH


### PR DESCRIPTION
Townsend submit has a lot of gratia data. To get this gratia data where it needs to go, we will add this node to the CHTC's topology entries. 