### PR TITLE
UCOPS-132: Fix UC projects issuer

### DIFF
--- a/virtual-organizations/OSG.yaml
+++ b/virtual-organizations/OSG.yaml
@@ -256,7 +256,7 @@ DataFederations:
       - Path: /ospool/uc-shared/project
         Authorizations:
           - SciTokens:
-              Issuer: https://pelican-osdf-project.tempest.uchicago.edu:8444
+              Issuer: https://pelican-osdf-project.tempest.uchicago.edu
               Base Path: /ospool/uc-shared/project
               Map Subject: True
           - SciTokens:


### PR DESCRIPTION
Our pelican bases in k8s set the WebPort to 443