### PR TITLE
(INF-2651) De-activate pre-pelican chtc ceph origin

### DIFF
--- a/topology/University of Wisconsin/CHTC/CHTC-OSDF.yaml
+++ b/topology/University of Wisconsin/CHTC/CHTC-OSDF.yaml
@@ -96,7 +96,7 @@ Resources:
       - ANY
 
   CHTC_STASHCACHE_ORIGIN_2000:
-    Active: true
+    Active: false
     Description: This is a StashCache origin server at UW.
     ID: 1069
     ContactLists:


### PR DESCRIPTION
We've stood up a Pelican origin for /chtc, de-activate the old pre-Pelican origin.