### PR TITLE
Remove OSPool AP association from CHTC CEs

### DIFF
--- a/topology/University of Wisconsin–Madison/CHTC/CHTC.yaml
+++ b/topology/University of Wisconsin–Madison/CHTC/CHTC.yaml
@@ -1015,8 +1015,8 @@ Resources:
     Description: CHTC CE Access Point
     FQDN: ce2000.chtc.wisc.edu
     Services:
-      Submit Node:
-        Description: OSPool access point
+      CE:
+        Description: Compute Element
         Details:
           hidden: false
     VOOwnership:
@@ -1042,8 +1042,8 @@ Resources:
     Description: CHTC CE Access Point
     FQDN: ce2001.chtc.wisc.edu
     Services:
-      Submit Node:
-        Description: OSPool access point
+      CE:
+        Description: Compute Element
         Details:
           hidden: false
     VOOwnership:

--- a/topology/University of Wisconsin–Madison/CHTC/CHTC.yaml
+++ b/topology/University of Wisconsin–Madison/CHTC/CHTC.yaml
@@ -1016,7 +1016,7 @@ Resources:
     FQDN: ce2000.chtc.wisc.edu
     Services:
       CE:
-        Description: Compute Element
+        Description: Compute Entrypoint
         Details:
           hidden: false
     VOOwnership:
@@ -1043,7 +1043,7 @@ Resources:
     FQDN: ce2001.chtc.wisc.edu
     Services:
       CE:
-        Description: Compute Element
+        Description: Compute Entrypoint
         Details:
           hidden: false
     VOOwnership:

--- a/topology/University of Wisconsin–Madison/CHTC/CHTC.yaml
+++ b/topology/University of Wisconsin–Madison/CHTC/CHTC.yaml
@@ -1019,8 +1019,6 @@ Resources:
         Description: OSPool access point
         Details:
           hidden: false
-    Tags:
-      - OSPool
     VOOwnership:
       GLOW: 100
   
@@ -1048,7 +1046,5 @@ Resources:
         Description: OSPool access point
         Details:
           hidden: false
-    Tags:
-      - OSPool
     VOOwnership:
       GLOW: 100


### PR DESCRIPTION
I thought about this some more and from the OSG perspective, we don't particularly care that they're technically APs. Also I don't think it's useful to mark them as associated with OSPool at the Topology level