### PR TITLE
Fully remove old ITB origins

### DIFF
--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -44,7 +44,7 @@ TEST_ENDPOINTS = [
     '/rgdowntime/ical',
     "/stashcache/authfile",
     "/stashcache/authfile-public",
-    "/stashcache/origin-authfile-public?fqdn=sc-origin2000.chtc.wisc.edu",
+    "/stashcache/origin-authfile-public?fqdn=sc-origin.chtc.wisc.edu",
     "/stashcache/origin-authfile",
     "/stashcache/scitokens",
     "/oasis-managers/json",

--- a/topology/University of Wisconsin/CHTC/CHTC-OSDF-ITB.yaml
+++ b/topology/University of Wisconsin/CHTC/CHTC-OSDF-ITB.yaml
@@ -7,37 +7,6 @@ Resources:
   # Old, pre-Pelican resources
   #######################################################################
 
-  CHTC-ITB-HELM-ORIGIN:
-    Active: false
-    Description: >-
-        This was a testing OSDF origin server on the Tiger cluster,
-        deployed via Helm. It served both public and protected data.
-    ID: 1370
-    ContactLists:
-      Administrative Contact:
-        Primary:
-          ID: OSG1000002
-          Name: Matyas Selmeci
-        Secondary:
-          ID: OSG1000003
-          Name: Brian Hua Lin
-      Security Contact:
-        Primary:
-          ID: OSG1000002
-          Name: Matyas Selmeci
-        Secondary:
-          ID: OSG1000003
-          Name: Brian Hua Lin
-    FQDN: helm-origin.osgdev.chtc.io
-    DN: /CN=helm-origin.osgdev.chtc.io
-    Services:
-      XRootD origin server:
-        Description: xrootd stash-origin and stash-origin-auth instances
-    VOOwnership:
-      OSG: 100
-    AllowedVOs:
-      - GLOW
-
   CHTC-ITB-HELM-CACHE1:
     Active: false
     Description: >-

--- a/topology/University of Wisconsin/CHTC/CHTC-OSDF.yaml
+++ b/topology/University of Wisconsin/CHTC/CHTC-OSDF.yaml
@@ -69,35 +69,6 @@ Resources:
     AllowedVOs:
       - ANY
 
-  CHTC_STASHCACHE_ORIGIN_2000:
-    Active: false
-    Description: This was a StashCache origin server at UW.
-    ID: 1069
-    ContactLists:
-      Administrative Contact:
-        Primary:
-          ID: OSG1000002
-          Name: Matyas Selmeci
-        Secondary:
-          ID: OSG1000015
-          Name: Aaron Moate
-      Security Contact:
-        Primary:
-          ID: OSG1000002
-          Name: Matyas Selmeci
-        Secondary:
-          ID: OSG1000015
-          Name: Aaron Moate
-    FQDN: sc-origin2000.chtc.wisc.edu
-    DN: /CN=sc-origin2000.chtc.wisc.edu
-    Services:
-      XRootD origin server:
-        Description: StashCache origin server
-    VOOwnership:
-      GLOW: 100
-    AllowedVOs:
-      - ANY
-
   CHTC_STASHCACHE_ORIGIN_AUTH_2000:
     Active: false
     Description: This was a StashCache origin server at UW.

--- a/virtual-organizations/GLOW.yaml
+++ b/virtual-organizations/GLOW.yaml
@@ -86,19 +86,6 @@ DataFederations:
           Issuer: https://chtc.cs.wisc.edu
           MaxScopeDepth: 3
 
-      - Path: /chtc/PROTECTED/sc-origin2000
-        Authorizations:
-          - FQAN: /GLOW
-          - DN: /DC=org/DC=cilogon/C=US/O=University of Wisconsin-Madison/CN=Matyas Selmeci A148276
-          - SciTokens:
-              Issuer: https://chtc.cs.wisc.edu
-              BasePath: /chtc
-              MapSubject: True
-        AllowedOrigins:
-          - CHTC_STASHCACHE_ORIGIN_2000
-        AllowedCaches:
-          - ANY
-
       - Path: /chtc/itb/helm-origin/PROTECTED
         Authorizations:
           - FQAN: /GLOW


### PR DESCRIPTION
Their existence in Topology interferes with monthly metrics gathering