### PR TITLE
Update WT2_downtime.yaml

### DIFF
--- a/topology/Stanford University/SLAC/WT2_downtime.yaml
+++ b/topology/Stanford University/SLAC/WT2_downtime.yaml
@@ -98,3 +98,25 @@
   Severity: Outage
   StartTime: Mar 16, 2018 07:00 +0000
 # ----------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 2005644571
+  Description: CE is down
+  Severity: Outage
+  StartTime: Dec 30, 2024 14:00 +0000
+  EndTime: Jan 06, 2025 08:00 +0000
+  CreatedTime: Dec 30, 2024 13:14 +0000
+  ResourceName: WT2_CE
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 2005646048
+  Description: CE is down
+  Severity: Outage
+  StartTime: Dec 30, 2024 14:00 +0000
+  EndTime: Jan 06, 2025 08:00 +0000
+  CreatedTime: Dec 30, 2024 13:16 +0000
+  ResourceName: WT2_SE
+  Services:
+  - XRootD component
+# ---------------------------------------------------------


### PR DESCRIPTION
The storage doors and the CE are not accessible for ATLAS. Declaring downtime till the end of holiday period to stop failing transfers.