### PR TITLE
Remove unnecessary OSDF namespace/issuer registrations

### DIFF
--- a/virtual-organizations/OSG.yaml
+++ b/virtual-organizations/OSG.yaml
@@ -205,23 +205,6 @@ DataFederations:
           Issuer: https://osg-htc.org/ospool
           MaxScopeDepth: 4
 
-      - Path: /ospool/ap40/data
-        Authorizations:
-          - SciTokens:
-              Issuer: https://osg-htc.org/ospool
-              Base Path: /ospool/ap40/data
-              Map Subject: True
-        AllowedOrigins:
-          - CHTC-ap40
-        AllowedCaches:
-          - ANY
-        Writeback: https://ospool-ap2140.chtc.wisc.edu:8443
-        DirList: https://ospool-ap2140.chtc.wisc.edu:8443
-        CredentialGeneration:
-          Strategy: OAuth2
-          Issuer: https://ospool-ap2140.chtc.wisc.edu:8443
-          MaxScopeDepth: 4
-
       ### These scitokens issuers are intentionally unregistered: the xrootd
       ### service serving them does not pull config from Topology, and the
       ### data is not meant to be cached.
@@ -252,18 +235,3 @@ DataFederations:
       #     - UChicago_OSGConnect_ap22
       #   # Do not cache this: direct access only
       #   AllowedCaches: []
-
-      - Path: /ospool/uc-shared/project
-        Authorizations:
-          - SciTokens:
-              Issuer: https://pelican-osdf-project.tempest.uchicago.edu
-              Base Path: /ospool/uc-shared/project
-              Map Subject: True
-        AllowedOrigins:
-          - UChicago_OSGConnect_Pelican_Project_Origin
-        AllowedCaches:
-          - ANY
-        CredentialGeneration:
-          Strategy: OAuth2
-          Issuer: https://osg-htc.org/ospool/uc-shared
-          MaxScopeDepth: 4


### PR DESCRIPTION
These are just served from origins now. No sense in having potential
points of confusion laying around from stale config