### PR TITLE
Add back Writeback and DirList to the /igwn/test-write namespace

### DIFF
--- a/virtual-organizations/LIGO.yaml
+++ b/virtual-organizations/LIGO.yaml
@@ -272,6 +272,8 @@ DataFederations:
         AllowedOrigins:
           - CIT_LIGO_ORIGIN_TEST_WRITE
         AllowedCaches: *ligo-allowed-caches
+        Writeback: https://origin-writetest.ligo.caltech.edu:8443
+        DirList: https://origin-writetest.ligo.caltech.edu:8443
       - Path: /gwdata
         Authorizations:
           - PUBLIC


### PR DESCRIPTION
Looks like the director uses these to mark the namespace as supporting Write and Listing, respectively.

This reverts commit edf19a8f87a1c6d73df54be0a497b38ea65bc862.