### PR TITLE
Add downtime for LIGO-StashCache-Origin due to power outages

### DIFF
--- a/topology/University of Nebraska/Nebraska-Lincoln/UNLCachingInfrastructure_downtime.yaml
+++ b/topology/University of Nebraska/Nebraska-Lincoln/UNLCachingInfrastructure_downtime.yaml
@@ -75,4 +75,48 @@
   Services:
   - Pelican cache
 # ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 2078399055
+  Description: City wide power outages caused by strong storms
+  Severity: Outage
+  StartTime: Mar 19, 2025 11:00 +0000
+  EndTime: Mar 20, 2025 22:00 +0000
+  CreatedTime: Mar 24, 2025 18:11 +0000
+  ResourceName: HCC-Origin
+  Services:
+  - XRootD origin server
+# ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 2078399056
+  Description: City wide power outages caused by strong storms
+  Severity: Outage
+  StartTime: Mar 19, 2025 11:00 +0000
+  EndTime: Mar 20, 2025 22:00 +0000
+  CreatedTime: Mar 24, 2025 18:11 +0000
+  ResourceName: HCC-StashCache-Origin
+  Services:
+  - XRootD origin server
+# ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 2078399057
+  Description: City wide power outages caused by strong storms
+  Severity: Outage
+  StartTime: Mar 19, 2025 11:00 +0000
+  EndTime: Mar 20, 2025 22:00 +0000
+  CreatedTime: Mar 24, 2025 18:11 +0000
+  ResourceName: LIGO-StashCache-Origin
+  Services:
+  - XRootD origin server
+# ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 2078399058
+  Description: City wide power outages caused by strong storms
+  Severity: Outage
+  StartTime: Mar 19, 2025 11:00 +0000
+  EndTime: Mar 20, 2025 22:00 +0000
+  CreatedTime: Mar 24, 2025 18:11 +0000
+  ResourceName: NEBRASKA_NRP_OSDF_CACHE
+  Services:
+  - Pelican cache
+# ---------------------------------------------------------
 


### PR DESCRIPTION
Additional downtime entry which covers xrootd-local.unl.edu which is not under Nebraska-CMS and thus was missed previously.