### PR TITLE
Create downtime for CHTC_STASHCACHE_ORIGIN_AUTH_2000

### DIFF
--- a/topology/University of Wisconsin/CHTC/CHTC-OSDF_downtime.yaml
+++ b/topology/University of Wisconsin/CHTC/CHTC-OSDF_downtime.yaml
@@ -252,3 +252,14 @@
   Services:
   - Pelican cache
 # ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 1997466342
+  Description: Replaced
+  Severity: Outage
+  StartTime: Dec 23, 2024 00:01 +0000
+  EndTime: Jan 20, 2025 23:45 +0000
+  CreatedTime: Dec 23, 2024 16:00 +0000
+  ResourceName: CHTC_STASHCACHE_ORIGIN_AUTH_2000
+  Services:
+  - XRootD origin server
+# ---------------------------------------------------------


### PR DESCRIPTION
Put CHTC_STASHCACHE_ORIGIN_AUTH_2000 into downtime since we spun up a production pelican origin in tiger to serve it's namespace.