### PR TITLE
Update JLab-Farm_downtime.yaml

### DIFF
--- a/topology/Thomas Jefferson National Accelerator Facility/JLAB/JLab-Farm_downtime.yaml
+++ b/topology/Thomas Jefferson National Accelerator Facility/JLAB/JLab-Farm_downtime.yaml
@@ -9,3 +9,14 @@
   Services:
   - CE
 # ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2274426170
+  Description: update to osg25
+  Severity: Outage
+  StartTime: Nov 12, 2025 13:00 +0000
+  EndTime: Nov 13, 2025 14:00 +0000
+  CreatedTime: Nov 06, 2025 15:23 +0000
+  ResourceName: JLab-FARM-CLAS-CE
+  Services:
+  - CE
+# ---------------------------------------------------------


### PR DESCRIPTION
taking osg-ce-2.jlab.org down to move it from osg3.6 to osg25