### PR TITLE
Add CHTC-ITB-PELICANPLATFORM2-ORIGIN

### DIFF
--- a/topology/University of Wisconsin–Madison/CHTC/CHTC-OSDF-ITB.yaml
+++ b/topology/University of Wisconsin–Madison/CHTC/CHTC-OSDF-ITB.yaml
@@ -178,6 +178,39 @@ Resources:
     AllowedVOs:
       - GLOW
 
+  CHTC-ITB-PELICANPLATFORM2-ORIGIN:
+    Active: true
+    Description: >-
+      This is an origin used for serving /pelicanplatform2 in the ITB OSDF.
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          ID: OSG1000002
+          Name: Matyas Selmeci
+        Secondary:
+          ID: OSG1000589
+          Name: William N Swanson
+        Tertiary:
+          ID: OSG1000003
+          Name: Brian Hua Lin
+      Security Contact:
+        Primary:
+          ID: OSG1000002
+          Name: Matyas Selmeci
+        Secondary:
+          ID: OSG1000589
+          Name: William N Swanson
+        Tertiary:
+          ID: OSG1000003
+          Name: Brian Hua Lin
+    FQDN: pelicanplatform2-origin.osdf-dev.chtc.io
+    DN: /CN=pelicanplatform2-origin.osdf-dev.chtc.io
+    Services:
+      Pelican origin:
+        Description: Origin for /pelicanplatform2 in ITB OSDF
+    AllowedVOs:
+      - GLOW
+
   ITB-OSDF-CHTC-ORIGIN:
     Active: true
     Description: >-


### PR DESCRIPTION
This is a second ITB origin that can be used for testing; it serves /pelicanplatform2 instead of /pelicanplatform