### PR TITLE
Point /usr/bin/python3 at /usr/bin/python3.12 so the webhook can find it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,9 @@ RUN \
 
 WORKDIR /app
 
+# Needed for webhook:
+RUN alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 10
+
 # Install application dependencies
 COPY requirements-apache.txt requirements-rootless.txt ./
 RUN python3.12 -m pip install --no-cache-dir -r requirements-apache.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN \
 WORKDIR /app
 
 # Needed for webhook:
-RUN alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 10
+RUN alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 10 && alternatives --set python3 /usr/bin/python3.12
 
 # Install application dependencies
 COPY requirements-apache.txt requirements-rootless.txt ./


### PR DESCRIPTION
The webhook calls out to automerge_check.py which has a shebang of #!/usr/bin/env python3 We need to make sure python3 is the one we installed all our dependencies for.

EL10 no longer has an alternatives setup for Python 3 (/var/lib/alternatives/python3 doesn't exist) so we have to make our own.