### PR TITLE
Add VOOwnership attributes to RTU-CMS and SU-ITS CEs so they show up in GGUS

### DIFF
--- a/topology/Riga Technical University/RTU-CMS/RTU.yaml
+++ b/topology/Riga Technical University/RTU-CMS/RTU.yaml
@@ -155,9 +155,8 @@ Resources:
     ### VOOwnership (optional) is the percentage of the resource owned by one or more VOs.
     ### If part of the resource is not owned by the VO, do not list it.
     ### The total percentage cannot exceed 100.
-    # VOOwnership:
-    #   <VO1>: <PERCENT>
-    #   <VO2>: <PERCENT>
+    VOOwnership:
+      CMS: 100
 
     ### WLCGInformation (optional) is only for resources that are part of the WLCG
     # WLCGInformation:

--- a/topology/Syracuse University/SU ITS/SU-ITS.yaml
+++ b/topology/Syracuse University/SU ITS/SU-ITS.yaml
@@ -29,6 +29,8 @@ Resources:
           hidden: false
     Tags:
       - CC*
+    VOOwnership:
+      CMS: 0
   SU-ITS-CE3:
     Active: true
     ContactLists:
@@ -56,6 +58,8 @@ Resources:
           hidden: false
     Tags:
       - CC*
+    VOOwnership:
+      CMS: 0
   SU-ITS-CE4:
     Active: true
     ContactLists:
@@ -83,6 +87,8 @@ Resources:
           hidden: false
     Tags:
       - CC*
+    VOOwnership:
+      CMS: 0
   SU-ITS-AD-CE4:
     Active: true
     ContactLists:
@@ -110,6 +116,8 @@ Resources:
           hidden: false
     Tags:
       - CC*
+    VOOwnership:
+      CMS: 0
   SU-OG-squid1:
     Active: true
     ContactLists:


### PR DESCRIPTION
[FD #79576](https://support.opensciencegrid.org/a/tickets/79576)

RTU-CMS is wholly owned by CMS; CMS runs opportunistically on SU-ITS.