### PR TITLE
Add osgsquid Squid server for OSG jobs

### DIFF
--- a/topology/University of Wisconsin/GLOW/GLOW.yaml
+++ b/topology/University of Wisconsin/GLOW/GLOW.yaml
@@ -204,7 +204,6 @@ Resources:
           Name: Carl Vuosalo
     Description: OSG Squid Servers RR alias
     FQDN: osgsquid.hep.wisc.edu
-    ID: 1399
     Services:
       Squid:
         Description: Generic squid service

--- a/topology/University of Wisconsin/GLOW/GLOW.yaml
+++ b/topology/University of Wisconsin/GLOW/GLOW.yaml
@@ -191,6 +191,25 @@ Resources:
         Description: Generic squid service
     VOOwnership:
       CMS: 100
+  OSG_SQUID:
+    Active: true
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          ID: 9c02556106ce823874deef0c51d069711191f98e
+          Name: Carl Vuosalo
+      Security Contact:
+        Primary:
+          ID: 9c02556106ce823874deef0c51d069711191f98e
+          Name: Carl Vuosalo
+    Description: OSG Squid Servers RR alias
+    FQDN: osgsquid.hep.wisc.edu
+    ID: 679
+    Services:
+      Squid:
+        Description: Generic squid service
+    VOOwnership:
+      CMS: 100
   GLOW_SQUID1:
     Active: true
     ContactLists:

--- a/topology/University of Wisconsin/GLOW/GLOW.yaml
+++ b/topology/University of Wisconsin/GLOW/GLOW.yaml
@@ -204,7 +204,7 @@ Resources:
           Name: Carl Vuosalo
     Description: OSG Squid Servers RR alias
     FQDN: osgsquid.hep.wisc.edu
-    ID: 679
+    ID: 1399
     Services:
       Squid:
         Description: Generic squid service

--- a/topology/University of Wisconsin/GLOW/GLOW.yaml
+++ b/topology/University of Wisconsin/GLOW/GLOW.yaml
@@ -191,7 +191,7 @@ Resources:
         Description: Generic squid service
     VOOwnership:
       CMS: 100
-  OSG_SQUID:
+  GLOW_OSG_SQUID:
     Active: true
     ContactLists:
       Administrative Contact:


### PR DESCRIPTION
osggrid01.hep.wisc.edu runs jobs submitted to OSG. osgsquid is being added for the Squid servers in round-robin that serve those jobs. These Squid servers have existed for a long time but have not been registered in the topology until now.