### PR TITLE
Add downtime for Stashcache-Kansas due to 'Storage issue: read only - probably SSD/HDD problem'

### DIFF
--- a/topology/Internet2/Internet2GreatPlains/I2GreatPlainsInfrastructure_downtime.yaml
+++ b/topology/Internet2/Internet2GreatPlains/I2GreatPlainsInfrastructure_downtime.yaml
@@ -51,3 +51,15 @@
   Services:
   - Pelican cache
 # ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 2038816539
+  Description: 'Storage issue: read only - probably SSD/HDD problem'
+  Severity: Outage
+  StartTime: Feb 05, 2025 09:00 +0000
+  EndTime: Feb 14, 2025 20:30 +0000
+  CreatedTime: Feb 06, 2025 22:40 +0000
+  ResourceName: Stashcache-Kansas
+  Services:
+  - Pelican cache
+# ---------------------------------------------------------
+


### PR DESCRIPTION
Add downtime for Stashcache-Kansas due to 'Storage issue: read only - probably SSD/HDD problem'