### PR TITLE
Bump and pin the versions of various GitHub Actions

### DIFF
--- a/.github/workflows/build-sw-container.yml
+++ b/.github/workflows/build-sw-container.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.repository, 'opensciencegrid/')
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Generate tag list
       id: generate-tag-list
@@ -31,23 +31,23 @@ jobs:
         echo "taglist=${tag_list[*]}" >> $GITHUB_OUTPUT
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2.7.0
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
     - name: Log in to Docker Hub
-      uses: docker/login-action@v2.2.0
+      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         
     - name: Log in to OSG Harbor
-      uses: docker/login-action@v2.2.0
+      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
       with:
         registry: hub.opensciencegrid.org
         username: ${{ secrets.OSG_HARBOR_ROBOT_USER }}
         password: ${{ secrets.OSG_HARBOR_ROBOT_PASSWORD }}
 
     - name: Build and push Docker images
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
       with:
         context: .
         push: true

--- a/.github/workflows/check_facility_institution_id.yml
+++ b/.github/workflows/check_facility_institution_id.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.repository, 'opensciencegrid/')
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: 3.9.15
           cache: 'pip' # caching pip dependencies

--- a/.github/workflows/check_project_fos_precision.yml
+++ b/.github/workflows/check_project_fos_precision.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.repository, 'opensciencegrid/')
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: 3.9.15
           cache: 'pip' # caching pip dependencies

--- a/.github/workflows/validate-code.yml
+++ b/.github/workflows/validate-code.yml
@@ -6,9 +6,9 @@ jobs:
     name: Validate Topology code
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: 3.12.13
       - name: Install packages

--- a/.github/workflows/validate-data.yml
+++ b/.github/workflows/validate-data.yml
@@ -7,9 +7,9 @@ jobs:
     name: Validate Topology data
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: 3.12.13
       - name: Install packages


### PR DESCRIPTION
actions/checkout: v3 -> v7.0.1
actions/setup-python: v4 -> v7.0.0
docker/build-push-action: v4 -> v7.3.0
docker/login-action: v2.2.0 -> v4.6.0
docker/setup-buildx-action: v2.7.0 -> v4.2.0