### PR TITLE
Add new BNL CE

### DIFF
--- a/topology/Brookhaven National Laboratory/BNL-SDCC/BNL-SDCC.yaml
+++ b/topology/Brookhaven National Laboratory/BNL-SDCC/BNL-SDCC.yaml
@@ -132,7 +132,6 @@ Resources:
   BNL-SDCC-CE11:
     Active: true
     Description: This is a compute cluster for SDCC.
-    ID: 
     ContactLists:
       Administrative Contact:
         Primary:

--- a/topology/Brookhaven National Laboratory/BNL-SDCC/BNL-SDCC.yaml
+++ b/topology/Brookhaven National Laboratory/BNL-SDCC/BNL-SDCC.yaml
@@ -150,6 +150,26 @@ Resources:
     Services:
       CE:
         Description: Shared Pool Compute Element
+  BNL-SDCC-SPOOLCE01:
+    Active: true
+    Description: This is a compute cluster for SDCC.
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          ID: b39de31776fc01735eff9678a851c2126a3680be
+          Name: Doug Benjamin
+
+      Security Contact:
+        Primary:
+          ID: OSG1000212
+          Name: Robert Hancock
+        Secondary:
+          ID: b39de31776fc01735eff9678a851c2126a3680be
+          Name: Doug Benjamin
+    FQDN: spoolce01.sdcc.bnl.gov
+    Services:
+      CE:
+        Description: Shared Pool Compute Element
 
   BNL-SUBMIT-01:
     Active: true


### PR DESCRIPTION
Fixes #4455, #4426

I did not remove the old CE as in #4426 as it appears to still be contributing hours according to the [GRACC](https://gracc.opensciencegrid.org/d/000000079/site-summary?orgId=1&var-site=All&var-type=Batch&var-interval=$__auto_interval_interval&var-Filter=ProbeName%7C%3D%7Chtcondor-ce:spce11.sdcc.bnl.gov&from=now-30d&to=now).