### PR TITLE
Add entry for CHTC-learn-ap (learn-ap2000.chtc.wisc.edu)

### DIFF
--- a/topology/University of Wisconsin–Madison/CHTC/CHTC.yaml
+++ b/topology/University of Wisconsin–Madison/CHTC/CHTC.yaml
@@ -962,4 +962,28 @@ Resources:
     AllowedVOs:
       - OSG
 
+  CHTC-learn-ap:
+    Active: true
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          ID: OSG1000015
+          Name: Aaron Moate
+      Security Contact:
+        Primary:
+          ID: OSG1000015
+          Name: Aaron Moate
+    Description: CHTC Access Point
+    FQDN: learn-ap2000.chtc.wisc.edu
+    ID: 
+    Services:
+      Submit Node:
+        Description: OS Pool access point
+        Details:
+          hidden: false
+    Tags:
+      - OSPool
+    VOOwnership:
+      GLOW: 100
+
 SupportCenter: GLOW-TECH


### PR DESCRIPTION
Done in support of INF-2493: Replace
learn.chtc.wisc.edu with an EL9 VM
https://opensciencegrid.atlassian.net/browse/INF-2493