### PR TITLE
Add downtime for Stashcache-Chicago for hardware replacement

### DIFF
--- a/topology/Internet2/Internet2Chicago/I2ChicagoInfrastructure_downtime.yaml
+++ b/topology/Internet2/Internet2Chicago/I2ChicagoInfrastructure_downtime.yaml
@@ -75,5 +75,15 @@
   Services:
   - Pelican cache
 # ---------------------------------------------------------
-
+- Class: SCHEDULED
+  ID: 2108510028
+  Description: System to be replaced with new hardware
+  Severity: Outage
+  StartTime: Apr 29, 2025 15:00 +0000
+  EndTime: May 31, 2025 05:00 +0000
+  CreatedTime: Apr 28, 2025 14:36 +0000
+  ResourceName: Stashcache-Chicago
+  Services:
+  - Pelican cache
+# ---------------------------------------------------------
 


### PR DESCRIPTION
osg-chicago-stashcache.nrp.internet2.edu will be replaced with osdf1.chic.smn.net.internet2.edu