### PR TITLE
Only one CE will be initially available at upcoming lapse of SE outage

### DIFF
--- a/topology/University of Michigan/AGLT2/AGLT2_downtime.yaml
+++ b/topology/University of Michigan/AGLT2/AGLT2_downtime.yaml
@@ -1432,5 +1432,27 @@
   - SRMv2
   - WebDAV
 # ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 1990403890
+  Description: Finishing emergency upgrade to RHEL9
+  Severity: Outage
+  StartTime: Dec 12, 2024 23:00 +0000
+  EndTime: Dec 13, 2024 23:00 +0000
+  CreatedTime: Dec 12, 2024 21:53 +0000
+  ResourceName: AGLT2_CE_2
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 1990403891
+  Description: Finishing emergency upgrade to RHEL9
+  Severity: Outage
+  StartTime: Dec 12, 2024 23:00 +0000
+  EndTime: Dec 13, 2024 23:00 +0000
+  CreatedTime: Dec 12, 2024 21:53 +0000
+  ResourceName: AGLT2_CE_3
+  Services:
+  - CE
+# ---------------------------------------------------------
 
   


### PR DESCRIPTION
Getting back online after recovery of dCache system.
But only gate01 CE is ready at the moment.