### PR TITLE
Versionlock osg-ca-certs to keep the CILogon CA

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,11 @@ RUN \
       httpd-devel \
       mod_ssl \
       gridsite \
-      osg-ca-certs \
       /usr/bin/pkill \
+      # XXX remove the versionlock once we no longer use CILogon certs \
+      'osg-ca-certs-1.135' \
+      'dnf-command(versionlock)' \
+    && yum versionlock osg-ca-certs \
     && yum clean all && rm -rf /var/cache/yum/*
 
 RUN alternatives --set python3 /usr/bin/python3.9


### PR DESCRIPTION
This is a stopgap until we get our clients certs from the OSG Internal CA.
[SOFTWARE-6130](https://opensciencegrid.atlassian.net/browse/SOFTWARE-6130)

[SOFTWARE-6130]: https://opensciencegrid.atlassian.net/browse/SOFTWARE-6130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