### PR TITLE
De-activate CHTC PATh pre-Pelican Origin

### DIFF
--- a/topology/University of Wisconsin/CHTC/PATh_facility.yaml
+++ b/topology/University of Wisconsin/CHTC/PATh_facility.yaml
@@ -27,7 +27,7 @@ Resources:
       GLOW: 100
 
   CHTC-PATH-ORIGIN:
-    Active: true
+    Active: false
     ContactLists:
       Administrative Contact:
         Primary:


### PR DESCRIPTION
Since we've stood up CHTC-PATH-PELICAN-ORIGIN to serve /path-facility/projects and /path-facility/data in the Pelican-OSDF, we should be able to de-activate the old pre-Pelican origin in Topology.

