### PR TITLE
Update LIGO.yaml

### DIFF
--- a/virtual-organizations/LIGO.yaml
+++ b/virtual-organizations/LIGO.yaml
@@ -65,11 +65,6 @@ OASIS:
   - http://hcc-cvmfs-repo.unl.edu:8000/cvmfs/ligo.osgstorage.org
   - http://hcc-cvmfs-repo.unl.edu:8000/cvmfs/gwosc.osgstorage.org
   - http://hcc-cvmfs-repo.unl.edu:8000/cvmfs/igwn.osgstorage.org
-  - http://hcc-cvmfs-repo.unl.edu:8000/cvmfs/virgo.storage.igwn.org
-  - http://hcc-cvmfs-repo.unl.edu:8000/cvmfs/ligo.storage.igwn.org
-  - http://hcc-cvmfs-repo.unl.edu:8000/cvmfs/shared.storage.igwn.org
-  - http://hcc-cvmfs-repo.unl.edu:8000/cvmfs/kagra.storage.igwn.org
-  - http://hcc-cvmfs-repo.unl.edu:8000/cvmfs/ligo-test.storage.igwn.org
   - http://cvmfs-software.ligo.caltech.edu:8000/cvmfs/software.igwn.org
   UseOASIS: true
 PrimaryURL: http://www.ligo.org


### PR DESCRIPTION
Retire LIGO/Virgo/KAGRA CVMFS repositories under *.storage.igwn.org domain.