### PR TITLE
Add API key support

### DIFF
--- a/.github/workflows/validate-code.yml
+++ b/.github/workflows/validate-code.yml
@@ -25,6 +25,7 @@ jobs:
           export TOPOLOGY_CONFIG=$PWD/src/config-ci.py
           export FLASK_DEBUG=1
           py.test ./src/tests/test_api.py
+          py.test ./src/tests/test_api_auth.py
       - name: Test StashCache
         run: |
           export TOPOLOGY_CONFIG=$PWD/src/config-ci.py

--- a/.github/workflows/validate-code.yml
+++ b/.github/workflows/validate-code.yml
@@ -26,6 +26,7 @@ jobs:
           export FLASK_DEBUG=1
           py.test ./src/tests/test_api.py
           py.test ./src/tests/test_api_auth.py
+          py.test ./src/tests/test_auth_helpers.py
       - name: Test StashCache
         run: |
           export TOPOLOGY_CONFIG=$PWD/src/config-ci.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,9 @@ COPY src/ ./
 RUN rm /etc/httpd/conf.d/ssl.conf
 COPY docker/apache.conf /etc/httpd/conf.d/topology.conf
 COPY docker/supervisor-apache.conf /etc/supervisord.d/40-apache.conf
+# Give the api keys file its own dir so it can be updated without a pod restart.
+RUN mkdir -p /secrets/api_keys
+COPY --chown=apache:apache --chmod=600 docker/api_keys.yaml /secrets/api_keys/api_keys.yaml
 
 EXPOSE 8080/tcp 8443/tcp
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,21 @@ For example, either of the following will match GLOW (13), HCC (67), and IceCube
 - `vo=on&vo_sel[]=13&vo_sel[]=67&vo_sel[]=38`
 
 
+Viewing Contact Information
+---------------------------
+
+Detailed contact information (email addresses, phone numbers, etc.) is private
+and requires an API key to view.
+To use an API key, include it as a `Bearer` token in the `Authorize` header of an
+API request. For example:
+
+```
+curl -H "Authorization: Bearer tk-XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX" \
+  https://topology.opensciencegrid.org/miscuser/xml
+```
+
+To request an API key, see "Getting Help" below.
+
 
 Getting Help
 ------------

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Viewing Contact Information
 
 Detailed contact information (email addresses, phone numbers, etc.) is private
 and requires an API key to view.
