### PR TITLE
Add scheduled outages for dCache upgrade

### DIFF
--- a/topology/Brookhaven National Laboratory/BNL ATLAS Tier1/BNL-ATLAS_downtime.yaml
+++ b/topology/Brookhaven National Laboratory/BNL ATLAS Tier1/BNL-ATLAS_downtime.yaml
@@ -2165,3 +2165,279 @@
   Services:
   - WebDAV.tape
 # ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2539061685
+  Description: dCache upgrade to 11.2 Golden Release
+  Severity: Outage
+  StartTime: Sep 14, 2026 13:00 +0000
+  EndTime: Sep 14, 2026 21:00 +0000
+  CreatedTime: Sep 08, 2026 22:22 +0000
+  ResourceName: BNL_ATLAS_01
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2539061686
+  Description: dCache upgrade to 11.2 Golden Release
+  Severity: Outage
+  StartTime: Sep 14, 2026 13:00 +0000
+  EndTime: Sep 14, 2026 21:00 +0000
+  CreatedTime: Sep 08, 2026 22:22 +0000
+  ResourceName: BNL_ATLAS_02
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2539061687
+  Description: dCache upgrade to 11.2 Golden Release
+  Severity: Outage
+  StartTime: Sep 14, 2026 13:00 +0000
+  EndTime: Sep 14, 2026 21:00 +0000
+  CreatedTime: Sep 08, 2026 22:22 +0000
+  ResourceName: BNL_ATLAS_03
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2539061688
+  Description: dCache upgrade to 11.2 Golden Release
+  Severity: Outage
+  StartTime: Sep 14, 2026 13:00 +0000
+  EndTime: Sep 14, 2026 21:00 +0000
+  CreatedTime: Sep 08, 2026 22:22 +0000
+  ResourceName: BNL_ATLAS_04
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2539061689
+  Description: dCache upgrade to 11.2 Golden Release
+  Severity: Outage
+  StartTime: Sep 14, 2026 13:00 +0000
+  EndTime: Sep 14, 2026 21:00 +0000
+  CreatedTime: Sep 08, 2026 22:22 +0000
+  ResourceName: BNL_ATLAS_06
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2539061690
+  Description: dCache upgrade to 11.2 Golden Release
+  Severity: Outage
+  StartTime: Sep 14, 2026 13:00 +0000
+  EndTime: Sep 14, 2026 21:00 +0000
+  CreatedTime: Sep 08, 2026 22:22 +0000
+  ResourceName: BNL_ATLAS_07
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2539061691
+  Description: dCache upgrade to 11.2 Golden Release
+  Severity: Outage
+  StartTime: Sep 14, 2026 13:00 +0000
+  EndTime: Sep 14, 2026 21:00 +0000
+  CreatedTime: Sep 08, 2026 22:22 +0000
+  ResourceName: BNL_ATLAS_08
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2539061692
+  Description: dCache upgrade to 11.2 Golden Release
+  Severity: Outage
+  StartTime: Sep 14, 2026 13:00 +0000
+  EndTime: Sep 14, 2026 21:00 +0000
+  CreatedTime: Sep 08, 2026 22:22 +0000
+  ResourceName: BNL_ATLAS_1
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2539061693
+  Description: dCache upgrade to 11.2 Golden Release
+  Severity: Outage
+  StartTime: Sep 14, 2026 13:00 +0000
+  EndTime: Sep 14, 2026 21:00 +0000
+  CreatedTime: Sep 08, 2026 22:22 +0000
+  ResourceName: BNL_ATLAS_2
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2539061694
+  Description: dCache upgrade to 11.2 Golden Release
+  Severity: Outage
+  StartTime: Sep 14, 2026 13:00 +0000
+  EndTime: Sep 14, 2026 21:00 +0000
+  CreatedTime: Sep 08, 2026 22:22 +0000
+  ResourceName: BNL_ATLAS_3
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2539061695
+  Description: dCache upgrade to 11.2 Golden Release
+  Severity: Outage
+  StartTime: Sep 14, 2026 13:00 +0000
+  EndTime: Sep 14, 2026 21:00 +0000
+  CreatedTime: Sep 08, 2026 22:22 +0000
+  ResourceName: BNL_ATLAS_4
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2539061696
+  Description: dCache upgrade to 11.2 Golden Release
+  Severity: Outage
+  StartTime: Sep 14, 2026 13:00 +0000
+  EndTime: Sep 14, 2026 21:00 +0000
+  CreatedTime: Sep 08, 2026 22:22 +0000
+  ResourceName: BNL_ATLAS_6
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2539061697
+  Description: dCache upgrade to 11.2 Golden Release
+  Severity: Outage
+  StartTime: Sep 14, 2026 13:00 +0000
+  EndTime: Sep 14, 2026 21:00 +0000
+  CreatedTime: Sep 08, 2026 22:22 +0000
+  ResourceName: BNL_ATLAS_7
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2539061698
+  Description: dCache upgrade to 11.2 Golden Release
+  Severity: Outage
+  StartTime: Sep 14, 2026 13:00 +0000
+  EndTime: Sep 14, 2026 21:00 +0000
+  CreatedTime: Sep 08, 2026 22:22 +0000
+  ResourceName: BNL_ATLAS_8
+  Services:
+  - CE
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2539061699
+  Description: dCache upgrade to 11.2 Golden Release
+  Severity: Outage
+  StartTime: Sep 14, 2026 13:00 +0000
+  EndTime: Sep 14, 2026 21:00 +0000
+  CreatedTime: Sep 08, 2026 22:22 +0000
+  ResourceName: BNL_ATLAS_CVMFS_Squid
+  Services:
+  - Squid
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2539061700
+  Description: dCache upgrade to 11.2 Golden Release
+  Severity: Outage
+  StartTime: Sep 14, 2026 13:00 +0000
+  EndTime: Sep 14, 2026 21:00 +0000
+  CreatedTime: Sep 08, 2026 22:22 +0000
+  ResourceName: BNL_ATLAS_Frontier_Squid
+  Services:
+  - Squid
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2539061701
+  Description: dCache upgrade to 11.2 Golden Release
+  Severity: Outage
+  StartTime: Sep 14, 2026 13:00 +0000
+  EndTime: Sep 14, 2026 21:00 +0000
+  CreatedTime: Sep 08, 2026 22:22 +0000
+  ResourceName: BNL_ATLAS_SE
+  Services:
+  - SRMv2.disk
+  - SRMv2.tape
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2539061702
+  Description: dCache upgrade to 11.2 Golden Release
+  Severity: Outage
+  StartTime: Sep 14, 2026 13:00 +0000
+  EndTime: Sep 14, 2026 21:00 +0000
+  CreatedTime: Sep 08, 2026 22:22 +0000
+  ResourceName: BNL_ATLAS_SE_AWS_East
+  Services:
+  - SRMv2
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2539061703
+  Description: dCache upgrade to 11.2 Golden Release
+  Severity: Outage
+  StartTime: Sep 14, 2026 13:00 +0000
+  EndTime: Sep 14, 2026 21:00 +0000
+  CreatedTime: Sep 08, 2026 22:22 +0000
+  ResourceName: BNL_ATLAS_SE_AWS_West
+  Services:
+  - SRMv2
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2539061704
+  Description: dCache upgrade to 11.2 Golden Release
+  Severity: Outage
+  StartTime: Sep 14, 2026 13:00 +0000
+  EndTime: Sep 14, 2026 21:00 +0000
+  CreatedTime: Sep 08, 2026 22:22 +0000
+  ResourceName: BNL_ATLAS_SE_AWS_West2
+  Services:
+  - SRMv2
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2539061705
+  Description: dCache upgrade to 11.2 Golden Release
+  Severity: Outage
+  StartTime: Sep 14, 2026 13:00 +0000
+  EndTime: Sep 14, 2026 21:00 +0000
+  CreatedTime: Sep 08, 2026 22:22 +0000
+  ResourceName: BNL_ATLAS_SE_GRIDFTP
+  Services:
+  - WebDAV
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2539061706
+  Description: dCache upgrade to 11.2 Golden Release
+  Severity: Outage
+  StartTime: Sep 14, 2026 13:00 +0000
+  EndTime: Sep 14, 2026 21:00 +0000
+  CreatedTime: Sep 08, 2026 22:22 +0000
+  ResourceName: BNL_ATLAS_TAPE
+  Services:
+  - WebDAV.tape
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2539061707
+  Description: dCache upgrade to 11.2 Golden Release
+  Severity: Outage
+  StartTime: Sep 14, 2026 13:00 +0000
+  EndTime: Sep 14, 2026 21:00 +0000
+  CreatedTime: Sep 08, 2026 22:22 +0000
+  ResourceName: lhcmon-bnl
+  Services:
+  - net.perfSONAR.Bandwidth
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2539061708
+  Description: dCache upgrade to 11.2 Golden Release
+  Severity: Outage
+  StartTime: Sep 14, 2026 13:00 +0000
+  EndTime: Sep 14, 2026 21:00 +0000
+  CreatedTime: Sep 08, 2026 22:22 +0000
+  ResourceName: lhcperfmon-bnl
+  Services:
+  - net.perfSONAR.Latency
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 2539061709
+  Description: dCache upgrade to 11.2 Golden Release
+  Severity: Outage
+  StartTime: Sep 14, 2026 13:00 +0000
+  EndTime: Sep 14, 2026 21:00 +0000
+  CreatedTime: Sep 08, 2026 22:22 +0000
+  ResourceName: ps-development
+  Services:
+  - net.perfSONAR.Latency
+# ---------------------------------------------------------


### PR DESCRIPTION
Added multiple scheduled outages for dCache upgrade to 11.2 Golden Release across various resources.