### PR TITLE
Update SPRACE_downtime.yaml

### DIFF
--- a/topology/Universidade Estadual Paulista/SPRACE/SPRACE_downtime.yaml
+++ b/topology/Universidade Estadual Paulista/SPRACE/SPRACE_downtime.yaml
@@ -5304,3 +5304,80 @@
   Services:
   - Squid
 # ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 2263365260
+  Description: Intermitent failures due to cvmfs stratum one in Brazil
+  Severity: Intermittent Outage
+  StartTime: Oct 24, 2025 21:00 +0000
+  EndTime: Oct 29, 2025 16:00 +0000
+  CreatedTime: Oct 24, 2025 20:08 +0000
+  ResourceName: BR-Sprace BW
+  Services:
+  - net.perfSONAR.Bandwidth
+# ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 2263365261
+  Description: Intermitent failures due to cvmfs stratum one in Brazil
+  Severity: Intermittent Outage
+  StartTime: Oct 24, 2025 21:00 +0000
+  EndTime: Oct 29, 2025 16:00 +0000
+  CreatedTime: Oct 24, 2025 20:08 +0000
+  ResourceName: BR-Sprace LT
+  Services:
+  - net.perfSONAR.Latency
+# ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 2263365262
+  Description: Intermitent failures due to cvmfs stratum one in Brazil
+  Severity: Intermittent Outage
+  StartTime: Oct 24, 2025 21:00 +0000
+  EndTime: Oct 29, 2025 16:00 +0000
+  CreatedTime: Oct 24, 2025 20:08 +0000
+  ResourceName: SPRACE
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 2263365263
+  Description: Intermitent failures due to cvmfs stratum one in Brazil
+  Severity: Intermittent Outage
+  StartTime: Oct 24, 2025 21:00 +0000
+  EndTime: Oct 29, 2025 16:00 +0000
+  CreatedTime: Oct 24, 2025 20:08 +0000
+  ResourceName: SPRACE-SE
+  Services:
+  - SRMv2
+# ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 2263365264
+  Description: Intermitent failures due to cvmfs stratum one in Brazil
+  Severity: Intermittent Outage
+  StartTime: Oct 24, 2025 21:00 +0000
+  EndTime: Oct 29, 2025 16:00 +0000
+  CreatedTime: Oct 24, 2025 20:08 +0000
+  ResourceName: SPRACE_OSDF_CACHE
+  Services:
+  - Pelican cache
+# ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 2263365265
+  Description: Intermitent failures due to cvmfs stratum one in Brazil
+  Severity: Intermittent Outage
+  StartTime: Oct 24, 2025 21:00 +0000
+  EndTime: Oct 29, 2025 16:00 +0000
+  CreatedTime: Oct 24, 2025 20:08 +0000
+  ResourceName: T2_BR_SPRACE-squid1
+  Services:
+  - Squid
+# ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 2263365266
+  Description: Intermitent failures due to cvmfs stratum one in Brazil
+  Severity: Intermittent Outage
+  StartTime: Oct 24, 2025 21:00 +0000
+  EndTime: Oct 29, 2025 16:00 +0000
+  CreatedTime: Oct 24, 2025 20:08 +0000
+  ResourceName: T2_BR_SPRACE-squid2
+  Services:
+  - Squid
+# ---------------------------------------------------------


### PR DESCRIPTION
The cvmfs stratum one hosted at the University of São Paulo is being recovered and this process may take until October 29, according to the server administrator.