### PR TITLE
Add downtime for NCAR_OSDF_CACHE due to Upgrade Biforst network

### DIFF
--- a/topology/NSF National Center for Atmospheric Research/NCAR-Wyoming Supercomputing Center/NCAR-OSDF_downtime.yaml
+++ b/topology/NSF National Center for Atmospheric Research/NCAR-Wyoming Supercomputing Center/NCAR-OSDF_downtime.yaml
@@ -109,4 +109,15 @@
   Services:
   - Pelican origin
 # ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2528603115
+  Description: Upgrade Biforst network
+  Severity: Outage
+  StartTime: Sep 01, 2026 14:00 +0000
+  EndTime: Sep 04, 2026 03:00 +0000
+  CreatedTime: Aug 27, 2026 19:51 +0000
+  ResourceName: NCAR_OSDF_CACHE
+  Services:
+  - Pelican cache
+# ---------------------------------------------------------
 


### PR DESCRIPTION
Added scheduled downtime for Biforst network upgrade.