### PR TITLE
Register Purdue_Anvil_AI_Datasets_OSDF_Origin

### DIFF
--- a/topology/Purdue University West Lafayette/Purdue Anvil/Purdue-Anvil.yaml
+++ b/topology/Purdue University West Lafayette/Purdue Anvil/Purdue-Anvil.yaml
@@ -92,10 +92,10 @@ Resources:
       Execution Endpoint:
         Description: OSG backfill on Anvil's Kubernetes resource
 
-  Purdue-Anvil-Datasets-OSDF-Origin:
+  Purdue-Anvil-AI-Datasets-OSDF-Origin:
     Active: true
     Description: >-
-      This is an origin serving /rcac.purdue.edu/anvil/datasets,
+      This is an origin serving /rcac.purdue.edu/anvil/datasets/ai,
       hosted on Purdue-Anvil-Composable.
     ContactLists:
       Administrative Contact:
@@ -122,9 +122,9 @@ Resources:
         Primary:
           ID: f11eeb608313b242e14f5aee602b3aff91839ace
           Name: Erik Gough
-    FQDN: datasets-origin.anvilcloud.rcac.purdue.edu
+    FQDN: ai-datasets-origin.anvilcloud.rcac.purdue.edu
     Services:
       Pelican origin:
-        Description: Origin for /rcac.purdue.edu/anvil/datasets in OSDF
+        Description: Origin for /rcac.purdue.edu/anvil/datasets/ai in OSDF
     AllowedVOs:
       - ANY

--- a/topology/Purdue University West Lafayette/Purdue Anvil/Purdue-Anvil.yaml
+++ b/topology/Purdue University West Lafayette/Purdue Anvil/Purdue-Anvil.yaml
@@ -91,3 +91,40 @@ Resources:
     Services:
       Execution Endpoint:
         Description: OSG backfill on Anvil's Kubernetes resource
+
+  Purdue-Anvil-Datasets-OSDF-Origin:
+    Active: true
+    Description: >-
+      This is an origin serving /rcac.purdue.edu/anvil/datasets,
+      hosted on Purdue-Anvil-Composable.
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          ID: OSG1000002
+          Name: Matyas Selmeci
+        Secondary:
+          ID: OSG1000589
+          Name: William N Swanson
+        Tertiary:
+          ID: OSG1000003
+          Name: Brian Hua Lin
+      Security Contact:
+        Primary:
+          ID: OSG1000002
+          Name: Matyas Selmeci
+        Secondary:
+          ID: OSG1000589
+          Name: William N Swanson
+        Tertiary:
+          ID: OSG1000003
+          Name: Brian Hua Lin
+      Site Contact:
+        Primary:
+          ID: f11eeb608313b242e14f5aee602b3aff91839ace
+          Name: Erik Gough
+    FQDN: datasets-origin.anvilcloud.rcac.purdue.edu
+    Services:
+      Pelican origin:
+        Description: Origin for /rcac.purdue.edu/anvil/datasets in OSDF
+    AllowedVOs:
+      - ANY

--- a/topology/Purdue University West Lafayette/Purdue Anvil/Purdue-Anvil.yaml
+++ b/topology/Purdue University West Lafayette/Purdue Anvil/Purdue-Anvil.yaml
@@ -122,7 +122,7 @@ Resources:
         Primary:
           ID: f11eeb608313b242e14f5aee602b3aff91839ace
           Name: Erik Gough
-    FQDN: ai-datasets-origin.anvilcloud.rcac.purdue.edu
+    FQDN: ai-datasets-origin.anvil.rcac.purdue.edu
     Services:
       Pelican origin:
         Description: Origin for /rcac.purdue.edu/anvil/datasets/ai in OSDF

--- a/topology/Purdue University West Lafayette/Purdue Anvil/Purdue-Anvil.yaml
+++ b/topology/Purdue University West Lafayette/Purdue Anvil/Purdue-Anvil.yaml
@@ -92,7 +92,7 @@ Resources:
       Execution Endpoint:
         Description: OSG backfill on Anvil's Kubernetes resource
 
-  Purdue-Anvil-AI-Datasets-OSDF-Origin:
+  Purdue_Anvil_AI_Datasets_OSDF_Origin:
     Active: true
     Description: >-
       This is an origin serving /rcac.purdue.edu/anvil/datasets/ai,


### PR DESCRIPTION
This origin will be used for exporting the /rcac.purdue.edu/anvil/datasets namespace.

(FD #84141)