### PR TITLE
Add Computer Science site, resources for University of Colorado Boulder

### DIFF
--- a/topology/University of Colorado/CU Boulder Comp Sci/CU-Boulder-CS-Cloud.yaml
+++ b/topology/University of Colorado/CU Boulder Comp Sci/CU-Boulder-CS-Cloud.yaml
@@ -43,8 +43,8 @@ Resources:
       # issues related to the resource
       Security Contact:
         Primary:
-          Name: <FIRSTNAME> <LASTNAME>
-          ID: <EMAIL HASH>
+          Name: Adam Zheng
+          ID: OSG1000959
         # Secondary:
         #   Name: <FIRSTNAME> <LASTNAME>
         #   ID: <EMAIL HASH>
@@ -184,6 +184,10 @@ Resources:
     Description: Frontier Squid for the CS Cloud backfill containers
     ContactLists:
       Administrative Contact:
+        Primary:
+          Name: Adam Zheng
+          ID: OSG1000959
+      Security Contact:
         Primary:
           Name: Adam Zheng
           ID: OSG1000959

--- a/topology/University of Colorado/CU Boulder Comp Sci/CU-Boulder-CS-Cloud.yaml
+++ b/topology/University of Colorado/CU Boulder Comp Sci/CU-Boulder-CS-Cloud.yaml
@@ -1,0 +1,193 @@
+# Production is true if the resources in this group will join the production OSG pool,
+# and not the Integration Test Bed (ITB) pool.
+Production: true
+# SupportCenter is one of the support centers in topology/support-centers.yaml
+SupportCenter: Self Supported
+
+# GroupDescription is a long description of the resource group; may be multiple lines.
+GroupDescription: This is a cluster of compute nodes from CS Cloud OpenStack
+
+# Resources contains one or more resources in this
+# ResourceGroup. A resource provides one or more services
+Resources:
+  # Resource Name should be a short descriptor of the resource.
+  # e.g. the Center for High Throughput Computing's GlideinWMS Frontend is "CHTC-glidein2"
+  # Resource Names need to be unique across all resources in the OSG.
+  CU-Boulder-CS-Cloud-EP:
+    # Active is true if the resource is accepting requests, and false otherwise.
+    # When first registering a resource, set this to false. Set it to true when it's ready for production.
+    Active: false
+    # Description is a long description of the resource; may be multiple lines
+    Description: This is a CU-Boulder-CS-Cloud-EP resource for CU Boulder Comp Sci operating out of CS Cloud OpenStack compute nodes.
+    # ContactLists contain information about people to contact regarding this resource.
+    # The "ID" of a user or email list can be found at https://topology.opensciencegrid.org/contacts
+    # If you cannot find the ID, plesae follow the docs at
+    # https://osg-htc.org/docs/common/contact-registration/
+    ContactLists:
+      # Administrative Contacts are persons or groups of people (i.e.,
+      # mailing lists) that are directly responsible for the
+      # maintenance of the resource
+      Administrative Contact:
+        Primary:
+          Name: Adam Zheng
+          ID: OSG1000959
+        # Secondary:
+        #   Name: <FIRSTNAME> <LASTNAME>
+        #   ID: <EMAIL HASH>
+        # Tertiary:
+        #   Name: <FIRSTNAME> <LASTNAME>
+        #   ID: <EMAIL HASH>
+
+      # Security Contact are persons or groups of people (i.e.,
+      # mailing lists) that are responsible for handling security
+      # issues related to the resource
+      Security Contact:
+        Primary:
+          Name: <FIRSTNAME> <LASTNAME>
+          ID: <EMAIL HASH>
+        # Secondary:
+        #   Name: <FIRSTNAME> <LASTNAME>
+        #   ID: <EMAIL HASH>
+        # Tertiary:
+        #   Name: <FIRSTNAME> <LASTNAME>
+        #   ID: <EMAIL HASH>
+
+      # (OPTIONAL) Executive Contacts are persons or groups of
+      # people (i.e., mailing lists) are responsible for making policy
+      # decisions regarding the site's integration with the OSG resource
+      # Executive Contact:
+        # Primary:
+        #   Name: <FIRSTNAME> <LASTNAME>
+        #   ID: <EMAIL HASH>
+        # Secondary:
+        #   Name: <FIRSTNAME> <LASTNAME>
+        #   ID: <EMAIL HASH>
+        # Tertiary:
+        #   Name: <FIRSTNAME> <LASTNAME>
+        #   ID: <EMAIL HASH>
+
+      # Local contacts are an optional set of persons or groups of
+      # people (i.e., mailing lists) if they are a different from the
+      # persons responsible for the resouce. For example, OSG Hosted
+      # CEs are operated by OSG Staff, who are separate from the local
+      # contacts that are responsible for running the site's scheduler
+
+      # (OPTIONAL) Local Executive Contacts are persons or groups of
+      # people (i.e., mailing lists) are responsible for making policy
+      # decisions regarding the site's integration with the OSG resource
+      # Local Executive Contact:
+        # Primary:
+        #   Name: <FIRSTNAME> <LASTNAME>
+        #   ID: <EMAIL HASH>
+        # Secondary:
+        #   Name: <FIRSTNAME> <LASTNAME>
+        #   ID: <EMAIL HASH>
+        # Tertiary:
+        #   Name: <FIRSTNAME> <LASTNAME>
+        #   ID: <EMAIL HASH>
+
+      # (OPTIONAL) Local Operaitonal Contacts are persons or groups of
+      # people (i.e., mailing lists) that are directly responsible for the
+      # maintenance of the site's integration with the OSG resource
+      # Local Operational Contact:
+        # Primary:
+        #   Name: <FIRSTNAME> <LASTNAME>
+        #   ID: <EMAIL HASH>
+        # Secondary:
+        #   Name: <FIRSTNAME> <LASTNAME>
+        #   ID: <EMAIL HASH>
+        # Tertiary:
+        #   Name: <FIRSTNAME> <LASTNAME>
+        #   ID: <EMAIL HASH>
+
+      # (OPTIONAL) Local Security Contacts are persons or groups of
+      # mailing lists) that are responsible for handling security
+      # issues related to the site's integration with the OSG resource
+      # Local Security Contact:
+        # Primary:
+        #   Name: <FIRSTNAME> <LASTNAME>
+        #   ID: <EMAIL HASH>
+        # Secondary:
+        #   Name: <FIRSTNAME> <LASTNAME>
+        #   ID: <EMAIL HASH>
+        # Tertiary:
+        #   Name: <FIRSTNAME> <LASTNAME>
+        #   ID: <EMAIL HASH>
+
+    # FQDN is the fully qualified domain name of the host running this resource
+    FQDN: cloud.cs.colorado.edu
+    ### FQDNAliases (optional) are any other DNS aliases by which this host can be accessed
+    # FQDNAliases:
+    #   - <HOSTNAME1>
+    #   - <HOSTNAME2>
+
+    ### DN (optional except for XCache resources) is the DN of the host cert of the resource
+    # in OpenSSL 1.0 format (i.e. /DC=org/DC=incommon/C=US/...)
+    # DN: <DN>
+
+    # Services is one or more services provided by this resource;
+    # valid services are listed in topology/services.yaml with the format "<SERVICE NAME>: <ID>"
+    Services:
+      Execution Endpoint:
+        # Description is a brief description of the service
+        Description: Backfill containers running on CS Cloud OpenStack
+        ### Details (optional)
+        # Details:
+        #   # hidden
+        #   hidden: false
+        #   ### uri_override (optional, use if your service is on some non-standard URL)
+        #   # uri_override: <HOST>:<PORT>
+        #   ### sam_uri (optional)
+        #   # sam_uri: htcondor://...
+        #   ### endpoint (for perfSONAR services)
+        #   # endpoint: <HOSTNAME>
+
+      # Other services if you have any
+      # <SERVICE NAME>:
+      # ...
+
+    ### Tags (optional) is a list of tags associated with the resource.
+    ### Include the tag "CC*" if applicable for a CC* CE.
+    ### Resources contributing to the OSPool should have the "OSPool" tag.
+    # Tags:
+    #   - <TAG1>
+    #   - <TAG2>
+
+    ### VOOwnership (optional) is the percentage of the resource owned by one or more VOs.
+    ### If part of the resource is not owned by the VO, do not list it.
+    ### The total percentage cannot exceed 100.
+    # VOOwnership:
+    #   <VO1>: <PERCENT>
+    #   <VO2>: <PERCENT>
+
+    ### WLCGInformation (optional) is only for resources that are part of the WLCG
+    # WLCGInformation:
+    #   APELNormalFactor: 0.0
+    #   HEPScore23Percentage: 0.0
+    #   AccountingName: <name>
+    #   HEPSPEC: 0
+    #   InteropAccounting: true
+    #   InteropBDII: true
+    #   InteropMonitoring: true
+    #   KSI2KMax: 0
+    #   KSI2KMin: 0
+    #   StorageCapacityMax: 0
+    #   StorageCapacityMin: 0
+    #   TapeCapacity: 0
+
+  # Other resources if you have any...
+  # <RESOURCE NAME>:
+  # ...
+
+  CS-Cloud-Squid:
+    Active: false
+    Description: Frontier Squid for the CS Cloud backfill containers
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          Name: Adam Zheng
+          ID: OSG1000959
+    FQDN: osg-frontier-squid.cs.colorado.edu
+    Services:
+      Squid:
+        Description: Generic squid service

