### PR TITLE
added new IceCube access point (OSG ticket #80657)

### DIFF
--- a/topology/University of Wisconsin–Madison/WIPAC/IceCube.yaml
+++ b/topology/University of Wisconsin–Madison/WIPAC/IceCube.yaml
@@ -150,6 +150,35 @@ Resources:
       IceCube: 100
     Tags:
       - OSPool
+  IceCube-grid-submitter:
+    Active: true
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          Name: David Schultz
+          ID: OSG1000039
+        Secondary:
+          Name: Maclean Mansfield-Parisi
+          ID: OSG1001302
+      Security Contact:
+        Primary:
+          Name: Steve Barnet
+          ID: 67523ec91c983a4c0c1c576beeac1037aa863da3
+        Secondary:
+          Name: Vladimir Brik
+          ID: bc87af94d3512f536e417f1e45808b975fb2874f
+    Description: This is a submit node for the IceCube collaboration.
+    FQDN: grid-submitter.icecube.wisc.edu
+    ID: [blank]
+    Services:
+      Submit Node:
+        Description: OSG Submission Node
+        Details:
+          hidden: false
+    VOOwnership:
+      IceCube: 100
+    Tags:
+      - OSPool
   NPX:
     Active: true
     ContactLists:

--- a/topology/University of Wisconsin–Madison/WIPAC/IceCube.yaml
+++ b/topology/University of Wisconsin–Madison/WIPAC/IceCube.yaml
@@ -169,7 +169,6 @@ Resources:
           ID: bc87af94d3512f536e417f1e45808b975fb2874f
     Description: This is a submit node for the IceCube collaboration.
     FQDN: grid-submitter.icecube.wisc.edu
-    ID: [blank]
     Services:
       Submit Node:
         Description: OSG Submission Node


### PR DESCRIPTION
This access point will replace `sub-2.icecube.wisc.edu` once it is put through its paces and users have been changed over. 

Configuration has changed significantly between the version of Condor running on `sub-2` and the latest, so we do not have a solid timeframe for when `sub-2` will be decommissioned. We are working to get it out of service!