### PR TITLE
Create new townsend-ap resource to reflect name change of AP

### DIFF
--- a/topology/University of Wisconsin/CHTC/CHTC.yaml
+++ b/topology/University of Wisconsin/CHTC/CHTC.yaml
@@ -686,17 +686,28 @@ Resources:
         Primary:
           ID: OSG1000015
           Name: Aaron Moate
+        Secondary:
+          ID: OSG1000141
+          Name: Joe Bartkowiak
+        Tertiary:
+          ID: OSG1000003
+          Name: Brian Hua Lin
       Security Contact:
         Primary:
           ID: OSG1000015
-          Name: Aaron Moate
+        Secondary:
+          ID: OSG1000141
+          Name: Joe Bartkowiak
+        Tertiary:
+          ID: OSG1000003
+          Name: Brian Hua Lin
     Description: CHTC Access Point
     FQDN: townsend-ap2000.chtc.wisc.edu
     FQDNAliases:
     - townsend-ap.chtc.wisc.edu
     Services:
       Submit Node:
-        Description: OS Pool access point
+        Description: OSPool access point
         Details:
           hidden: false
     Tags:

--- a/topology/University of Wisconsin/CHTC/CHTC.yaml
+++ b/topology/University of Wisconsin/CHTC/CHTC.yaml
@@ -695,6 +695,7 @@ Resources:
       Security Contact:
         Primary:
           ID: OSG1000015
+          Name: Aaron Moate
         Secondary:
           ID: OSG1000141
           Name: Joe Bartkowiak

--- a/topology/University of Wisconsin/CHTC/CHTC.yaml
+++ b/topology/University of Wisconsin/CHTC/CHTC.yaml
@@ -657,7 +657,7 @@ Resources:
       GLOW: 100
 
   CHTC-townsend-submit:
-    Active: true
+    Active: false
     ContactLists:
       Administrative Contact:
         Primary:
@@ -669,6 +669,31 @@ Resources:
           Name: Aaron Moate
     Description: CHTC Access Point
     FQDN: townsend-submit.chtc.wisc.edu
+    Services:
+      Submit Node:
+        Description: OS Pool access point
+        Details:
+          hidden: false
+    Tags:
+      - OSPool
+    VOOwnership:
+      GLOW: 100
+ 
+  CHTC-townsend-ap:
+    Active: true
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          ID: OSG1000015
+          Name: Aaron Moate
+      Security Contact:
+        Primary:
+          ID: OSG1000015
+          Name: Aaron Moate
+    Description: CHTC Access Point
+    FQDN: townsend-ap2000.chtc.wisc.edu
+    FQDNAliases:
+    - townsend-ap.chtc.wisc.edu
     Services:
       Submit Node:
         Description: OS Pool access point


### PR DESCRIPTION
We renamed townsend-submit to townsend-ap2000; create a new AP entry in topology so that Gratia will work on the device.