### PR TITLE
UCOPS-128: stage UC Pelican issuers across the non-Pelican inf

### DIFF
--- a/virtual-organizations/OSG.yaml
+++ b/virtual-organizations/OSG.yaml
@@ -148,6 +148,10 @@ DataFederations:
               Issuer: https://ap20.uc.osg-htc.org:1094/ospool/ap20
               Base Path: /ospool/ap20,/ospool/uc-shared/project
               Map Subject: True
+          - SciTokens:
+              Issuer: https://ap20.uc.osg-htc.org:8444
+              Base Path: /ospool/ap20
+              Map Subject: True
         AllowedOrigins:
           - UChicago_OSGConnect_ap20
         AllowedCaches:
@@ -164,6 +168,10 @@ DataFederations:
           - SciTokens:
               Issuer: https://ap21.uc.osg-htc.org:1094/ospool/ap21
               Base Path: /ospool/ap21,/ospool/uc-shared/project
+              Map Subject: True
+          - SciTokens:
+              Issuer: https://ap21.uc.osg-htc.org:8444
+              Base Path: /ospool/ap21
               Map Subject: True
         AllowedOrigins:
           - UChicago_OSGConnect_ap21


### PR DESCRIPTION
I'd like to have the non-Pelican OSDF infrastructure accepting the new Pelican origin issuers by the time that the UC team is ready to proceed with the transition.