### PR TITLE
Put ESNet caches in downtime for OS and Pelican upgrades

### DIFF
--- a/topology/Energy Sciences Network/Amsterdam/EsnetAmsterdam_downtime.yaml
+++ b/topology/Energy Sciences Network/Amsterdam/EsnetAmsterdam_downtime.yaml
@@ -31,3 +31,14 @@
   Services:
   - Pelican cache
 # ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 2123177693
+  Description: OS and Pelican upgrade
+  Severity: Outage
+  StartTime: May 15, 2025 15:00 +0000
+  EndTime: May 16, 2025 00:00 +0000
+  CreatedTime: May 15, 2025 14:02 +0000
+  ResourceName: AMSTERDAM_ESNET_OSDF_CACHE
+  Services:
+  - Pelican cache
+# ---------------------------------------------------------

--- a/topology/Energy Sciences Network/London/ESnetLondon_downtime.yaml
+++ b/topology/Energy Sciences Network/London/ESnetLondon_downtime.yaml
@@ -9,3 +9,14 @@
   Services:
   - Pelican cache
 # ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 2123177856
+  Description: OS and Pelican upgrade
+  Severity: Outage
+  StartTime: May 15, 2025 15:00 +0000
+  EndTime: May 16, 2025 00:00 +0000
+  CreatedTime: May 15, 2025 14:03 +0000
+  ResourceName: LONDON_ESNET_OSDF_CACHE
+  Services:
+  - Pelican cache
+# ---------------------------------------------------------


### PR DESCRIPTION
Info given by Justas over Slack