--- a/topology/University of Colorado/CU Boulder Comp Sci/SITE.yaml
+++ b/topology/University of Colorado/CU Boulder Comp Sci/SITE.yaml
@@ -1,0 +1,23 @@
+# LongName is the expanded name of the site
+LongName: Department of Computer Science at the University of Colorado Boulder
+# Description is a brief description of your site
+Description: University of Colorado Boulder, 589 Space Science Building (SPSC) Site
+
+# AddressLine1 is the street address of the site
+AddressLine1: 3665 Discovery Dr
+### AddressLine2 (optional) is the second line of the street address
+# AddressLine2: Room 101
+# City is the city the site is located in
+City: Boulder
+
+# Country is the country the site is located in
+Country: United States
+### State (optional) is the state or province the site is located in
+# State: Colorado
+### Zipcode (optional) is the zipcode/postal code of the site
+# Zipcode: "80303"
+
+# Latitude is the latitude of the site (positive values are in the northern hemisphere)
+Latitude: 40.01
+# Longitude is the longitude of the site (positive values are in the eastern hemisphere)
+Longitude: -105.25


### PR DESCRIPTION
Add additional site and resources for University of Colorado Boulder utilizing topology identifiers osg-support provided.

```
Facility: University of Colorado
Site: CU Boulder Comp Sci
Resource Group: CU-Boulder-CS-Cloud
Resource: CU-Boulder-CS-Cloud-EP
```