### PR TITLE
removing the capitalization of the URL of CMS's new issuer

### DIFF
--- a/virtual-organizations/CMS.yaml
+++ b/virtual-organizations/CMS.yaml
@@ -43,37 +43,37 @@ Credentials:
 
     - Description: CMS IAM development instance
       Subject: bad55f4e-602c-4e8d-a5c5-bd8ffb762113
-      URL: https://CMS-auth.cern.ch/
+      URL: https://cms-auth.cern.ch/
       DefaultUnixUser: cmspilot
 
     - Description: SAM/ETF tests (development)
       Subject: 08ca855e-d715-410e-a6ff-ad77306e1763
-      URL: https://CMS-auth.cern.ch/
+      URL: https://cms-auth.cern.ch/
       DefaultUnixUser: lcgadmin
 
     - Description: CMS ITB pilots (development)
       Subject: 490a9a36-0268-4070-8813-65af031be5a3
-      URL: https://CMS-auth.cern.ch/
+      URL: https://cms-auth.cern.ch/
       DefaultUnixUser: cmspilot
 
     - Description: CMS LOCAL pilots (development)
       Subject: 07f75a9a-bb78-4735-938b-7e61b2b62d5c
-      URL: https://CMS-auth.cern.ch/
+      URL: https://cms-auth.cern.ch/
       DefaultUnixUser: cmslocal
 
     - Description: CMS ITB LOCAL pilots (development)
       Subject: efbed8c1-f9a7-4063-92f7-f89c04ce04a3
-      URL: https://CMS-auth.cern.ch/
+      URL: https://cms-auth.cern.ch/
       DefaultUnixUser: cmslocal
 
     - Description: USCMS LOCAL pilots (development)
       Subject: 99b97e4f-5cf0-4d3b-9fcc-82fa86dca1e8
-      URL: https://CMS-auth.cern.ch/
+      URL: https://cms-auth.cern.ch/
       DefaultUnixUser: uscmslocal
 
     - Description: USCMS HEPCloud pilots (development)
       Subject: 2f327ad0-1934-4635-8ba3-ee72da0a304c
-      URL: https://CMS-auth.cern.ch/
+      URL: https://cms-auth.cern.ch/
       DefaultUnixUser: uscms
 Contacts:
   Administrative Contact:


### PR DESCRIPTION
At UCSD we noticed that the mapping of the new CMS issuer was making our CEs to fail the auth of SAM-dev tests. Removing the capitalization in the URL seemed to fix the issue. e.g.

https://CMS-auth.cern.ch/ => https://cms-auth.cern.ch/

More in here:https://ggus.eu/index.php?mode=ticket_info&ticket_id=169391
 