### PR TITLE
Disable non-functioning origins for `/gwdata`

### DIFF
--- a/virtual-organizations/LIGO.yaml
+++ b/virtual-organizations/LIGO.yaml
@@ -279,8 +279,8 @@ DataFederations:
           - PUBLIC
         AllowedOrigins:
           - CIT_LIGO_ORIGIN
-          - LIGO-StashCache-Origin
-          - UCL-Virgo-StashCache-Origin
+          #- LIGO-StashCache-Origin
+          #- UCL-Virgo-StashCache-Origin
         AllowedCaches:
           - ANY
         DirList: https://origin.ligo.caltech.edu:1094


### PR DESCRIPTION
The `/gwdata` namespace is currently only functioning on `CIT_LIGO_ORIGIN`; momentarily comment out the other two origins until we are able to diagnose the problems with them (esp. as they are non-Pelican).

(Purposely commenting out so this change instead of removing the lines so this is clearly visible.)