### PR TITLE
httpd: disable CRL checking

### DIFF
--- a/docker/apache.conf
+++ b/docker/apache.conf
@@ -26,8 +26,9 @@ WSGIDaemonProcess topomerge home=/app
 
   SSLCACertificatePath /etc/grid-security/certificates
   SSLCARevocationPath /etc/grid-security/certificates
-  SSLCARevocationCheck chain
+  #SSLCARevocationCheck chain
   #SSLCARevocationCheck chain no_crl_for_cert_ok
+  SSLCARevocationCheck none
 
  <Directory /app>
    Require all granted


### PR DESCRIPTION
It was resulting in "tlsv1 alert unknown CA" errors for the certs (multiple) people were using. Only setting it to "none" worked; "chain no_crl_for_cert_ok" didn't work; "leaf no_crl_for_cert_ok" didn't work.