### PR TITLE
UCOPS-128: prepare AP22 for Pelican transition

### DIFF
--- a/virtual-organizations/OSG.yaml
+++ b/virtual-organizations/OSG.yaml
@@ -180,7 +180,7 @@ DataFederations:
         Authorizations:
           - SciTokens:
               Issuer: https://ap22.uc.osg-htc.org:1094/ospool/ap22
-              Base Path: /ospool/ap22,/ospool/uc-shared/project
+              Base Path: /ospool/ap22
               Map Subject: True
         AllowedOrigins:
           - UChicago_OSGConnect_ap22
@@ -254,10 +254,6 @@ DataFederations:
           - SciTokens:
               Issuer: https://ap21.uc.osg-htc.org:1094/ospool/ap21
               Base Path: /ospool/ap21,/ospool/uc-shared/project
-              Map Subject: True
-          - SciTokens:
-              Issuer: https://ap22.uc.osg-htc.org:1094/ospool/ap22
-              Base Path: /ospool/ap22,/ospool/uc-shared/project
               Map Subject: True
         AllowedOrigins:
           - UChicago_OSGConnect_ap23


### PR DESCRIPTION
1. Pelican clients seem to have issues selecting the appropriate token
   when an origin reports an issuer with a comma-delimited BasePath
2. The projects Pelican origin doesn't pull in Topology scitokens
   config so the second hunk doesn't actually do anything