-To use an API key, include it as a `Bearer` token in the `Authorize` header of an
+To use an API key, include it as a `Bearer` token in the `Authorization` header of an
 API request. For example:
 
 ```

--- a/bin/make_api_key.py
+++ b/bin/make_api_key.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+
+import argparse
+import hashlib
+import pathlib
+import re
+import sys
+import urllib.request
+import uuid
+import xml.etree.ElementTree as ET
+
+USERS_ENDPOINT = "https://topology.opensciencegrid.org/miscuser/xml"
+VALID_API_KEY_RE = re.compile(
+    r"^tk-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+)
+
+
+class NoMatch(Exception):
+    pass
+
+
+def get_user_info(fullname=None, id_=None, endpoint=USERS_ENDPOINT) -> tuple[str, str]:
+    """
+    Get the miscuser XML from Topology, look up a user by ID or FullName,
+    and return a tuple containing the (FullName, ID) from Topology, or raise
+    NoMatch if no record is found.
+
+    The XML is retrieved from the URL at `endpoint` and looks something like this:
+    <Users>
+        <User>
+            <FullName>Name Of Person</FullName>
+            <ID>(either an OSG ID or a hash)</ID>
+        </User>
+    </Users>
+
+    If neither fullname nor id_ are specified, ValueError will be raised.
+    If both fullname and id_ are specified, looks up the record by ID and
+    makes sure the FullName matches, raising a NoMatch exception if it
+    does not.
+    """
+    if not fullname and not id_:
+        raise ValueError("Either fullname or id_ must be provided")
+
+    # Fetch the XML from the endpoint
+    with urllib.request.urlopen(endpoint) as response:
+        xml_data = response.read()
+
+    # Parse the XML
+    root = ET.fromstring(xml_data)
+
+    # Search through users for a match
+    for user in root.findall('User'):
+        user_fullname = user.findtext('FullName', '').strip()
+        user_id = user.findtext('ID', '').strip()
+
+        if id_ and fullname:
+            # Both specified: match by ID and verify FullName matches
+            if user_id == id_:
+                if user_fullname == fullname:
+                    return (user_fullname, user_id)
+                else:
+                    raise NoMatch(
+                        f"ID {id_} found but FullName does not match. Expected {fullname}, got {user_fullname}"
+                    )
+        elif id_:
+            # Match by ID only
+            if user_id == id_:
+                return (user_fullname, user_id)
+        elif fullname:
+            # Match by FullName only
+            if user_fullname == fullname:
+                return (user_fullname, user_id)
+
+    # No match found
+    if id_ and fullname:
+        raise NoMatch(f"No user found with ID {id_} and FullName {fullname}")
+    elif id_:
+        raise NoMatch(f"No user found with ID {id_}")
+    else:
+        raise NoMatch(f"No user found with FullName {fullname}")
+
+
+def get_arguments():
+    """
+    Parses command-line arguments for generating or retrieving an API key.
+    """
+    parser = argparse.ArgumentParser(
+        description="Generate an API key and optional apikeys file block."
+    )
+    parser.add_argument(
+        "--outfile", default="", help="write the raw API key to this file"
+    )
+    parser.add_argument(
+        "--keyfile",
+        default="",
+        help="read the API key from this file instead of generating a new one",
+    )
+    parser.add_argument(
+        "--name", dest="fullname", default="", help="look up the contact by FullName"
+    )
+    parser.add_argument(
+        "--id", dest="id_", metavar="ID", default="", help="look up the contact by ID"
+    )
+    args = parser.parse_args()
+    return args
+
+
+def read_api_key_from_file(keyfile: str) -> str:
+    """
+    Reads an API key from a specified file and validates its format.
+
+    The function reads the contents of the given file, removes any leading or
+    trailing whitespace, and validates the API key against a predefined format.
+    If the file cannot be read, is empty, or the API key format is invalid,
+    an error is raised.
+
+    Args:
+        keyfile (str): Path to the file containing the API key.
+
+    Raises:
+        ValueError: If the file cannot be read, is empty, or contains an invalid API key.
+
+    Returns:
+        str: The validated API key.
+    """
+    path = pathlib.Path(keyfile)
+    try:
+        key_string = path.read_text().strip()
+    except OSError as exc:
+        raise ValueError(f"Could not read API key file {keyfile}: {exc}") from exc
+
+    if not key_string:
+        raise ValueError(f"API key file {keyfile} is empty")
+
+    if not VALID_API_KEY_RE.fullmatch(key_string):
+        raise ValueError(f"API key file {keyfile} does not contain a valid API key")
+
+    return key_string
+
+
+def get_api_key(keyfile: str = "") -> str:
+    """
+    Make or read the API key
+    """
+    if keyfile:
+        api_key = read_api_key_from_file(keyfile)
+    else:
+        api_key = "tk-" + str(uuid.uuid4())
+        assert VALID_API_KEY_RE.fullmatch(api_key)
+    return api_key
+
+
+def make_key_hash(api_key: str) -> str:
+    """
+    Create a sha256 sum of the key that can be added to the apikeys file
+    """
+    hash_b = hashlib.sha256(api_key.encode())
+    api_key_hash = f"sha256:{hash_b.hexdigest()}"
+    return api_key_hash
+
+
+def print_keys_file_block(api_key_hash: str, fullname: str, id_: str):
+    """
+    Print the text to include in the API_KEYS_FILE; if we have the FullName
+    and ID, print the whole block; otherwise, just the APIKeyHash.
+    """
+    if fullname and id_:
+        print(f"{id_}:")
+        print(f"  FullName: {fullname}")
+        print(f"  APIKeyHash: {api_key_hash}")
+    else:
+        print(f"APIKeyHash: {api_key_hash}")
+
+
+def main() -> int:
+    args = get_arguments()
+
+    if args.fullname or args.id_:
+        try:
+            fullname, id_ = get_user_info(fullname=args.fullname, id_=args.id_)
+        except NoMatch as err:
+            print(str(err), file=sys.stderr)
+            return 1
+    else:
+        fullname, id_ = "", ""
+
+    try:
+        api_key = get_api_key(keyfile=args.keyfile)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    api_key_hash = make_key_hash(api_key)
+    print_keys_file_block(api_key_hash, fullname, id_)
+
+    # Either write the key to a file and print the file name to console,
+    # or print the key itself to console.
+    # The message is written to stderr so we can redirect stdout to
+    # save the API_KEYS_FILE block to a file.
+    if args.outfile:
+        outfile = pathlib.Path(args.outfile)
+        outfile.write_text(api_key)
+        print(f"\nKey written to {args.outfile}", file=sys.stderr)
+    elif not args.keyfile:
+        # We didn't load the key from a file, so print the generated one.
+        print("\nGenerated API Key: %r" % api_key, file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/make_api_key.py
+++ b/bin/make_api_key.py
@@ -1,7 +1,12 @@
 #!/usr/bin/env python3
+"""
+This script creates an API key that clients can use to access contact
+information in Topology pages.
+"""
 
 import argparse
 import hashlib
+import os
 import pathlib
 import re
 import sys
@@ -85,7 +90,7 @@ def get_arguments():
     Parses command-line arguments for generating or retrieving an API key.
     """
     parser = argparse.ArgumentParser(
-        description="Generate an API key and optional apikeys file block."
+        description=__doc__
     )
     parser.add_argument(
         "--outfile", default="", help="write the raw API key to this file"
@@ -199,7 +204,9 @@ def main() -> int:
     # save the API_KEYS_FILE block to a file.
     if args.outfile:
         outfile = pathlib.Path(args.outfile)
+        old_umask = os.umask(0o077)
         outfile.write_text(api_key)
+        os.umask(old_umask)
         print(f"\nKey written to {args.outfile}", file=sys.stderr)
     elif not args.keyfile:
         # We didn't load the key from a file, so print the generated one.

--- a/bin/make_api_key.py
+++ b/bin/make_api_key.py
@@ -15,6 +15,7 @@ import uuid
 import xml.etree.ElementTree as ET
 
 USERS_ENDPOINT = "https://topology.opensciencegrid.org/miscuser/xml"
+# Regex for an API key, formatted as `tk-` followed by a UUID
 VALID_API_KEY_RE = re.compile(
     r"^tk-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
 )

--- a/bin/make_api_key.py
+++ b/bin/make_api_key.py
@@ -14,11 +14,15 @@ import urllib.request
 import uuid
 import xml.etree.ElementTree as ET
 
+
+if __name__ == "__main__" and __package__ is None:
+    _parent = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path.append(_parent + "/src")
+
+from webapp.common import API_KEY_RE, token_to_apikeyhash
+
+
 USERS_ENDPOINT = "https://topology.opensciencegrid.org/miscuser/xml"
-# Regex for an API key, formatted as `tk-` followed by a UUID
-VALID_API_KEY_RE = re.compile(
-    r"^tk-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
-)
 
 
 class NoMatch(Exception):
@@ -138,7 +142,7 @@ def read_api_key_from_file(keyfile: str) -> str:
     if not key_string:
         raise ValueError(f"API key file {keyfile} is empty")
 
-    if not VALID_API_KEY_RE.fullmatch(key_string):
+    if not API_KEY_RE.fullmatch(key_string):
         raise ValueError(f"API key file {keyfile} does not contain a valid API key")
 
     return key_string
@@ -152,17 +156,8 @@ def get_api_key(keyfile: str = "") -> str:
         api_key = read_api_key_from_file(keyfile)
     else:
         api_key = "tk-" + str(uuid.uuid4())
-        assert VALID_API_KEY_RE.fullmatch(api_key)
+        assert API_KEY_RE.fullmatch(api_key)
     return api_key
-
-
-def make_key_hash(api_key: str) -> str:
-    """
-    Create a sha256 sum of the key that can be added to the apikeys file
-    """
-    hash_b = hashlib.sha256(api_key.encode())
-    api_key_hash = f"sha256:{hash_b.hexdigest()}"
-    return api_key_hash
 
 
 def print_keys_file_block(api_key_hash: str, fullname: str, id_: str):
@@ -196,7 +191,7 @@ def main() -> int:
         print(f"Error: {exc}", file=sys.stderr)
         return 1
 
-    api_key_hash = make_key_hash(api_key)
+    api_key_hash = token_to_apikeyhash(api_key)
     print_keys_file_block(api_key_hash, fullname, id_)
 
     # Either write the key to a file and print the file name to console,

--- a/docker/apache.conf
+++ b/docker/apache.conf
@@ -3,6 +3,8 @@ Listen 8443
 
 LoadModule wsgi_module /usr/local/lib64/python3.12/site-packages/mod_wsgi/server/mod_wsgi-py312.cpython-312-x86_64-linux-gnu.so
 WSGIPythonPath /app
+# Pass the Authorization header from the request so bearer token auth works
+WSGIPassAuthorization On
 
 # Run apps in separate processes to stop yaml.CSafeLoader import-time error
 WSGIDaemonProcess topology  home=/app processes=5

--- a/docker/api_keys.yaml
+++ b/docker/api_keys.yaml
@@ -1,0 +1,7 @@
+# Stub file for API key hashes used by contacts for automated access.
+#
+# Format
+# ------
+# <contact ID>:
+#    FullName: <contact name>
+#    APIKeyHash: sha256:<hash>

--- a/src/README.md
+++ b/src/README.md
@@ -628,8 +628,8 @@ The hashes for validating API keys are loaded from a file specified in `API_KEYS
 Only contacts registered in contacts.yaml or COManage can have API keys.
 API keys not associated with a valid contact are not accepted.
 A contact may only have one API key.
-The API keys file is re-read at the same frequency as contact info (every 5 minutes)
-by default.
+The API keys file is re-read at the same frequency as contact info
+(configured via CONTACT_CACHE_LIFETIME).
 
 Use the `bin/make_api_key.py` script to make a new API key and also output
 the YAML block that should be copy-pasted into the API keys file.
@@ -656,7 +656,7 @@ bin/make_api_key.py --keyfile apikey --name "Example User"
 ```
 
 The Docker image is configured to look for the API keys file
-at `/etc/api_keys/api_keys.yaml`.
+at `/secrets/api_keys/api_keys.yaml`.
 
 Unlike with X.509, an invalid API key will return a 401 instead of
 silently falling back to showing no contact info.

--- a/src/README.md
+++ b/src/README.md
@@ -606,3 +606,57 @@ The final result looks like
   ]
 }
 ```
