### PR TITLE
Migrate origin-readtest.ligo.caltech.edu (CIT_LIGO_ORIGIN_TEST) to Pelican (FD #79132)

### DIFF
--- a/topology/California Institute of Technology/Caltech LIGO/CIT_LIGO.yaml
+++ b/topology/California Institute of Technology/Caltech LIGO/CIT_LIGO.yaml
@@ -79,25 +79,35 @@ Resources:
         Description: StashCache Origin server
     AllowedVOs:
       - LIGO
+
   CIT_LIGO_ORIGIN_TEST:
     Active: true
     Description: This serves proprietary LIGO interferometer data in a test configuration
     ContactLists:
       Administrative Contact:
         Primary:
+          Name: Joshua Willis
+          ID: OSG1000316
+        Secondary:
           Name: Stuart Anderson
           ID: c50e7cc9d0086272ef995fb76461612d40c70435
       Security Contact:
-        Primary:
+        # Primary:
+        #   Name: Randy Trudeau
+        #   ID: <not registered>
+        # Secondary:
+        #   Name: Warren Anderson
+        #   ID: <not registered>
+        Tertiary:
           Name: Stuart Anderson
           ID: c50e7cc9d0086272ef995fb76461612d40c70435
     FQDN: origin-readtest.ligo.caltech.edu
-    DN: /DC=org/DC=incommon/C=US/ST=California/O=California Institute of Technology/CN=origin-readtest.ligo.caltech.edu
     Services:
-      XRootD origin server:
-        Description: StashCache Origin server
+      Pelican origin:
+        Description: Pelican origin
     AllowedVOs:
       - LIGO
+
   CIT_LIGO_ORIGIN_TEST_WRITE:
     Active: true
     Description: This serves proprietary user data staged to and from the CIT cluster in a test configuration
@@ -125,6 +135,7 @@ Resources:
         Description: Pelican origin
     AllowedVOs:
       - LIGO
+
   CIT_LIGO_SQUID:
     ContactLists:
       Administrative Contact:

--- a/virtual-organizations/LIGO.yaml
+++ b/virtual-organizations/LIGO.yaml
@@ -234,6 +234,7 @@ DataFederations:
         AllowedCaches: *ligo-allowed-caches
         Writeback: https://origin-staging.ligo.caltech.edu:1095
         DirList: https://origin-staging.ligo.caltech.edu:1095
+
       - Path: /igwn/test
         Authorizations:
           - DN: /DC=org/DC=incommon/C=US/ST=Nebraska/O=University of Nebraska-Lincoln/CN=hcc-cvmfs-repo.unl.edu
@@ -253,7 +254,7 @@ DataFederations:
         AllowedOrigins:
           - CIT_LIGO_ORIGIN_TEST
         AllowedCaches: *ligo-allowed-caches
-        DirList: https://origin-readtest.ligo.caltech.edu:1095
+
       - Path: /igwn/test-write
         Authorizations:
           - FQAN: /osg/ligo


### PR DESCRIPTION
Similar to CIT_LIGO_ORIGIN_TEST_WRITE; see  https://support.opensciencegrid.org/a/tickets/79132