### PR TITLE
Add downtime for Nebraska resources due to campus wide power outage

### DIFF
--- a/topology/University of Nebraska System/Nebraska-CMS/CMS Glidein Systems_downtime.yaml
+++ b/topology/University of Nebraska System/Nebraska-CMS/CMS Glidein Systems_downtime.yaml
@@ -29,3 +29,14 @@
   Services:
   - Submit Node
 # ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2487093716
+  Description: Campus wide power outage for infrastructure upgrades
+  Severity: Outage
+  StartTime: Jul 13, 2026 22:00 +0000
+  EndTime: Jul 15, 2026 22:00 +0000
+  CreatedTime: Jul 10, 2026 18:49 +0000
+  ResourceName: Nebraska_glidein_hcc_crabserver
+  Services:
+  - Submit Node
+# ---------------------------------------------------------

--- a/topology/University of Nebraska System/Nebraska-CMS/Nebraska_downtime.yaml
+++ b/topology/University of Nebraska System/Nebraska-CMS/Nebraska_downtime.yaml
@@ -209,3 +209,114 @@
   Services:
   - CE
 # ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2487089384
+  Description: Campus wide power outage for infrastructure upgrades
+  Severity: Outage
+  StartTime: Jul 13, 2026 22:00 +0000
+  EndTime: Jul 15, 2026 22:00 +0000
+  CreatedTime: Jul 10, 2026 18:42 +0000
+  ResourceName: Nebraska
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2487089385
+  Description: Campus wide power outage for infrastructure upgrades
+  Severity: Outage
+  StartTime: Jul 13, 2026 22:00 +0000
+  EndTime: Jul 15, 2026 22:00 +0000
+  CreatedTime: Jul 10, 2026 18:42 +0000
+  ResourceName: T2_Nebraska_SE_gridftp
+  Services:
+  - GridFtp
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2487089386
+  Description: Campus wide power outage for infrastructure upgrades
+  Severity: Outage
+  StartTime: Jul 13, 2026 22:00 +0000
+  EndTime: Jul 15, 2026 22:00 +0000
+  CreatedTime: Jul 10, 2026 18:42 +0000
+  ResourceName: T2_US_Nebraska-red-squid2
+  Services:
+  - Squid
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2487089387
+  Description: Campus wide power outage for infrastructure upgrades
+  Severity: Outage
+  StartTime: Jul 13, 2026 22:00 +0000
+  EndTime: Jul 15, 2026 22:00 +0000
+  CreatedTime: Jul 10, 2026 18:42 +0000
+  ResourceName: T2_US_Nebraska_red-squid1
+  Services:
+  - Squid
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2487089388
+  Description: Campus wide power outage for infrastructure upgrades
+  Severity: Outage
+  StartTime: Jul 13, 2026 22:00 +0000
+  EndTime: Jul 15, 2026 22:00 +0000
+  CreatedTime: Jul 10, 2026 18:42 +0000
+  ResourceName: US-Nebraska BW
+  Services:
+  - net.perfSONAR.Bandwidth
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2487089389
+  Description: Campus wide power outage for infrastructure upgrades
+  Severity: Outage
+  StartTime: Jul 13, 2026 22:00 +0000
+  EndTime: Jul 15, 2026 22:00 +0000
+  CreatedTime: Jul 10, 2026 18:42 +0000
+  ResourceName: US-Nebraska BW (Test)
+  Services:
+  - net.perfSONAR.Bandwidth
+  - net.perfSONAR.Latency
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2487089390
+  Description: Campus wide power outage for infrastructure upgrades
+  Severity: Outage
+  StartTime: Jul 13, 2026 22:00 +0000
+  EndTime: Jul 15, 2026 22:00 +0000
+  CreatedTime: Jul 10, 2026 18:42 +0000
+  ResourceName: US-Nebraska LT
+  Services:
+  - net.perfSONAR.Latency
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2487089391
+  Description: Campus wide power outage for infrastructure upgrades
+  Severity: Outage
+  StartTime: Jul 13, 2026 22:00 +0000
+  EndTime: Jul 15, 2026 22:00 +0000
+  CreatedTime: Jul 10, 2026 18:42 +0000
+  ResourceName: coffea-casa-cms
+  Services:
+  - Execution Endpoint
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2487089392
+  Description: Campus wide power outage for infrastructure upgrades
+  Severity: Outage
+  StartTime: Jul 13, 2026 22:00 +0000
+  EndTime: Jul 15, 2026 22:00 +0000
+  CreatedTime: Jul 10, 2026 18:42 +0000
+  ResourceName: red-gateway1
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2487089393
+  Description: Campus wide power outage for infrastructure upgrades
+  Severity: Outage
+  StartTime: Jul 13, 2026 22:00 +0000
+  EndTime: Jul 15, 2026 22:00 +0000
+  CreatedTime: Jul 10, 2026 18:42 +0000
+  ResourceName: red-gateway2
+  Services:
+  - CE
+# ---------------------------------------------------------

--- a/topology/University of Nebraska System/Nebraska-Lincoln/HCC Submitters_downtime.yaml
+++ b/topology/University of Nebraska System/Nebraska-Lincoln/HCC Submitters_downtime.yaml
@@ -40,3 +40,25 @@
   Services:
   - Submit Node
 # ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2487093441
