### PR TITLE
Properly categorize projects with "Other" FieldOfScience

### DIFF
--- a/projects/KnowledgeLab.yaml
+++ b/projects/KnowledgeLab.yaml
@@ -1,6 +1,6 @@
 Department: Computation Institute
 Description: Knowledge Lab / CI
-FieldOfScience: Other
+FieldOfScience: Multidisciplinary
 ID: '65'
 Organization: University of Chicago
 PIName: James Evans
@@ -8,4 +8,4 @@ Sponsor:
   CampusGrid:
     Name: OSG Connect
 InstitutionID: 'https://osg-htc.org/iid/o14joi278jrs'
-FieldOfScienceID: 'nan'
+FieldOfScienceID: '30'

--- a/projects/NCSU_Staff.yaml
+++ b/projects/NCSU_Staff.yaml
@@ -2,8 +2,8 @@ Description: >
   Continue my access to the OSPool after the OSG School to further 
   support potential users and workflows for NC State University
 Department: Research Facilitation Service
-FieldOfScience: Other
+FieldOfScience: Research Computing
 Organization: North Carolina State University
 PIName: Christopher Blanton
 InstitutionID: 'https://osg-htc.org/iid/mcejqenugk6j'
-FieldOfScienceID: 'nan'
+FieldOfScienceID: '11.07'

--- a/projects/TG-STA110011S.yaml
+++ b/projects/TG-STA110011S.yaml
@@ -1,6 +1,6 @@
 Department: NICS
 Description: renewing project
-FieldOfScience: Other
+FieldOfScience: Computer Science
 ID: '113'
 Organization: University of Tennessee, Knoxville
 PIName: Stephen McNally

--- a/projects/TG-TRA120004.yaml
+++ b/projects/TG-TRA120004.yaml
@@ -1,7 +1,7 @@
 Department: Columbia University Information Techonology
 Description: This allocation will be used to help researchers at Columbia University
   understand how to use XSEDE resources.
-FieldOfScience: Other
+FieldOfScience: Computer Science
 ID: '392'
 Organization: Columbia University
 PIName: Rob Lane

--- a/projects/TG-TRA130011.yaml
+++ b/projects/TG-TRA130011.yaml
@@ -4,7 +4,7 @@ Description: This allocation will be used to support the use of high performance
   and students at IUP to gain experience and start using XSEDE resources to further
   their education and research objectives.  This is the Campus Champion allocation
   request for IUP.
-FieldOfScience: Other
+FieldOfScience: Computer Science
 ID: '160'
 Organization: Indiana University of Pennsylvania
 PIName: John Chrispell
@@ -12,4 +12,4 @@ Sponsor:
   CampusGrid:
     Name: OSG-XSEDE
 InstitutionID: 'https://osg-htc.org/iid/ekm8sdum58z7'
-FieldOfScienceID: 'nan'
+FieldOfScienceID: '30.3001'

--- a/projects/TG-TRA140029.yaml
+++ b/projects/TG-TRA140029.yaml
@@ -2,7 +2,7 @@ Department: Center for Research Computing
 Description: The immediate purpose of this request is to have small allocations available
   for showcasing and quick access to a variety of XSEDE resources.  Long term goals
   are to encourage and assist campus users in applying for their own allocations.
-FieldOfScience: Other
+FieldOfScience: Computer Science
 ID: '332'
 Organization: University of Notre Dame
 PIName: Scott Hampton
@@ -10,4 +10,4 @@ Sponsor:
   CampusGrid:
     Name: OSG-XSEDE
 InstitutionID: 'https://osg-htc.org/iid/mavkovkq2s0l'
-FieldOfScienceID: 'nan'
+FieldOfScienceID: '30.3001'

--- a/projects/TG-TRA150018.yaml
+++ b/projects/TG-TRA150018.yaml
@@ -1,7 +1,7 @@
 Department: Information Services
 Description: A request for initial campus champion resources for Oregon State University
   researchers.
-FieldOfScience: Other
+FieldOfScience: Computer Science
 ID: '303'
 Organization: Oregon State University
 PIName: Stephen Wolbers
@@ -9,4 +9,4 @@ Sponsor:
   CampusGrid:
     Name: OSG-XSEDE
 InstitutionID: 'https://osg-htc.org/iid/h0s7lk6vj9dn'
-FieldOfScienceID: 'nan'
+FieldOfScienceID: '30.3001'

--- a/projects/UCSD_ResearchIT.yaml
+++ b/projects/UCSD_ResearchIT.yaml
@@ -1,6 +1,6 @@
 Description: General group for OSG testing and prototyping 
 Department: Information Technology
-FieldOfScience: Other
+FieldOfScience: Computer Science
 Organization: University of California, San Diego
 PIName: Alan Moxley
 


### PR DESCRIPTION
To prevent projects from showing up as "Other" for Field of Science in the project dashboard website. 
This attribute is being deprecated in favor of FieldOfScienceID, but management wants "Other" cleaned up before then.