### PR TITLE
Remove old CHTC learn submit registration

### DIFF
--- a/topology/University of Wisconsin–Madison/CHTC/CHTC.yaml
+++ b/topology/University of Wisconsin–Madison/CHTC/CHTC.yaml
@@ -139,7 +139,7 @@ Resources:
       GLOW: 100
 
   CHTC-submit-learn:
-    Active: true
+    Active: false
     ContactLists:
       Administrative Contact:
         Primary:


### PR DESCRIPTION
We provisioned a new host that reuses the FQDN but now sets the
SiteName to `CHTC-learn-ap`