+  Description: Campus wide power outage for infrastructure upgrades
+  Severity: Outage
+  StartTime: Jul 13, 2026 22:00 +0000
+  EndTime: Jul 15, 2026 22:00 +0000
+  CreatedTime: Jul 10, 2026 18:49 +0000
+  ResourceName: HCC GlideinWMS Frontend
+  Services:
+  - Submit Node
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2487093442
+  Description: Campus wide power outage for infrastructure upgrades
+  Severity: Outage
+  StartTime: Jul 13, 2026 22:00 +0000
+  EndTime: Jul 15, 2026 22:00 +0000
+  CreatedTime: Jul 10, 2026 18:49 +0000
+  ResourceName: HCC-CPASS
+  Services:
+  - Submit Node
+# ---------------------------------------------------------

--- a/topology/University of Nebraska System/Nebraska-Lincoln/UNLCachingInfrastructure_downtime.yaml
+++ b/topology/University of Nebraska System/Nebraska-Lincoln/UNLCachingInfrastructure_downtime.yaml
@@ -164,4 +164,36 @@
   Services:
   - Pelican cache
 # ---------------------------------------------------------
-
+- Class: SCHEDULED
+  ID: 2487092804
+  Description: Campus wide power outage for infrastructure upgrades
+  Severity: Outage
+  StartTime: Jul 13, 2026 22:00 +0000
+  EndTime: Jul 15, 2026 22:00 +0000
+  CreatedTime: Jul 10, 2026 18:48 +0000
+  ResourceName: HCC-Origin
+  Services:
+  - XRootD origin server
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2487092805
+  Description: Campus wide power outage for infrastructure upgrades
+  Severity: Outage
+  StartTime: Jul 13, 2026 22:00 +0000
+  EndTime: Jul 15, 2026 22:00 +0000
+  CreatedTime: Jul 10, 2026 18:48 +0000
+  ResourceName: HCC-StashCache-Origin
+  Services:
+  - XRootD origin server
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2487092807
+  Description: Campus wide power outage for infrastructure upgrades
+  Severity: Outage
+  StartTime: Jul 13, 2026 22:00 +0000
+  EndTime: Jul 15, 2026 22:00 +0000
+  CreatedTime: Jul 10, 2026 18:48 +0000
+  ResourceName: NEBRASKA_NRP_OSDF_CACHE
+  Services:
+  - Pelican cache
+# ---------------------------------------------------------

--- a/topology/University of Nebraska System/Nebraska-Lincoln/UNLNRPOrigin_downtime.yaml
+++ b/topology/University of Nebraska System/Nebraska-Lincoln/UNLNRPOrigin_downtime.yaml
@@ -165,5 +165,58 @@
   Services:
   - XRootD origin server
 # ---------------------------------------------------------
-
-
+- Class: SCHEDULED
+  ID: 2487091363
+  Description: Campus wide power outage for infrastructure upgrades
+  Severity: Outage
+  StartTime: Jul 13, 2026 22:00 +0000
+  EndTime: Jul 15, 2026 22:00 +0000
+  CreatedTime: Jul 10, 2026 18:45 +0000
+  ResourceName: NEBRASKA_NRP_HCC_OSDF_ORIGIN
+  Services:
+  - Pelican origin
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2487091364
+  Description: Campus wide power outage for infrastructure upgrades
+  Severity: Outage
+  StartTime: Jul 13, 2026 22:00 +0000
+  EndTime: Jul 15, 2026 22:00 +0000
+  CreatedTime: Jul 10, 2026 18:45 +0000
+  ResourceName: NEBRASKA_NRP_OSDF_ORIGIN
+  Services:
+  - Pelican origin
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2487091365
+  Description: Campus wide power outage for infrastructure upgrades
+  Severity: Outage
+  StartTime: Jul 13, 2026 22:00 +0000
+  EndTime: Jul 15, 2026 22:00 +0000
+  CreatedTime: Jul 10, 2026 18:45 +0000
+  ResourceName: NEBRASKA_NRP_OSDF_ORIGIN2
+  Services:
+  - Pelican origin
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2487091366
+  Description: Campus wide power outage for infrastructure upgrades
+  Severity: Outage
+  StartTime: Jul 13, 2026 22:00 +0000
+  EndTime: Jul 15, 2026 22:00 +0000
+  CreatedTime: Jul 10, 2026 18:45 +0000
+  ResourceName: OSSTORE_HEPSIM_ORIGIN
+  Services:
+  - Pelican origin
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2487091367
+  Description: Campus wide power outage for infrastructure upgrades
+  Severity: Outage
+  StartTime: Jul 13, 2026 22:00 +0000
+  EndTime: Jul 15, 2026 22:00 +0000
+  CreatedTime: Jul 10, 2026 18:45 +0000
+  ResourceName: UNL_NRP_OSDF_XENON_ORIGIN
+  Services:
+  - XRootD origin server
+# ---------------------------------------------------------

--- a/topology/University of Nebraska System/Nebraska-Lincoln/UNLOSGRepoMirror_downtime.yaml
+++ b/topology/University of Nebraska System/Nebraska-Lincoln/UNLOSGRepoMirror_downtime.yaml
@@ -9,3 +9,14 @@
   Services:
   - Software Repo Mirror
 # ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2487093303
+  Description: Campus wide power outage for infrastructure upgrades
+  Severity: Outage
+  StartTime: Jul 13, 2026 22:00 +0000
+  EndTime: Jul 15, 2026 22:00 +0000
+  CreatedTime: Jul 10, 2026 18:48 +0000
+  ResourceName: Nebraska-OSG-repo-mirror
+  Services:
+  - Software Repo Mirror
+# ---------------------------------------------------------


### PR DESCRIPTION
Add downtime for Nebraska resources due to campus wide power outage.

Note that the LIGO-StashCache-Origin resource was left off intentionally to avoid a repeat of https://github.com/opensciencegrid/topology/pull/5410#issuecomment-4433433584