### PR TITLE
Add downtime for BNL-ATLAS due to dCache maintenance

### DIFF
--- a/topology/Brookhaven National Laboratory/BNL ATLAS Tier1/BNL-ATLAS_downtime.yaml
+++ b/topology/Brookhaven National Laboratory/BNL ATLAS Tier1/BNL-ATLAS_downtime.yaml
@@ -1944,4 +1944,224 @@
   Services:
   - WebDAV
 # ---------------------------------------------------------
-
+- Class: SCHEDULED
+  ID: 2142278750
+  Description: ' dCache maintenance'
+  Severity: Outage
+  StartTime: Jun 24, 2025 13:00 +0000
+  EndTime: Jun 24, 2025 19:00 +0000
+  CreatedTime: Jun 06, 2025 16:37 +0000
+  ResourceName: BNL_ATLAS_01
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2142278751
+  Description: ' dCache maintenance'
+  Severity: Outage
+  StartTime: Jun 24, 2025 13:00 +0000
+  EndTime: Jun 24, 2025 19:00 +0000
+  CreatedTime: Jun 06, 2025 16:37 +0000
+  ResourceName: BNL_ATLAS_02
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2142278752
+  Description: ' dCache maintenance'
+  Severity: Outage
+  StartTime: Jun 24, 2025 13:00 +0000
+  EndTime: Jun 24, 2025 19:00 +0000
+  CreatedTime: Jun 06, 2025 16:37 +0000
+  ResourceName: BNL_ATLAS_03
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2142278753
+  Description: ' dCache maintenance'
+  Severity: Outage
+  StartTime: Jun 24, 2025 13:00 +0000
+  EndTime: Jun 24, 2025 19:00 +0000
+  CreatedTime: Jun 06, 2025 16:37 +0000
+  ResourceName: BNL_ATLAS_04
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2142278754
+  Description: ' dCache maintenance'
+  Severity: Outage
+  StartTime: Jun 24, 2025 13:00 +0000
+  EndTime: Jun 24, 2025 19:00 +0000
+  CreatedTime: Jun 06, 2025 16:37 +0000
+  ResourceName: BNL_ATLAS_06
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2142278755
+  Description: ' dCache maintenance'
+  Severity: Outage
+  StartTime: Jun 24, 2025 13:00 +0000
+  EndTime: Jun 24, 2025 19:00 +0000
+  CreatedTime: Jun 06, 2025 16:37 +0000
+  ResourceName: BNL_ATLAS_07
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2142278756
+  Description: ' dCache maintenance'
+  Severity: Outage
+  StartTime: Jun 24, 2025 13:00 +0000
+  EndTime: Jun 24, 2025 19:00 +0000
+  CreatedTime: Jun 06, 2025 16:37 +0000
+  ResourceName: BNL_ATLAS_08
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2142278757
+  Description: ' dCache maintenance'
+  Severity: Outage
+  StartTime: Jun 24, 2025 13:00 +0000
+  EndTime: Jun 24, 2025 19:00 +0000
+  CreatedTime: Jun 06, 2025 16:37 +0000
+  ResourceName: BNL_ATLAS_1
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2142278758
+  Description: ' dCache maintenance'
+  Severity: Outage
+  StartTime: Jun 24, 2025 13:00 +0000
+  EndTime: Jun 24, 2025 19:00 +0000
+  CreatedTime: Jun 06, 2025 16:37 +0000
+  ResourceName: BNL_ATLAS_2
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2142278759
+  Description: ' dCache maintenance'
+  Severity: Outage
+  StartTime: Jun 24, 2025 13:00 +0000
+  EndTime: Jun 24, 2025 19:00 +0000
+  CreatedTime: Jun 06, 2025 16:37 +0000
+  ResourceName: BNL_ATLAS_3
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2142278760
+  Description: ' dCache maintenance'
+  Severity: Outage
+  StartTime: Jun 24, 2025 13:00 +0000
+  EndTime: Jun 24, 2025 19:00 +0000
+  CreatedTime: Jun 06, 2025 16:37 +0000
+  ResourceName: BNL_ATLAS_4
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2142278761
+  Description: ' dCache maintenance'
+  Severity: Outage
+  StartTime: Jun 24, 2025 13:00 +0000
+  EndTime: Jun 24, 2025 19:00 +0000
+  CreatedTime: Jun 06, 2025 16:37 +0000
+  ResourceName: BNL_ATLAS_6
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2142278762
+  Description: ' dCache maintenance'
+  Severity: Outage
+  StartTime: Jun 24, 2025 13:00 +0000
+  EndTime: Jun 24, 2025 19:00 +0000
+  CreatedTime: Jun 06, 2025 16:37 +0000
+  ResourceName: BNL_ATLAS_7
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2142278763
+  Description: ' dCache maintenance'
+  Severity: Outage
+  StartTime: Jun 24, 2025 13:00 +0000
+  EndTime: Jun 24, 2025 19:00 +0000
+  CreatedTime: Jun 06, 2025 16:37 +0000
+  ResourceName: BNL_ATLAS_8
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2142278766
+  Description: ' dCache maintenance'
+  Severity: Outage
+  StartTime: Jun 24, 2025 13:00 +0000
+  EndTime: Jun 24, 2025 19:00 +0000
+  CreatedTime: Jun 06, 2025 16:37 +0000
+  ResourceName: BNL_ATLAS_SE
+  Services:
+  - SRMv2.disk
+  - SRMv2.tape
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2142278767
+  Description: ' dCache maintenance'
+  Severity: Outage
+  StartTime: Jun 24, 2025 13:00 +0000
+  EndTime: Jun 24, 2025 19:00 +0000
+  CreatedTime: Jun 06, 2025 16:37 +0000
+  ResourceName: BNL_ATLAS_SE_AWS_East
+  Services:
+  - SRMv2
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2142278768
+  Description: ' dCache maintenance'
+  Severity: Outage
+  StartTime: Jun 24, 2025 13:00 +0000
+  EndTime: Jun 24, 2025 19:00 +0000
+  CreatedTime: Jun 06, 2025 16:37 +0000
+  ResourceName: BNL_ATLAS_SE_AWS_West
+  Services:
+  - SRMv2
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2142278769
+  Description: ' dCache maintenance'
+  Severity: Outage
+  StartTime: Jun 24, 2025 13:00 +0000
+  EndTime: Jun 24, 2025 19:00 +0000
+  CreatedTime: Jun 06, 2025 16:37 +0000
+  ResourceName: BNL_ATLAS_SE_AWS_West2
+  Services:
+  - SRMv2
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2142278770
+  Description: ' dCache maintenance'
+  Severity: Outage
+  StartTime: Jun 24, 2025 13:00 +0000
+  EndTime: Jun 24, 2025 19:00 +0000
+  CreatedTime: Jun 06, 2025 16:37 +0000
+  ResourceName: BNL_ATLAS_SE_GRIDFTP
+  Services:
+  - WebDAV
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2142278771
+  Description: ' dCache maintenance'
+  Severity: Outage
+  StartTime: Jun 24, 2025 13:00 +0000
+  EndTime: Jun 24, 2025 19:00 +0000
+  CreatedTime: Jun 06, 2025 16:37 +0000
+  ResourceName: BNL_ATLAS_TAPE
+  Services:
+  - WebDAV.tape
+# ---------------------------------------------------------


### PR DESCRIPTION
We are planning to perform maintenance on the US ATLAS dCache instance. This will involve work on the hardware supporting the core database systems, as well as a database upgrade, and will require the system to be stopped during the intervention.
 
In addition, we will take the opportunity to migrate residual dCache components currently hosted in RHEV, and to update the dCache minor version as needed. This also provides a chance to enable monitoring data collectors that require a dCache cell restart.