### PR TITLE
Update MTState-Tempest_downtime.yaml

### DIFF
--- a/topology/Montana State University/Montana State RCI/MTState-Tempest_downtime.yaml
+++ b/topology/Montana State University/Montana State RCI/MTState-Tempest_downtime.yaml
@@ -64,3 +64,14 @@
   Services:
   - CE
 # ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2498214746
+  Description: Summer maintenance upgrades
+  Severity: Outage
+  StartTime: Jul 25, 2026 06:01 +0000
+  EndTime: Aug 02, 2026 05:59 +0000
+  CreatedTime: Jul 23, 2026 15:44 +0000
+  ResourceName: MTState-Tempest-CE1
+  Services:
+  - CE
+# ---------------------------------------------------------


### PR DESCRIPTION
Add downtime for MTState-Tempest-CE1 for scheduled yearly summer upgrades. 

Some tidbits... New Pure Flashblade flash array (1.7PB), 30+ GPU nodes, a few more CPU nodes, network bandwidth going from 100MBit trunk to 400MBit trunk... and Tempest Operating System will be upgraded to Rocky 10 Linux.