### PR TITLE
Mark defunct IceCube access points as inactive

### DIFF
--- a/topology/University of Wisconsin–Madison/WIPAC/IceCube.yaml
+++ b/topology/University of Wisconsin–Madison/WIPAC/IceCube.yaml
@@ -45,7 +45,7 @@ Resources:
           ID: bc87af94d3512f536e417f1e45808b975fb2874f
           Name: Vladimir Brik
   IceCube-submit-1:
-    Active: true
+    Active: false
     ContactLists:
       Administrative Contact:
         Primary:
@@ -69,7 +69,7 @@ Resources:
     VOOwnership:
       IceCube: 100
   IceCube-submit-simprod:
-    Active: true
+    Active: false
     ContactLists:
       Administrative Contact:
         Primary:
@@ -93,7 +93,7 @@ Resources:
     VOOwnership:
       IceCube: 100
   IceCube-sub-grid-test:
-    Active: true
+    Active: false
     ContactLists:
       Administrative Contact:
         Primary:


### PR DESCRIPTION
I've confirmed both in our infrastructure and with other members of the admin team that these access points are no longer in service.