+
+
+API Key Authentication
+----------------------
+
+Clients can access authenticated data (namely, contact information) through either X.509 client certs (deprecated)
+or an API key that's used as a Bearer token in the HTTP Authorization header.
+
+An API key looks like `tk-XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX` where each X is a lowercase hex value.
+(So, a UUID.)
+
+The hashes for validating API keys are loaded from a file specified in `API_KEYS_FILE` in the config.  The hashes are keyed to user IDs, in the following format:
+
+```yaml
+<id>:
+  FullName: <full name as it appears in contact info>
+  APIKeyHash: sha256:<SHA-256 checksum of the key as a 64-character hex string>
+```
+
+Only contacts registered in contacts.yaml or COManage can have API keys.
+API keys not associated with a valid contact are not accepted.
+A contact may only have one API key.
+The API keys file is re-read at the same frequency as contact info (every 5 minutes)
+by default.
+
+Use the `bin/make_api_key.py` script to make a new API key and also output
+the YAML block that should be copy-pasted into the API keys file.
+You may specify the contact by FullName (`--name`) or ID (`--id`).
+
+Example usages:
+```
+# Make the key; print the key to and the hash to console. (Does not print the
+# whole YAML block, since the script doesn't know the contact.)
+bin/make_api_key.py
+
+# Make the key associated with the user with FullName "ExampleUser".
+# Write the key to `apikey` and append the YAML block to `api_keys_file.yaml`.
+bin/make_api_key.py --name "Example User" --outfile apikey | tee -a api_keys_file.yaml
+
+# Make the key associated with the user with ID OSG10000001.  (The ID
+# can also be an email hash from contacts.yaml.)
+# Write the key to `apikey` and append the YAML block to `api_keys_file.yaml`.
+bin/make_api_key.py --id "OSG10000001" --outfile apikey | tee -a api_keys_file.yaml
+
+# Load a key from `apikey` and print the YAML block to include in `api_keys_file.yaml`
+# to associate it with Example User.
+bin/make_api_key.py --keyfile apikey --name "Example User"
+```
+
+The Docker image is configured to look for the API keys file
+at `/etc/api_keys/api_keys.yaml`.
+
+Unlike with X.509, an invalid API key will return a 401 instead of
+silently falling back to showing no contact info.

--- a/src/app.py
+++ b/src/app.py
@@ -5,7 +5,6 @@ import csv
 import flask
 import flask.logging
 from flask import Flask, Response, make_response, request, render_template, redirect, url_for, session
-import hashlib
 from io import StringIO
 import logging
 import os

