### PR TITLE
Add network outage entries to SPRACE_downtime.yaml

### DIFF
--- a/topology/Universidade Estadual Paulista/SPRACE/SPRACE_downtime.yaml
+++ b/topology/Universidade Estadual Paulista/SPRACE/SPRACE_downtime.yaml
@@ -5931,3 +5931,80 @@
   Services:
   - Squid
 # ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 2412949551
+  Description: network outage
+  Severity: Outage
+  StartTime: Apr 15, 2026 23:15 +0000
+  EndTime: Apr 16, 2026 15:00 +0000
+  CreatedTime: Apr 15, 2026 23:15 +0000
+  ResourceName: BR-Sprace BW
+  Services:
+  - net.perfSONAR.Bandwidth
+# ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 2412949552
+  Description: network outage
+  Severity: Outage
+  StartTime: Apr 15, 2026 23:15 +0000
+  EndTime: Apr 16, 2026 15:00 +0000
+  CreatedTime: Apr 15, 2026 23:15 +0000
+  ResourceName: BR-Sprace LT
+  Services:
+  - net.perfSONAR.Latency
+# ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 2412949553
+  Description: network outage
+  Severity: Outage
+  StartTime: Apr 15, 2026 23:15 +0000
+  EndTime: Apr 16, 2026 15:00 +0000
+  CreatedTime: Apr 15, 2026 23:15 +0000
+  ResourceName: SPRACE
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 2412949554
+  Description: network outage
+  Severity: Outage
+  StartTime: Apr 15, 2026 23:15 +0000
+  EndTime: Apr 16, 2026 15:00 +0000
+  CreatedTime: Apr 15, 2026 23:15 +0000
+  ResourceName: SPRACE-SE
+  Services:
+  - SRMv2
+# ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 2412949555
+  Description: network outage
+  Severity: Outage
+  StartTime: Apr 15, 2026 23:15 +0000
+  EndTime: Apr 16, 2026 15:00 +0000
+  CreatedTime: Apr 15, 2026 23:15 +0000
+  ResourceName: SPRACE_OSDF_CACHE
+  Services:
+  - Pelican cache
+# ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 2412949556
+  Description: network outage
+  Severity: Outage
+  StartTime: Apr 15, 2026 23:15 +0000
+  EndTime: Apr 16, 2026 15:00 +0000
+  CreatedTime: Apr 15, 2026 23:15 +0000
+  ResourceName: T2_BR_SPRACE-squid1
+  Services:
+  - Squid
+# ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 2412949557
+  Description: network outage
+  Severity: Outage
+  StartTime: Apr 15, 2026 23:15 +0000
+  EndTime: Apr 16, 2026 15:00 +0000
+  CreatedTime: Apr 15, 2026 23:15 +0000
+  ResourceName: T2_BR_SPRACE-squid2
+  Services:
+  - Squid
+# ---------------------------------------------------------


### PR DESCRIPTION
Added multiple entries for network outages with details including ID, description, severity, start time, end time, created time, resource name, and associated services.