### PR TITLE
Retire ComputeCanada cache

### DIFF
--- a/topology/Compute Canada/ComputeCanada - Cedar/ComputeCanada-Cedar.yaml
+++ b/topology/Compute Canada/ComputeCanada - Cedar/ComputeCanada-Cedar.yaml
@@ -33,7 +33,7 @@ Resources:
         Details:
           hidden: false
   ComputeCanada-Cedar-Cache:
-    Active: true
+    Active: false
     Description: Compute Canada Cedar Cluster at SFU - StashCache XRootD cache server
     ID: 1407
     ContactLists:


### PR DESCRIPTION
The current node, installed in 2016, is very old and unstable. We need to retire it.