### PR TITLE
Retire old origins

### DIFF
--- a/topology/University of Wisconsin/CHTC/CHTC-OSDF-ITB.yaml
+++ b/topology/University of Wisconsin/CHTC/CHTC-OSDF-ITB.yaml
@@ -112,7 +112,7 @@ Resources:
   #######################################################################
 
   CHTC-ITB-OSDF-PELICAN-ORIGIN:
-    Active: true
+    Active: false
     Description: >-
       This is an origin used for testing the Pelican client and
       integration with the OSDF

--- a/virtual-organizations/GLOW.yaml
+++ b/virtual-organizations/GLOW.yaml
@@ -48,25 +48,3 @@ ReportingGroups:
 - glow
 SupportURL: https://chtc.cs.wisc.edu
 
-DataFederations:
-  StashCache:
-    Namespaces:
-      - Path: /chtc/itb/osdf-pelican
-        Authorizations:
-          - SciTokens:
-              Issuer: https://chtc.cs.wisc.edu
-              Base Path: /chtc
-              Map Subject: True
-        AllowedOrigins:
-          - CHTC-ITB-OSDF-PELICAN-ORIGIN
-        AllowedCaches:
-          - ANY
-
-      - Path: /data.lhncbc.nlm.nih.gov/public
-        Authorizations:
-          - PUBLIC
-        AllowedOrigins:
-          - CHTC_NIH_ORIGIN
-        AllowedCaches:
-          - ANY
-


### PR DESCRIPTION
1. We decided that we had enough other ITB origins to retire
   CHTC-ITB-OSDF-PELICAN-ORIGIN
1. We got the thumbs up from Justin to remove the NIH one. It was
   already `Active: false`