### PR TITLE
Disable CHTC_STASHCACHE_ORIGIN_AUTH_2000

### DIFF
--- a/topology/University of Wisconsin/CHTC/CHTC-OSDF.yaml
+++ b/topology/University of Wisconsin/CHTC/CHTC-OSDF.yaml
@@ -96,7 +96,7 @@ Resources:
       - ANY
 
   CHTC_STASHCACHE_ORIGIN_2000:
-    Active: false
+    Active: true
     Description: This is a StashCache origin server at UW.
     ID: 1069
     ContactLists:
@@ -125,7 +125,7 @@ Resources:
       - ANY
 
   CHTC_STASHCACHE_ORIGIN_AUTH_2000:
-    Active: true
+    Active: false
     Description: This is a StashCache origin server at UW.
     ID: 1192
     ContactLists:


### PR DESCRIPTION
Previous commit accidentally disabled CHTC_STASHCACHE_ORIGIN_2000 instead of CHTC_STASHCACHE_ORIGIN_AUTH_2000.