### PR TITLE
Add downtime for DENVER_INTERNET2_OSDF_CACHE due to '"Unable to perfo…

### DIFF
--- a/topology/Internet2/Internet2Denver/I2DenverInfrastructure_downtime.yaml
+++ b/topology/Internet2/Internet2Denver/I2DenverInfrastructure_downtime.yaml
@@ -109,4 +109,16 @@
   Services:
   - Pelican cache
 # ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 2014491756
+  Description: '"Unable to perform accept; too many open files"'
+  Severity: Outage
+  StartTime: Jan 08, 2025 09:00 +0000
+  EndTime: Jan 14, 2025 20:30 +0000
+  CreatedTime: Jan 09, 2025 18:59 +0000
+  ResourceName: DENVER_INTERNET2_OSDF_CACHE
+  Services:
+  - Pelican cache
+# ---------------------------------------------------------
+
 


### PR DESCRIPTION
…rm accept; too many open files"'