### PR TITLE
Set "Active: false" for several CHTC squid resources

### DIFF
--- a/topology/University of Wisconsin–Madison/CHTC/CHTC.yaml
+++ b/topology/University of Wisconsin–Madison/CHTC/CHTC.yaml
@@ -183,7 +183,7 @@ Resources:
       GLOW: 100
 
   CHTC_SQUID_CS_3370:
-    Active: true
+    Active: false
     Description: Squid service located at Computer Sciences 3370a
     ID: 1127
     ContactLists:
@@ -223,7 +223,7 @@ Resources:
       GLOW: 100
 
   CHTC_SQUID_CS_B240:
-    Active: true
+    Active: false
     Description: Squid service located in CS B240
     ID: 972
     ContactLists:
@@ -358,7 +358,7 @@ Resources:
       GLOW: 100
       
   CHTC_CVMFS_EXCLUSIVE_SQUID_B240:
-    Active: true
+    Active: false
     Description: CVMFS-exclusive squid cache located at B240
     ID: 1175
     ContactLists:


### PR DESCRIPTION
Per @cvuosalo 's request set Active: false on several CHTC squid resources