### PR TITLE
Hypatia full downtime

### DIFF
--- a/topology/Albert Einstein Institute/Albert Einstein Institute/AEI-Hypatia_downtime.yaml
+++ b/topology/Albert Einstein Institute/Albert Einstein Institute/AEI-Hypatia_downtime.yaml
@@ -1,0 +1,11 @@
+- Class: SCHEDULED
+  ID: 2085175619
+  Description: Hypatia OS upgrades and filesystem migrations
+  Severity: Outage
+  StartTime: Apr 08, 2025 08:00 +0000
+  EndTime: Apr 17, 2025 15:00 +0000
+  CreatedTime: Apr 01, 2025 14:26 +0000
+  ResourceName: AEI-Hypatia-CE1
+  Services:
+  - CE
+# ---------------------------------------------------------


### PR DESCRIPTION
We're going to upgrade all of Hypatia, including OS and HTCondor upgrades and filesystem migrations. The work is about to start on Apr 8, 2025 and to finish before Easter. EndTime will be adjusted when the work is finished.