### PR TITLE
Add downtime for UWEC-BOSE for scheduled maintenance

### DIFF
--- a/topology/University of Wisconsin–Eau Claire/UW-Eau Claire LTS/UWEC-BOSE_downtime.yaml
+++ b/topology/University of Wisconsin–Eau Claire/UW-Eau Claire LTS/UWEC-BOSE_downtime.yaml
@@ -9,4 +9,14 @@
   Services:
   - CE
 # ---------------------------------------------------------
-
+- Class: SCHEDULED
+  ID: 2120621349
+  Description: Scheduled cluster maintenance from May 21st-May 23rd
+  Severity: Outage
+  StartTime: May 21, 2025 13:00 +0000
+  EndTime: May 23, 2025 22:00 +0000
+  CreatedTime: May 12, 2025 15:02 +0000
+  ResourceName: UWEC-BOSE-CE1
+  Services:
+  - CE
+# ---------------------------------------------------------


### PR DESCRIPTION
Add downtime for UW-Eau Claire's BOSE cluster due to scheduled maintenance from May 21st through May 23rd.