--- a/src/app.py
+++ b/src/app.py
@@ -32,7 +32,6 @@ from webapp.common import (
     is_null,
     is_true,
     readfile,
-    shorten,
     simplify_attr_list,
     support_cors,
     token_to_apikeyhash,

--- a/src/app.py
+++ b/src/app.py
@@ -5,6 +5,7 @@ import csv
 import flask
 import flask.logging
 from flask import Flask, Response, make_response, request, render_template, redirect, url_for, session
+import hashlib
 from io import StringIO
 import logging
 import os
@@ -21,8 +22,24 @@ from flask_wtf.csrf import CSRFProtect
 from werkzeug.middleware.proxy_fix import ProxyFix
 
 from webapp import default_config
-from webapp.common import readfile, to_xml_bytes, to_json_bytes, Filters, support_cors, simplify_attr_list, is_null, \
-    escape, cache_control_private, PreJSON, is_true, GRIDTYPE_1, GRIDTYPE_2, NamespacesFilters
+from webapp.common import (
+    Filters,
+    GRIDTYPE_1,
+    GRIDTYPE_2,
+    NamespacesFilters,
+    PreJSON,
+    cache_control_private,
+    escape,
+    is_null,
+    is_true,
+    readfile,
+    shorten,
+    simplify_attr_list,
+    support_cors,
+    token_to_apikeyhash,
+    to_json_bytes,
+    to_xml_bytes,
+)
 from webapp.flask_common import create_accepted_response
 from webapp.exceptions import DataError, ResourceNotRegistered, ResourceMissingServices
 from webapp.forms import GenerateDowntimeForm, GenerateResourceGroupDowntimeForm, GenerateProjectForm
@@ -40,8 +57,19 @@ except ImportError as e:
 
 
 class InvalidArgumentsError(Exception): pass
+class AuthenticationFailedError(Exception): pass
+
 
 def _verify_config(cfg):
+    """
+    Checks some attributes in the application config for consistency.
+
+    - If we use Git to fetch data (i.e., not NO_GIT), GIT_SSH_KEY must be
+      pointed to an existing key that's only readable by the owner
+      (unless IGNORE_SECRET_PERMS is set).
+
+    - If the API keys file is specified, it must exist.
+    """
     if not cfg["NO_GIT"]:
         ssh_key = cfg["GIT_SSH_KEY"]
         if not ssh_key:
@@ -56,6 +84,20 @@ def _verify_config(cfg):
                 else:
                     raise PermissionError(ssh_key)
 
+    api_keys_file = cfg.get("API_KEYS_FILE")
+    if not api_keys_file:
+        app.logger.info("API_KEYS_FILE not specified - API key auth unavailable")
+    else:
+        try:
+            _ = open(api_keys_file, "rb").read(4096)
+        except OSError as err:
+            app.logger.warning(
+                "API_KEYS_FILE (%s) not readable: %s - API key auth unavailable",
+                api_keys_file,
+                err,
+                exc_info=True,
+            )
+
 
 default_authorized = False
 
@@ -65,7 +107,6 @@ app.config.from_pyfile("config.py", silent=True)
 
 if "TOPOLOGY_CONFIG" in os.environ:
     app.config.from_envvar("TOPOLOGY_CONFIG", silent=False)
-_verify_config(app.config)
 
 if "AUTH" in app.config:
     if app.debug:
@@ -75,6 +116,14 @@ if "AUTH" in app.config:
 
 if "LOGLEVEL" in app.config:
     app.logger.setLevel(app.config["LOGLEVEL"])
+
+_verify_config(app.config)
+
+
+@app.errorhandler(AuthenticationFailedError)
+def _handle_authentication_failed(err):
+    return Response(str(err), status=401)
+
 
 global_data = GlobalData(app.config, strict=app.config.get("STRICT", app.debug))
 
@@ -1122,8 +1171,61 @@ def _get_authorized():
 
     returns: True if authorized, False otherwise
     """
-    global app
+    if _authorize_bearer_header():
+        return True
 
+    if _authorize_dn_credentials():
+        return True
+
+    # If it gets here, then it is not authorized
+    return default_authorized
+
+
+def _authorize_bearer_header() -> bool:
+    """
+    Determine if the client is authorized based on an API Key passed
+    in the Authorization header as a Bearer token.
+
+    returns: True if authorized, False otherwise;
+    if the header is present but invalid, raises AuthenticationFailedError
+    to indicate that the request should be rejected rather than allowed
+    to fallback to other authentication methods.
+    """
+    if app and app.logger:
+        log = app.logger
+    else:
+        log = logging.getLogger(__name__)
+
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header.startswith("Bearer "):
+        return False
+
+    bearer_token = auth_header[7:].strip(" \t\n'\"")
+    if not bearer_token:
+        log.info("Rejected empty token")
+        raise AuthenticationFailedError("Empty bearer token")
+
+    try:
+        token_hash = token_to_apikeyhash(bearer_token)
+    except ValueError as err:
+        log.info("Rejected invalid token %s: %s", shorten(bearer_token, 20), err)
+        raise AuthenticationFailedError("Invalid bearer token")
+
+    hash_prefix = token_hash[7:15]  # skip leading 'sha256:'
+    authorized_api_keys = global_data.get_api_keys()
+    if authorized_api_keys and token_hash in authorized_api_keys:
+        log.info(
+            "Authorized bearer with hash=%s... owner=%s",
+            hash_prefix,
+            authorized_api_keys[token_hash],
+        )
+        return True
+
+    log.debug("Rejected bearer with hash=%s...", hash_prefix)
+    raise AuthenticationFailedError("Invalid bearer token")
+
+
+def _authorize_dn_credentials() -> bool:
     # Loop through looking for all of the creds
     for key, value in request.environ.items():
         if key.startswith('GRST_CRED_AURI_') and value.startswith("dn:"):
@@ -1143,8 +1245,7 @@ def _get_authorized():
                 if app and app.logger:
                     app.logger.debug("Rejected %s", client_dn)
 
-    # If it gets here, then it is not authorized
-    return default_authorized
+    return False
 
 
 try:

--- a/src/app.py
+++ b/src/app.py
@@ -89,7 +89,8 @@ def _verify_config(cfg):
         app.logger.info("API_KEYS_FILE not specified - API key auth unavailable")
     else:
         try:
-            _ = open(api_keys_file, "rb").read(4096)
+            with open(api_keys_file, "rb") as fh:
+                _ = fh.read(4096)
         except OSError as err:
             app.logger.warning(
                 "API_KEYS_FILE (%s) not readable: %s - API key auth unavailable",
@@ -1208,7 +1209,7 @@ def _authorize_bearer_header() -> bool:
     try:
         token_hash = token_to_apikeyhash(bearer_token)
     except ValueError as err:
-        log.info("Rejected invalid token %s: %s", shorten(bearer_token, 20), err)
+        log.info("Rejected invalid token (len=%d): %s", len(bearer_token), err)
         raise AuthenticationFailedError("Invalid bearer token")
 
     hash_prefix = token_hash[7:15]  # skip leading 'sha256:'

--- a/src/tests/data/testcontact.yaml
+++ b/src/tests/data/testcontact.yaml
@@ -1,0 +1,35 @@
+8f4a2c1d9e7b0a6c3f21e5d4b9a8c7e6d5f4a3b2:
+  ContactInformation:
+    DNs:
+    - /DC=org/DC=example/C=US/O=Example University/CN=Alex Morgan X123456
+    PrimaryEmail: alex.morgan@example.edu
+    PrimaryPhone: +1 555 402 7812
+  CILogonID: OSG2000456
+  Flags:
+  - Example Staff
+  FullName: Alex Jordan Morgan
+  GitHub: alexmorgan-dev
+  Profile: Sample profile for CI testing and integration validation
+
+9c1e7a4b3f2d8e5a6b0c4d9f1a2e3c5b6a7e8d9:
+  ContactInformation:
+    PrimaryEmail: user01@example.org
+    PrimaryPhone: +44 20 7946 0958
+  FullName: Luca Ferreri
+  Profile: Test account used for automated certificate workflows
+
+a3d9b6c2f0e1a8d7c5b4e9f2a1c6d8e7b9a0f4:
+  ContactInformation:
+    PrimaryEmail: hpc-support@example.net
+  FullName: Taylor Nguyen
+  Profile: Placeholder site contact for system-level testing
+
+f0e9d8c7b6a5d4c3b2a1908e7f6d5c4b3a2e1:
+  ContactInformation:
+    PrimaryEmail: ops.user@example.com
+  Flags:
+  - Example Staff
+  FullName: Jordan Patel
+  GitHub: jordanp-sample
+  Profile: Simulated operations role for CI and staging environments
+

--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -1,8 +1,8 @@
+# pyright: reportOptionalMemberAccess=false, reportOptionalSubscript=false
 import re
 import flask
 import pytest
-from typing import Dict, List
-import urllib.parse
+import warnings
 
 
 # Rewrites the path so the app can be imported like it normally is
@@ -15,6 +15,15 @@ topdir = os.path.join(os.path.dirname(__file__), "..")
 sys.path.append(topdir)
 
 os.environ['TESTING'] = "True"
+
+# Third-party deprecation from python-dateutil under Python 3.12;
+# we do not control that dependency's internal datetime usage in these tests.
+warnings.filterwarnings(
+    "ignore",
+    message=r"datetime\.datetime\.utcfromtimestamp\(\) is deprecated.*",
+    category=DeprecationWarning,
+    module=r"dateutil\.tz\.tz",
+)
 
 from app import app, global_data
 from webapp.topology import Facility, Site, Resource, ResourceGroup
@@ -801,6 +810,7 @@ class TestEndpointContent:
         osg_ids_set = set(osg_ids_list)
         duplicates = len(osg_ids_list) - len(osg_ids_set)
         assert duplicates == 0, "%d duplicate ids found in institution_ids list provided by API" % duplicates
+
 
 
 if __name__ == '__main__':

--- a/src/tests/test_api_auth.py
+++ b/src/tests/test_api_auth.py
@@ -1,0 +1,291 @@
+import logging
+import os
+import sys
+import warnings
+from typing import Generator
+
+import pytest
+from flask.testing import FlaskClient
+from pytest_mock import MockerFixture
+
+# Rewrites the path so the app can be imported like it normally is
+
+topdir = os.path.join(str(os.path.dirname(__file__)), "..")
+sys.path.append(topdir)
+
+os.environ["TESTING"] = "True"
+
+# Third-party deprecation from python-dateutil under Python 3.12;
+# we do not control that dependency's internal datetime usage in these tests.
+warnings.filterwarnings(
+    "ignore",
+    message=r"datetime\.datetime\.utcfromtimestamp\(\) is deprecated.*",
+    category=DeprecationWarning,
+    module=r"dateutil\.tz\.tz",
+)
+
+from app import app, global_data
+from webapp.common import API_KEY_RE, token_to_apikeyhash
+from webapp.contacts_reader import ContactsData
+
+_TESTCONTACT_YAML = os.path.join(str(os.path.dirname(__file__)), "data", "testcontact.yaml")
+
+
+def _testtoken(suffix: str = "0"):
+    """
+    Return a token in the correct format with the given suffix.
+    The suffix must be 0-12 lowercase hex digits.
+    """
+    return "tk-aaaaaaaa-bbbb-cccc-dddd-%s" % suffix.zfill(12)
+
+
+TEST_TOKEN = _testtoken("1")
+UNKNOWN_TOKEN = _testtoken("0")
+
+assert API_KEY_RE.fullmatch(TEST_TOKEN), "TEST_TOKEN %r does not match pattern" % TEST_TOKEN
+assert API_KEY_RE.fullmatch(UNKNOWN_TOKEN), "UNKNOWN_TOKEN %r does not match pattern" % UNKNOWN_TOKEN
+
+_TEST_DN = "/DC=org/DC=opensciencegrid/O=Open Science Grid/OU=Services/CN=test-host.example.com"
+
+
+@pytest.fixture
+def client() -> Generator[FlaskClient, None, None]:
+    with app.test_client() as client:
+        yield client
+
+
+class TestApiKeyAuth:
+    """Tests for the Bearer-token auth path in _get_authorized()."""
+
+    @pytest.fixture
+    def mock_api_keys(self, mocker: MockerFixture):
+        """Patch get_api_keys to return {hash: owner} and disable the CI AUTH bypass."""
+        from webapp.common import load_yaml_file
+
+        contacts_data = ContactsData(load_yaml_file(_TESTCONTACT_YAML))
+        mocker.patch.object(
+            global_data,
+            "get_api_keys",
+            return_value={token_to_apikeyhash(TEST_TOKEN): "Alex Jordan Morgan"},
+        )
+        mocker.patch.object(global_data, "get_contacts_data", return_value=contacts_data)
+        mocker.patch("app.default_authorized", False)
+
+    @staticmethod
+    def dn_auth_environ(dn: str) -> dict:
+        """Return an environ_base dict that injects a GRST DN credential."""
+        return {"GRST_CRED_AURI_0": "dn:" + dn}
+
+    # ------------------------------------------------------------------
+    # _get_authorized() parser tests (black-box via /miscuser/xml)
+    # ------------------------------------------------------------------
+
+    def test_valid_bearer_token_authorizes(
+        self, client: FlaskClient, mocker: MockerFixture, mock_api_keys
+    ):
+        """A correct Bearer token causes the route to behave as authorized."""
+        response = client.get(
+            "/miscuser/xml", headers={"Authorization": f"Bearer {TEST_TOKEN}"}
+        )
+        assert response.status_code == 200
+        assert b"<ContactInformation>" in response.data
+
+    def test_empty_bearer_token_returns_401(
+        self, client: FlaskClient, mocker: MockerFixture, mock_api_keys
+    ):
+        """Empty token -> 401."""
+        headers = {"Authorization": "Bearer "}
+        response = client.get("/miscuser/xml", headers=headers)
+        assert response.status_code == 401
+        assert b"<ContactInformation>" not in response.data
+
+    def test_invalid_non_empty_bearer_returns_401(
+        self, client: FlaskClient, mocker: MockerFixture, mock_api_keys
+    ):
+        response = client.get(
+            "/miscuser/xml", headers={"Authorization": f"Bearer {UNKNOWN_TOKEN}"}
+        )
+        assert response.status_code == 401
+        assert b"<ContactInformation>" not in response.data
+
+    def test_query_param_token_does_not_authorize(
+        self, client: FlaskClient, mocker: MockerFixture, mock_api_keys
+    ):
+        """Token in the query string (not the Authorization header) does not grant access."""
+        response = client.get(f"/miscuser/xml?token={TEST_TOKEN}")
+        assert response.status_code == 200
+        assert b"<ContactInformation>" not in response.data
+
+    def test_valid_dn_with_bad_bearer_is_unauthorized(
+        self, client: FlaskClient, mocker: MockerFixture, mock_api_keys
+    ):
+        """An invalid non-empty Bearer token fails auth and does not fall back to DN."""
+        mocker.patch.object(global_data, "get_dns", return_value={_TEST_DN})
+        response = client.get(
+            "/miscuser/xml",
+            headers={"Authorization": f"Bearer {UNKNOWN_TOKEN}"},
+            environ_base=self.dn_auth_environ(_TEST_DN),
+        )
+        assert response.status_code == 401
+        assert b"<ContactInformation>" not in response.data
+
+    def test_no_bearer_with_valid_dn_falls_back_to_dn_auth(
+        self, client: FlaskClient, mocker: MockerFixture, mock_api_keys
+    ):
+        """No Bearer token should allow DN fallback to authorize."""
+        mocker.patch.object(global_data, "get_dns", return_value={_TEST_DN})
+        response = client.get(
+            "/miscuser/xml",
+            environ_base=self.dn_auth_environ(_TEST_DN),
+        )
+        assert response.status_code == 200
+        assert b"<ContactInformation>" in response.data
+
+    def test_none_api_keys_with_valid_header_is_401(
+        self, client: FlaskClient, mocker: MockerFixture
+    ):
+        """When get_api_keys() returns None, a valid-looking Bearer token is rejected with 401."""
+        mocker.patch.object(global_data, "get_api_keys", return_value=None)
+        mocker.patch("app.default_authorized", False)
+        response = client.get(
+            "/miscuser/xml", headers={"Authorization": f"Bearer {TEST_TOKEN}"}
+        )
+        assert response.status_code == 401
+        assert b"<ContactInformation>" not in response.data
+
+    # ------------------------------------------------------------------
+    # Route deny-path (no auth headers, default_authorized=False)
+    # ------------------------------------------------------------------
+
+    def test_miscuser_xml_deny_omits_contact_information(
+        self, client: FlaskClient, mocker: MockerFixture
+    ):
+        mocker.patch("app.default_authorized", False)
+        mocker.patch.object(global_data, "get_api_keys", return_value=set())
+        response = client.get("/miscuser/xml")
+        assert response.status_code == 200
+        assert b"<ContactInformation>" not in response.data
+        assert "private" in response.headers.get("Cache-Control", "")
+
+    def test_contacts_deny_omits_email_and_phone(
+        self, client: FlaskClient, mocker: MockerFixture
+    ):
+        mocker.patch("app.default_authorized", False)
+        mocker.patch.object(global_data, "get_api_keys", return_value=set())
+        response = client.get("/contacts")
+        assert response.status_code == 200
+        assert b"PrimaryEmail" not in response.data
+        assert "private" in response.headers.get("Cache-Control", "")
+
+    def test_oasis_managers_deny_returns_403(
+        self, client: FlaskClient, mocker: MockerFixture
+    ):
+        mocker.patch("app.default_authorized", False)
+        mocker.patch.object(global_data, "get_api_keys", return_value=set())
+        response = client.get("/oasis-managers/json?vo=CMS")
+        assert response.status_code == 403
+        assert "private" in response.headers.get("Cache-Control", "")
+
+    def test_vosummary_xml_deny_omits_email(
+        self, client: FlaskClient, mocker: MockerFixture
+    ):
+        mocker.patch("app.default_authorized", False)
+        mocker.patch.object(global_data, "get_api_keys", return_value=set())
+        response = client.get("/vosummary/xml")
+        assert response.status_code == 200
+        assert b"<Email>" not in response.data
+
+    # ------------------------------------------------------------------
+    # Route allow-path equivalence: DN auth == Bearer token auth
+    # ------------------------------------------------------------------
+
+    def test_miscuser_xml_dn_and_bearer_expose_same_fields(
+        self, client: FlaskClient, mocker: MockerFixture, mock_api_keys
+    ):
+        mocker.patch.object(global_data, "get_dns", return_value={_TEST_DN})
+        resp_dn = client.get(
+            "/miscuser/xml", environ_base=self.dn_auth_environ(_TEST_DN)
+        )
+        resp_bearer = client.get(
+            "/miscuser/xml", headers={"Authorization": f"Bearer {TEST_TOKEN}"}
+        )
+        dn_has_ci = b"<ContactInformation>" in resp_dn.data
+        bearer_has_ci = b"<ContactInformation>" in resp_bearer.data
+        assert dn_has_ci == bearer_has_ci
+
+    def test_contacts_dn_and_bearer_expose_same_fields(
+        self, client: FlaskClient, mocker: MockerFixture, mock_api_keys
+    ):
+        mocker.patch.object(global_data, "get_dns", return_value={_TEST_DN})
+        resp_dn = client.get("/contacts", environ_base=self.dn_auth_environ(_TEST_DN))
+        resp_bearer = client.get(
+            "/contacts", headers={"Authorization": f"Bearer {TEST_TOKEN}"}
+        )
+        dn_has_email = b"PrimaryEmail" in resp_dn.data
+        bearer_has_email = b"PrimaryEmail" in resp_bearer.data
+        assert dn_has_email == bearer_has_email
+
+    def test_oasis_managers_dn_and_bearer_both_200(
+        self, client: FlaskClient, mocker: MockerFixture, mock_api_keys
+    ):
+        mocker.patch.object(global_data, "get_dns", return_value={_TEST_DN})
+        mocker.patch("app.get_oasis_manager_endpoint_info", return_value=[])
+        mocker.patch("app.cilogon_pass", b"dummy")
+        resp_dn = client.get(
+            "/oasis-managers/json?vo=CMS", environ_base=self.dn_auth_environ(_TEST_DN)
+        )
+        resp_bearer = client.get(
+            "/oasis-managers/json?vo=CMS",
+            headers={"Authorization": f"Bearer {TEST_TOKEN}"},
+        )
+        assert resp_dn.status_code == 200
+        assert resp_bearer.status_code == 200
+
+    def test_vosummary_xml_dn_and_bearer_expose_same_fields(
+        self, client: FlaskClient, mocker: MockerFixture, mock_api_keys
+    ):
+        mocker.patch.object(global_data, "get_dns", return_value={_TEST_DN})
+        resp_dn = client.get(
+            "/vosummary/xml", environ_base=self.dn_auth_environ(_TEST_DN)
+        )
+        resp_bearer = client.get(
+            "/vosummary/xml", headers={"Authorization": f"Bearer {TEST_TOKEN}"}
+        )
+        dn_has_email = b"<Email>" in resp_dn.data
+        bearer_has_email = b"<Email>" in resp_bearer.data
+        assert dn_has_email == bearer_has_email
+
+    # ------------------------------------------------------------------
+    # Log redaction tests
+    # ------------------------------------------------------------------
+
+    def test_successful_bearer_logs_hash_prefix_and_owner(
+        self, client: FlaskClient, mocker: MockerFixture, mock_api_keys, caplog
+    ):
+        """Successful auth logs a hash prefix and the owner name but not the raw token."""
+        _ = mocker, mock_api_keys
+        token_hash = token_to_apikeyhash(TEST_TOKEN)
+        with caplog.at_level(logging.INFO, logger="app"):
+            client.get(
+                "/miscuser/xml", headers={"Authorization": f"Bearer {TEST_TOKEN}"}
+            )
+        assert token_hash[7:15] in caplog.text
+        assert "Alex Jordan Morgan" in caplog.text
+        assert TEST_TOKEN not in caplog.text
+
+    def test_rejected_bearer_logs_hash_prefix_only(
+        self, client: FlaskClient, mocker: MockerFixture, mock_api_keys, caplog
+    ):
+        """Rejected auth logs a hash prefix but not the raw token."""
+        _ = mocker, mock_api_keys
+        token_hash = token_to_apikeyhash(UNKNOWN_TOKEN)
+        with caplog.at_level(logging.DEBUG, logger="app"):
+            client.get(
+                "/miscuser/xml", headers={"Authorization": f"Bearer {UNKNOWN_TOKEN}"}
+            )
+        assert token_hash[7:15] in caplog.text
+        assert UNKNOWN_TOKEN not in caplog.text
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/src/tests/test_auth_helpers.py
+++ b/src/tests/test_auth_helpers.py
@@ -1,0 +1,248 @@
+"""
+Unit tests for API key loading and GlobalData API key caching behavior.
+"""
+import pytest
+import warnings
+from unittest.mock import MagicMock, patch
+import yaml
+
+import os
+import sys
+
+topdir = os.path.join(str(os.path.dirname(__file__)), "..")
+sys.path.insert(0, topdir)
+
+os.environ.setdefault('TESTING', 'True')
+
+# Third-party deprecation from python-dateutil under Python 3.12;
+# we do not control that dependency's internal datetime usage in these tests.
+warnings.filterwarnings(
+    "ignore",
+    message=r"datetime\.datetime\.utcfromtimestamp\(\) is deprecated.*",
+    category=DeprecationWarning,
+    module=r"dateutil\.tz\.tz",
+)
+
+from webapp.common import token_to_apikeyhash
+from webapp.contacts_reader import ContactsData, get_api_keys_data
+from webapp.models import GlobalData, CachedData
+
+
+# ---------------------------------------------------------------------------
+# Minimal YAML-dict helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_user_yaml(full_name="Test User", email="test@example.com"):
+    """Return a minimal user YAML dict."""
+    data = {
+        "FullName": full_name,
+        "ContactInformation": {
+            "PrimaryEmail": email,
+        },
+    }
+    return data
+
+
+def _make_contacts_data_by_id(raw):
+    """Build a ContactsData from a mapping of contact_id -> yaml_data."""
+    return ContactsData(raw)
+
+
+def _write_api_keys_file(tmp_path, data):
+    path = tmp_path / "api-keys.yaml"
+    path.write_text(yaml.safe_dump(data), encoding="utf-8")
+    return str(path)
+
+
+def _testtoken(suffix: str = "0"):
+    """
+    Return a token in the correct format with the given suffix.
+    The suffix must be 0-12 lowercase hex digits.
+    """
+    return "tk-aaaaaaaa-bbbb-cccc-dddd-%s" % suffix.zfill(12)
+
+
+# ---------------------------------------------------------------------------
+# contacts_reader.get_api_keys_data() tests
+# ---------------------------------------------------------------------------
+
+class TestGetApiKeysData:
+
+    def test_returns_hash_to_name_mapping(self, tmp_path):
+        hash_a = token_to_apikeyhash(_testtoken("a"))
+        hash_b = token_to_apikeyhash(_testtoken("b"))
+        contacts = _make_contacts_data_by_id(
+            {
+                "id-a": _make_user_yaml(full_name="User A"),
+                "id-b": _make_user_yaml(full_name="User B"),
+            }
+        )
+        api_keys_file = _write_api_keys_file(
+            tmp_path,
+            {
+                "id-a": {"FullName": "User A", "APIKeyHash": hash_a},
+                "id-b": {"FullName": "User B", "APIKeyHash": hash_b},
+            },
+        )
+        result = get_api_keys_data(api_keys_file, contacts)
+        assert result == {hash_a: "User A", hash_b: "User B"}
+
+    def test_returns_empty_dict_when_path_is_empty(self):
+        contacts = _make_contacts_data_by_id({"id-a": _make_user_yaml(full_name="User A")})
+        assert get_api_keys_data("", contacts) == {}
+
+    def test_skips_entries_with_invalid_api_key_hash(self, tmp_path, caplog):
+        import logging
+
+        contacts = _make_contacts_data_by_id(
+            {"id-a": _make_user_yaml(full_name="User A")}
+        )
+        api_keys_file = _write_api_keys_file(
+            tmp_path,
+            {"id-a": {"FullName": "User A", "APIKeyHash": "sha256:xyz"}},
+        )
+        with caplog.at_level(logging.WARNING, logger="webapp.contacts_reader"):
+            result = get_api_keys_data(api_keys_file, contacts)
+        assert result == {}
+        assert "invalid APIKeyHash" in caplog.text
+
+    def test_skips_entries_with_unknown_contact_id(self, tmp_path, caplog):
+        import logging
+
+        contacts = _make_contacts_data_by_id(
+            {"id-a": _make_user_yaml(full_name="User A")}
+        )
+        api_keys_file = _write_api_keys_file(
+            tmp_path,
+            {"id-missing": {"FullName": "User A", "APIKeyHash": token_to_apikeyhash(_testtoken())}},
+        )
+        with caplog.at_level(logging.WARNING, logger="webapp.contacts_reader"):
+            result = get_api_keys_data(api_keys_file, contacts)
+        assert result == {}
+        assert "does not match any contacts.yaml ID" in caplog.text
+
+    def test_skips_entries_with_fullname_mismatch(self, tmp_path, caplog):
+        import logging
+
+        contacts = _make_contacts_data_by_id(
+            {"id-a": _make_user_yaml(full_name="User A")}
+        )
+        api_keys_file = _write_api_keys_file(
+            tmp_path,
+            {"id-a": {"FullName": "Different Name", "APIKeyHash": token_to_apikeyhash(_testtoken())}},
+        )
+        with caplog.at_level(logging.WARNING, logger="webapp.contacts_reader"):
+            result = get_api_keys_data(api_keys_file, contacts)
+        assert result == {}
+        assert "FullName mismatch" in caplog.text
+
+    def test_invalid_top_level_type_returns_empty_dict(self, tmp_path, caplog):
+        import logging
+
+        contacts = _make_contacts_data_by_id(
+            {"id-a": _make_user_yaml(full_name="User A")}
+        )
+        path = tmp_path / "api-keys.yaml"
+        path.write_text(yaml.safe_dump([{"id-a": {"FullName": "User A"}}]), encoding="utf-8")
+
+        with caplog.at_level(logging.WARNING, logger="webapp.contacts_reader"):
+            result = get_api_keys_data(str(path), contacts)
+
+        assert result == {}
+        assert "must be a YAML mapping" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# GlobalData.get_api_keys() tests
+#
+# We build a minimal GlobalData with CONTACT_DATA_DIR=None so it won't try
+# to read any files, then override internal state and mocks as needed.
+# ---------------------------------------------------------------------------
+
+def _make_global_data():
+    """Return a GlobalData instance configured for in-memory testing."""
+    return GlobalData(config={"TOPOLOGY_DATA_DIR": ".", "CONTACT_DATA_DIR": None, "API_KEYS_FILE": ""})
+
+
+class TestGlobalDataGetApiKeys:
+
+    def test_returns_a_dict(self, tmp_path):
+        """get_api_keys() returns a dict of hash->owner when hashes exist in API_KEY_FILE."""
+        gd = _make_global_data()
+        token_hash = token_to_apikeyhash(_testtoken())
+        contacts = _make_contacts_data_by_id({"id-1": _make_user_yaml(full_name="User 1")})
+        gd.api_keys_file = _write_api_keys_file(
+            tmp_path,
+            {"id-1": {"FullName": "User 1", "APIKeyHash": token_hash}},
+        )
+        gd.get_contact_db_data = MagicMock(return_value=contacts)
+        result = gd.get_api_keys()
+        assert isinstance(result, dict)
+        assert result == {token_hash: "User 1"}
+
+    def test_calls_get_contact_db_data_when_cache_stale_and_stores_result(self, tmp_path):
+        """get_api_keys() fetches contacts.yaml data when cache is stale and caches the mapping."""
+        gd = _make_global_data()
+        gd.api_key_set = CachedData()
+        token_hash = token_to_apikeyhash(_testtoken("0"))
+        contacts = _make_contacts_data_by_id({"id-1": _make_user_yaml(full_name="Cached User")})
+        gd.api_keys_file = _write_api_keys_file(
+            tmp_path,
+            {"id-1": {"FullName": "Cached User", "APIKeyHash": token_hash}},
+        )
+        gd.get_contact_db_data = MagicMock(return_value=contacts)
+
+        result = gd.get_api_keys()
+
+        gd.get_contact_db_data.assert_called_once()
+        assert result is not None
+        assert result[token_hash] == "Cached User"
+        result2 = gd.get_api_keys()
+        gd.get_contact_db_data.assert_called_once()
+        assert result2 == result
+
+    def test_calls_try_again_on_get_api_keys_exception_and_returns_cached(self, tmp_path):
+        """When API key loading raises, try_again() is called and previous data is returned."""
+        gd = _make_global_data()
+        gd.api_key_set = CachedData()
+        gd.api_key_set.update({token_to_apikeyhash(_testtoken("3")): "Old User"})
+        gd.api_key_set.force_update = True
+        gd.api_keys_file = _write_api_keys_file(
+            tmp_path,
+            {"id-1": {"FullName": "User 1", "APIKeyHash": token_to_apikeyhash(_testtoken("1"))}},
+        )
+
+        gd.get_contact_db_data = MagicMock(return_value=_make_contacts_data_by_id({"id-1": _make_user_yaml(full_name="User 1")}))
+
+        with patch("webapp.models.contacts_reader.get_api_keys_data", side_effect=RuntimeError("boom")):
+            with patch.object(gd.api_key_set, 'try_again', wraps=gd.api_key_set.try_again) as mock_try_again:
+                result = gd.get_api_keys()
+                mock_try_again.assert_called_once()
+
+        assert result == {token_to_apikeyhash(_testtoken("3")): "Old User"}
+
+    def test_returns_empty_dict_when_contact_db_data_is_none_on_first_load(self, tmp_path):
+        """get_api_keys() returns {} when contact-db data is unavailable on first load."""
+        gd = _make_global_data()
+        gd.api_key_set = CachedData()
+        gd.api_keys_file = _write_api_keys_file(
+            tmp_path,
+            {"id-1": {"FullName": "User 1", "APIKeyHash": token_to_apikeyhash(_testtoken("1"))}},
+        )
+        gd.get_contact_db_data = MagicMock(return_value=None)
+
+        result = gd.get_api_keys()
+
+        assert result == {}
+
+    def test_returns_empty_dict_when_api_keys_file_unset(self):
+        """get_api_keys() returns an empty mapping when API_KEYS_FILE is unset."""
+        gd = _make_global_data()
+        gd.api_key_set = CachedData()
+        gd.api_keys_file = ""
+        gd.get_contact_db_data = MagicMock(return_value=None)
+
+        result = gd.get_api_keys()
+
+        assert result == {}

--- a/src/tests/test_auth_helpers.py
+++ b/src/tests/test_auth_helpers.py
@@ -120,7 +120,7 @@ class TestGetApiKeysData:
         with caplog.at_level(logging.WARNING, logger="webapp.contacts_reader"):
             result = get_api_keys_data(api_keys_file, contacts)
         assert result == {}
-        assert "does not match any contacts.yaml ID" in caplog.text
+        assert "does not match any contact" in caplog.text
 
     def test_skips_entries_with_fullname_mismatch(self, tmp_path, caplog):
         import logging

--- a/src/webapp/common.py
+++ b/src/webapp/common.py
@@ -1,6 +1,5 @@
 from collections import OrderedDict
 from logging import getLogger
-import base64
 import hashlib
 import json
 import os

--- a/src/webapp/common.py
+++ b/src/webapp/common.py
@@ -419,16 +419,3 @@ def token_to_apikeyhash(token: Union[str, bytes]) -> str:
     if not API_KEY_RE.fullmatch(token_s):
         raise ValueError("Token does not match pattern")
     return "sha256:" + hashlib.sha256(token_s.encode()).hexdigest()
-
-
-def shorten(a_str: str, maxlen: int = 80) -> str:
-    """
-    Shortens a string to a specified maximum length with an ellipsis appended if truncation occurs.
-    maxlen must be at least 3 to account for the ellipsis.
-    """
-    if maxlen < 3:
-        raise ValueError("maxlen must be at least 3")
-    if len(a_str) > maxlen - 3:
-        return a_str[: maxlen - 3] + "..."
-    else:
-        return a_str

--- a/src/webapp/common.py
+++ b/src/webapp/common.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 from logging import getLogger
+import base64
 import hashlib
 import json
 import os
@@ -400,3 +401,35 @@ PELICAN_CACHE = "Pelican cache"
 PELICAN_ORIGIN = "Pelican origin"
 GRIDTYPE_1 = "OSG Production Resource"
 GRIDTYPE_2 = "OSG Integration Test Bed Resource"
+API_KEY_RE = re.compile(r"tk-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
+API_KEY_HASH_RE = re.compile(r"sha256:[0-9a-f]{64}")
+
+
+def token_to_apikeyhash(token: Union[str, bytes]) -> str:
+    """
+    Converts a given token to a hashed API key string - a SHA256 sum
+    (as a 64-character hex string), prefixed with "sha256:"
+    (matching the format in the apikeys yaml file).
+
+    Raises ValueError if the token does not match the token pattern.
+    """
+    if isinstance(token, bytes):
+        token_s = token.decode("latin-1")
+    else:
+        token_s = token
+    if not API_KEY_RE.fullmatch(token_s):
+        raise ValueError("Token does not match pattern")
+    return "sha256:" + hashlib.sha256(token_s.encode()).hexdigest()
+
+
+def shorten(a_str: str, maxlen: int = 80) -> str:
+    """
+    Shortens a string to a specified maximum length with an ellipsis appended if truncation occurs.
+    maxlen must be at least 3 to account for the ellipsis.
+    """
+    if maxlen < 3:
+        raise ValueError("maxlen must be at least 3")
+    if len(a_str) > maxlen - 3:
+        return a_str[: maxlen - 3] + "..."
+    else:
+        return a_str

--- a/src/webapp/contacts_reader.py
+++ b/src/webapp/contacts_reader.py
@@ -213,11 +213,11 @@ def get_api_keys_data(infile: Optional[str], contacts_data: Optional[ContactsDat
         try:
             contact_user = contacts_data.users_by_id[id_]
         except KeyError:
-            log.warning("API key file entry for %s does not match any contacts.yaml ID; skipping", id_)
+            log.warning("API key file entry for %s does not match any contact ID; skipping", id_)
             continue
         if contact_user.name != full_name:
             log.warning(
-                "API key file entry for %s FullName mismatch: expected %r from contacts.yaml; got %r; skipping",
+                "API key file entry for %s FullName mismatch: expected %r; got %r; skipping",
                 id_,
                 contact_user.name,
                 full_name,

--- a/src/webapp/contacts_reader.py
+++ b/src/webapp/contacts_reader.py
@@ -177,7 +177,7 @@ def get_api_keys_data(infile: Optional[str], contacts_data: Optional[ContactsDat
         return {}
 
     if contacts_data is None:
-        log.warning("API_KEY_FILE is configured but contacts.yaml data is unavailable; returning no API keys")
+        log.warning("API_KEYS_FILE is configured but contacts.yaml data is unavailable; returning no API keys")
         return {}
 
     raw_data = load_yaml_file(infile)

--- a/src/webapp/contacts_reader.py
+++ b/src/webapp/contacts_reader.py
@@ -11,11 +11,10 @@ from typing import Dict, Optional
 if __name__ == "__main__" and __package__ is None:
     sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from webapp.common import to_xml, MISCUSER_SCHEMA_URL, load_yaml_file
+from webapp.common import API_KEY_HASH_RE, to_xml, MISCUSER_SCHEMA_URL, load_yaml_file
 
 
 log = getLogger(__name__)
-
 
 class User(object):
     def __init__(self, id_, yaml_data):
@@ -62,6 +61,10 @@ class User(object):
     @property
     def cilogon_id(self):
         return self.yaml_data.get("CILogonID", None)
+
+    @property
+    def api_key_hash(self):
+        return self.yaml_data["ContactInformation"].get("APIKeyHash", None)
 
     @staticmethod
     def _get_gravatar_url(email):
@@ -156,6 +159,74 @@ def get_contacts_data(infile) -> ContactsData:
         return ContactsData(load_yaml_file(infile))
     else:
         return ContactsData({})
+
+
+def get_api_keys_data(infile: Optional[str], contacts_data: Optional[ContactsData]) -> Dict[str, str]:
+    """
+    Read API key hashes from a YAML mapping keyed by contact ID.
+
+    Each entry must look like:
+
+        <contact_id>:
+          FullName: <contact full name>
+          APIKeyHash: sha256:<64 lowercase hex chars>
+
+    Entries that fail validation are skipped with a warning.
+    """
+    if not infile:
+        return {}
+
+    if contacts_data is None:
+        log.warning("API_KEY_FILE is configured but contacts.yaml data is unavailable; returning no API keys")
+        return {}
+
+    raw_data = load_yaml_file(infile)
+    if not isinstance(raw_data, dict):
+        log.warning(
+            "API key file %s must be a YAML mapping keyed by contact ID; got %s",
+            infile,
+            type(raw_data).__name__,
+        )
+        return {}
+
+    api_keys: Dict[str, str] = {}
+    for id_, entry in raw_data.items():
+        if not isinstance(id_, str):
+            log.warning("API key file entry key %r is not a string contact ID; skipping", id_)
+            continue
+        if not isinstance(entry, dict):
+            log.warning("API key file entry for %s must be a mapping; skipping", id_)
+            continue
+
+        full_name = entry.get("FullName")
+        api_key_hash = entry.get("APIKeyHash")
+        if not isinstance(full_name, str) or not full_name:
+            log.warning("API key file entry for %s has invalid FullName; skipping", id_)
+            continue
+        if not isinstance(api_key_hash, str) or not API_KEY_HASH_RE.fullmatch(api_key_hash):
+            log.warning(
+                "API key file entry for %s has invalid APIKeyHash; expected sha256:<64 lowercase hex chars>; skipping",
+                id_,
+            )
+            continue
+
+        try:
+            contact_user = contacts_data.users_by_id[id_]
+        except KeyError:
+            log.warning("API key file entry for %s does not match any contacts.yaml ID; skipping", id_)
+            continue
+        if contact_user.name != full_name:
+            log.warning(
+                "API key file entry for %s FullName mismatch: expected %r from contacts.yaml; got %r; skipping",
+                id_,
+                contact_user.name,
+                full_name,
+            )
+            continue
+
+        api_keys[api_key_hash] = full_name
+
+    return api_keys
 
 
 def main(argv):

--- a/src/webapp/default_config.py
+++ b/src/webapp/default_config.py
@@ -17,6 +17,7 @@ CONTACT_DATA_DIR = "/tmp/topology/contact"
 CONTACT_DATA_REPO = "git@bitbucket.org:opensciencegrid/contact.git"
 CONTACT_DATA_BRANCH = "master"
 CONTACT_CACHE_LIFETIME = 60 * 2
+API_KEYS_FILE = ""
 
 OSG_LDAP_PASSFILE = None
 

--- a/src/webapp/models.py
+++ b/src/webapp/models.py
@@ -81,6 +81,7 @@ class GlobalData:
         self.contacts_data = CachedData(cache_lifetime=contact_cache_lifetime)
         self.comanage_data = CachedData(cache_lifetime=contact_cache_lifetime)
         self.merged_contacts_data = CachedData(cache_lifetime=contact_cache_lifetime)
+        self.api_key_set = CachedData(cache_lifetime=contact_cache_lifetime)
         self.dn_set = CachedData(cache_lifetime=topology_cache_lifetime)
         self.projects = CachedData(cache_lifetime=topology_cache_lifetime)
         self.topology = CachedData(cache_lifetime=topology_cache_lifetime)
@@ -104,6 +105,7 @@ class GlobalData:
         self.auto_pr_gh_api_user = config.get("AUTO_PR_GH_API_USER")
         self.auto_pr_gh_api_token = config.get("AUTO_PR_GH_API_TOKEN")
         self.csrf_secret_key = config.get("CSRF_SECRET_KEY")
+        self.api_keys_file = config.get("API_KEYS_FILE", "")
         if config["CONTACT_DATA_DIR"]:
             self.contacts_file = os.path.join(config["CONTACT_DATA_DIR"], "contacts.yaml")
         else:
@@ -267,6 +269,20 @@ class GlobalData:
                 log.exception("Failed to update DNs (%s)", err)
                 self.contacts_data.try_again()
         return self.dn_set.data
+
+    def get_api_keys(self) -> Optional[Dict[str, str]]:
+        if self.api_key_set.should_update():
+            contact_db_data = self.get_contact_db_data()
+            try:
+                self.api_key_set.update(
+                    contacts_reader.get_api_keys_data(self.api_keys_file, contact_db_data)
+                )
+            except Exception as err:
+                if self.strict:
+                    raise
+                log.exception("Failed to update API key set (%s)", err)
+                self.api_key_set.try_again()
+        return self.api_key_set.data
 
     def get_topology(self) -> Optional[Topology]:
         """

--- a/src/webapp/models.py
+++ b/src/webapp/models.py
@@ -272,10 +272,10 @@ class GlobalData:
 
     def get_api_keys(self) -> Optional[Dict[str, str]]:
         if self.api_key_set.should_update():
-            contact_db_data = self.get_contact_db_data()
+            contacts_data = self.get_contacts_data()
             try:
                 self.api_key_set.update(
-                    contacts_reader.get_api_keys_data(self.api_keys_file, contact_db_data)
+                    contacts_reader.get_api_keys_data(self.api_keys_file, contacts_data)
                 )
             except Exception as err:
                 if self.strict:


### PR DESCRIPTION
This pull request introduces API key authentication to the application, allowing clients to authenticate using bearer tokens in the `Authorization` header instead of X.509 certs. It also adds a script for creating API keys.

The API key must be a UUID with a "tk-" ("topology key") prefix. The client sends the API Key as a "Bearer" credential in the HTTP Authorization header.  (As-is, no need to base64-encode it, since the format already only uses URL-safe characters.)

The hash of the incoming key is checked against hashes loaded from an API_KEYS_FILE. 

API_KEYS_FILE must be a YAML mapping of ID to FullName and APIKeyHash (similar to contacts.yaml) and the IDs and FullNames are checked against the topology contacts.

There is a `bin/make_api_key.py` script to help generate valid keys and API_KEYS_FILE blocks.

The Docker image includes a stub api_keys.yaml file in `/secrets/api_keys/api_keys.yaml`; the extra directory layer is there so you can mount a Secret over the `/secrets/api_keys` directory and have it get updated as you update the Secret. Topology re-reads the file every 5 minutes.