### PR TITLE
Add downtime for Purdue-Hammer due to maintenance

### DIFF
--- a/topology/Purdue University/Purdue CMS/Purdue_downtime.yaml
+++ b/topology/Purdue University/Purdue CMS/Purdue_downtime.yaml
@@ -1725,4 +1725,14 @@
   Services:
   - CE
 # ---------------------------------------------------------
-
+- Class: SCHEDULED
+  ID: 2207773497
+  Description: Cluster Maintenance
+  Severity: Severe
+  StartTime: Aug 27, 2025 11:00 +0000
+  EndTime: Aug 27, 2025 21:00 +0000
+  CreatedTime: Aug 21, 2025 11:55 +0000
+  ResourceName: Purdue-Hammer
+  Services:
+  - CE
+# ---------------------------------------------------------


### PR DESCRIPTION
We had some issues come up during maintenance prep that caused me to postpone the previously scheduled maintenance for a week.