### PR TITLE
Update public gwdata LIGO origin to be marked as Pelican

### DIFF
--- a/topology/California Institute of Technology/Caltech LIGO/CIT_LIGO.yaml
+++ b/topology/California Institute of Technology/Caltech LIGO/CIT_LIGO.yaml
@@ -15,8 +15,8 @@ Resources:
     FQDN: origin.ligo.caltech.edu
     ID: 948
     Services:
-      XRootD origin server:
-        Description: StashCache Origin server
+      Pelican origin:
+        Description: OSDF Pelican Origin
     AllowedVOs:
       - LIGO
   CIT_LIGO_ORIGIN_IFO:


### PR DESCRIPTION
Per Josh Willis, this host has been cut over to Pelican to attempt to fix the access to public `/gwdata` namespace.