### PR TITLE
Add network outage entries to SPRACE_downtime.yaml

### DIFF
--- a/topology/Universidade Estadual Paulista (Unesp)/SPRACE/SPRACE_downtime.yaml
+++ b/topology/Universidade Estadual Paulista (Unesp)/SPRACE/SPRACE_downtime.yaml
@@ -6239,3 +6239,80 @@
   Services:
   - Squid
 # ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 2535290343
+  Description: network outage
+  Severity: Outage
+  StartTime: Sep 04, 2026 13:36 +0000
+  EndTime: Sep 04, 2026 21:00 +0000
+  CreatedTime: Sep 04, 2026 13:37 +0000
+  ResourceName: BR-Sprace BW
+  Services:
+  - net.perfSONAR.Bandwidth
+# ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 2535290344
+  Description: network outage
+  Severity: Outage
+  StartTime: Sep 04, 2026 13:36 +0000
+  EndTime: Sep 04, 2026 21:00 +0000
+  CreatedTime: Sep 04, 2026 13:37 +0000
+  ResourceName: BR-Sprace LT
+  Services:
+  - net.perfSONAR.Latency
+# ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 2535290345
+  Description: network outage
+  Severity: Outage
+  StartTime: Sep 04, 2026 13:36 +0000
+  EndTime: Sep 04, 2026 21:00 +0000
+  CreatedTime: Sep 04, 2026 13:37 +0000
+  ResourceName: SPRACE
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 2535290346
+  Description: network outage
+  Severity: Outage
+  StartTime: Sep 04, 2026 13:36 +0000
+  EndTime: Sep 04, 2026 21:00 +0000
+  CreatedTime: Sep 04, 2026 13:37 +0000
+  ResourceName: SPRACE-SE
+  Services:
+  - SRMv2
+# ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 2535290347
+  Description: network outage
+  Severity: Outage
+  StartTime: Sep 04, 2026 13:36 +0000
+  EndTime: Sep 04, 2026 21:00 +0000
+  CreatedTime: Sep 04, 2026 13:37 +0000
+  ResourceName: SPRACE_OSDF_CACHE
+  Services:
+  - Pelican cache
+# ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 2535290348
+  Description: network outage
+  Severity: Outage
+  StartTime: Sep 04, 2026 13:36 +0000
+  EndTime: Sep 04, 2026 21:00 +0000
+  CreatedTime: Sep 04, 2026 13:37 +0000
+  ResourceName: T2_BR_SPRACE-squid1
+  Services:
+  - Squid
+# ---------------------------------------------------------
+- Class: UNSCHEDULED
+  ID: 2535290349
+  Description: network outage
+  Severity: Outage
+  StartTime: Sep 04, 2026 13:36 +0000
+  EndTime: Sep 04, 2026 21:00 +0000
+  CreatedTime: Sep 04, 2026 13:37 +0000
+  ResourceName: T2_BR_SPRACE-squid2
+  Services:
+  - Squid
+# ---------------------------------------------------------


### PR DESCRIPTION
Added multiple entries for network outages with details including ID, description, severity, start and end times, created time, resource names, and services affected.