### PR TITLE
Add downtime for Notre Dame OSDF Cache due to updates

### DIFF
--- a/topology/University of Notre Dame/NWICG_NDCMS/OSDF_downtime.yaml
+++ b/topology/University of Notre Dame/NWICG_NDCMS/OSDF_downtime.yaml
@@ -1,0 +1,11 @@
+- Class: SCHEDULED
+  ID: 2187964575
+  Description: Rebooting for updates
+  Severity: Outage
+  StartTime: Jul 30, 2025 16:00 +0000
+  EndTime: Jul 30, 2025 17:00 +0000
+  CreatedTime: Jul 29, 2025 13:40 +0000
+  ResourceName: NOTRE_DAME_OSDF_CACHE
+  Services:
+  - Pelican cache
+# ---------------------------------------------------------


### PR DESCRIPTION
Adding a downtime for University of Notre Dame's OSDF Cache.  We need to update the new kernel, so we plan on rebooting the machine. It shouldn't be down for longer than 15 minutes, but playing it safe.