### PR TITLE
Add downtime for NMSU-Discovery-CE1 due to data center poweroutage

### DIFF
--- a/topology/New Mexico State University/New Mexico State Discovery/NMSU_DISCOVERY_downtime.yaml
+++ b/topology/New Mexico State University/New Mexico State Discovery/NMSU_DISCOVERY_downtime.yaml
@@ -88,4 +88,14 @@
   ResourceName: NMSU-Discovery-CE1
   Services:
   - CE
+- Class: SCHEDULED
+  ID: 2172626808
+  Description: Data Center Prolonged Power Outage
+  Severity: Outage
+  StartTime: Jul 13, 2025 06:00 +0000
+  EndTime: Jul 14, 2025 05:59 +0000
+  CreatedTime: Jul 11, 2025 19:38 +0000
+  ResourceName: NMSU-Discovery-CE1
+  Services:
+  - CE
 # ---------------------------------------------------------


### PR DESCRIPTION
24-hour downtime due to a planned power outage in the datacenter to hook-up new backup generators.  Actually downtime should be much shorter but we've scheduled the full day just in-case.