### PR TITLE
Update UFlorida-HPC.yaml

### DIFF
--- a/topology/University of Florida/UF HPC/UFlorida-HPC.yaml
+++ b/topology/University of Florida/UF HPC/UFlorida-HPC.yaml
@@ -21,13 +21,13 @@ Resources:
           Name: Bockjoo Kim
     Description: This is the perfSONAR-ps latency instance at the University of Florida
       CMS T2 site for IPv4 and IPv6
-    FQDN: perfsonar3.rc.ufl.edu
+    FQDN: perfsonar2.rc.ufl.edu
     ID: 1228
     Services:
       net.perfSONAR.Latency:
         Description: PerfSonar Latency monitoring node
         Details:
-          endpoint: perfsonar3.rc.ufl.edu
+          endpoint: perfsonar2.rc.ufl.edu
     VOOwnership:
       CMS: 100
   T2_US_Florida_BW:


### PR DESCRIPTION
It was recommended that the bandwidth and the latency perfsonar be on a different physical NIC.  So, I changed the latency perfsonar from perfsonar3 to perfsonar2.