### PR TITLE
Add OU_OSCER_ATLAS_SE_1 storage element configuration

### DIFF
--- a/topology/University of Oklahoma/OU ATLAS/OU_OSCER_ATLAS.yaml
+++ b/topology/University of Oklahoma/OU ATLAS/OU_OSCER_ATLAS.yaml
@@ -7,14 +7,14 @@ Resources:
     ContactLists:
       Administrative Contact:
         Primary:
-          ID: 2a7d2665e9aa0e66ab4131e53de14df72a51b74d
+          ID:  OSG1000435
           Name: Horst Severini
         Secondary:
           ID: 4be1a67e41871a12c36d34d01308553ea1e0c023
           Name: Christopher Arnold Walker
       Security Contact:
         Primary:
-          ID: 2a7d2665e9aa0e66ab4131e53de14df72a51b74d
+          ID:  OSG1000435
           Name: Horst Severini
         Secondary:
           ID: 4be1a67e41871a12c36d34d01308553ea1e0c023
@@ -50,14 +50,14 @@ Resources:
     ContactLists:
       Administrative Contact:
         Primary:
-          ID: 2a7d2665e9aa0e66ab4131e53de14df72a51b74d
+          ID:  OSG1000435
           Name: Horst Severini
         Secondary:
           ID: 4be1a67e41871a12c36d34d01308553ea1e0c023
           Name: Christopher Arnold Walker
       Security Contact:
         Primary:
-          ID: 2a7d2665e9aa0e66ab4131e53de14df72a51b74d
+          ID:  OSG1000435
           Name: Horst Severini
         Secondary:
           ID: 4be1a67e41871a12c36d34d01308553ea1e0c023
@@ -92,14 +92,14 @@ Resources:
     ContactLists:
       Administrative Contact:
         Primary:
-          ID: 2a7d2665e9aa0e66ab4131e53de14df72a51b74d
+          ID:  OSG1000435
           Name: Horst Severini
         Secondary:
           ID: 4be1a67e41871a12c36d34d01308553ea1e0c023
           Name: Christopher Arnold Walker
       Security Contact:
         Primary:
-          ID: 2a7d2665e9aa0e66ab4131e53de14df72a51b74d
+          ID:  OSG1000435
           Name: Horst Severini
         Secondary:
           ID: 4be1a67e41871a12c36d34d01308553ea1e0c023
@@ -135,14 +135,14 @@ Resources:
     ContactLists:
       Administrative Contact:
         Primary:
-          ID: 2a7d2665e9aa0e66ab4131e53de14df72a51b74d
+          ID:  OSG1000435
           Name: Horst Severini
         Secondary:
           ID: 4be1a67e41871a12c36d34d01308553ea1e0c023
           Name: Christopher Arnold Walker
       Security Contact:
         Primary:
-          ID: 2a7d2665e9aa0e66ab4131e53de14df72a51b74d
+          ID:  OSG1000435
           Name: Horst Severini
         Secondary:
           ID: 4be1a67e41871a12c36d34d01308553ea1e0c023

--- a/topology/University of Oklahoma/OU ATLAS/OU_OSCER_ATLAS.yaml
+++ b/topology/University of Oklahoma/OU ATLAS/OU_OSCER_ATLAS.yaml
@@ -64,7 +64,6 @@ Resources:
           Name: Christopher Arnold Walker
     Description: OU OSCER Xrootd Storage
     FQDN: se0.oscer.ou.edu
-    ID: 905
     Services:
       GridFtp:
         Description: GridFtp Storage Element

--- a/topology/University of Oklahoma/OU ATLAS/OU_OSCER_ATLAS.yaml
+++ b/topology/University of Oklahoma/OU ATLAS/OU_OSCER_ATLAS.yaml
@@ -45,6 +45,49 @@ Resources:
       KSI2KMin: 0
       StorageCapacityMax: 10
       StorageCapacityMin: 10
+  OU_OSCER_ATLAS_SE_1:
+    Active: true
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          ID: 2a7d2665e9aa0e66ab4131e53de14df72a51b74d
+          Name: Horst Severini
+        Secondary:
+          ID: 4be1a67e41871a12c36d34d01308553ea1e0c023
+          Name: Christopher Arnold Walker
+      Security Contact:
+        Primary:
+          ID: 2a7d2665e9aa0e66ab4131e53de14df72a51b74d
+          Name: Horst Severini
+        Secondary:
+          ID: 4be1a67e41871a12c36d34d01308553ea1e0c023
+          Name: Christopher Arnold Walker
+    Description: OU OSCER Xrootd Storage
+    FQDN: se0.oscer.ou.edu
+    ID: 905
+    Services:
+      GridFtp:
+        Description: GridFtp Storage Element
+        Details:
+          hidden: false
+      XRootD component:
+        Description: XRootD component
+        Details:
+          hidden: false
+    VOOwnership:
+      ATLAS: 55
+      DOSAR: 45
+    WLCGInformation:
+      APELNormalFactor: 0
+      AccountingName: US-SWT2
+      HEPSPEC: 0
+      InteropAccounting: true
+      InteropBDII: true
+      InteropMonitoring: true
+      KSI2KMax: 0
+      KSI2KMin: 0
+      StorageCapacityMax: 10
+      StorageCapacityMin: 10
   OU_OSCER_ATLAS_SE:
     Active: true
     ContactLists:


### PR DESCRIPTION
In support of Freshdesk #84294. Per Horst (somewhat confusingly), the new SE should be named OU_OSCER_ATLAS_SE_1 and use FQDN `se0.oscer.ou.edu`