### PR TITLE
Add downtime for NCSU-OSG-CE1 due to CVE resolution for SLURM scheduler

### DIFF
--- a/topology/North Carolina State University/NCSU - HPC/NCSU-OSG_downtime.yaml
+++ b/topology/North Carolina State University/NCSU - HPC/NCSU-OSG_downtime.yaml
@@ -31,3 +31,15 @@
   Services:
   - CE
 # ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2525990292
+  Description: SLURM Upgrade for CVE resolution
+  Severity: Outage
+  StartTime: Sep 02, 2026 13:00 +0000
+  EndTime: Sep 02, 2026 16:00 +0000
+  CreatedTime: Aug 24, 2026 19:17 +0000
+  ResourceName: NCSU-OSG-CE1
+  Services:
+  - CE
+# ---------------------------------------------------------
+


### PR DESCRIPTION
Please schedule the downtime requested for NCSU-OSG-CE1. During this time we will be conducting upgrade to SLURM in order to resolve a CVE. We will be upgrading SLURM form 25.05.8 to 25.11.08.

Apologies if this commit doesn't match my dlewell@ncsu.edu email because currently the configuration set up at our institution doesn't allow forking external repositories.
